### PR TITLE
Add script to test firmware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 project_generator==0.6.1
+mbed_ls
+pyserial
+pyOCD

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -1,0 +1,275 @@
+# CMSIS-DAP Interface Firmware
+# Copyright (c) 2009-2013 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse, os, sys
+from time import sleep
+from random import randrange
+import math
+
+import pyOCD
+from pyOCD.board import MbedBoard
+from pyOCD.utility.conversion import float32beToU32be
+import logging
+
+def basic_test(board_id, file):
+    with MbedBoard.chooseBoard(board_id=board_id) as board:
+        addr = 0
+        size = 0
+        f = None
+        binary_file = "l1_"
+
+        interface = None
+
+        target_type = board.getTargetType()
+
+        if file is None:
+            binary_file = os.path.join(parentdir, 'binaries', board.getTestBinary())
+        else:
+            binary_file = file
+
+        print "binary file: %s" % binary_file
+
+        addr_bin = 0x00000000
+
+        if target_type == "lpc1768":
+            addr = 0x10000001
+            size = 0x1102
+            addr_flash = 0x10000
+        elif target_type == "lpc11u24":
+            addr = 0x10000001
+            size = 0x502
+            addr_flash = 0x4000
+        elif target_type == "kl25z":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "kl28z":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "k64f":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "k22f":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "k20d50m":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "kl46z":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "lpc800":
+            addr = 0x10000001
+            size = 0x502
+            addr_flash = 0x2000
+        elif target_type == "nrf51":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x20000
+        elif target_type == "lpc4330":
+            addr = 0x10000001
+            size = 0x1102
+            addr_flash = 0x14010000
+            addr_bin = 0x14000000
+        elif target_type == "maxwsnenv":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "max32600mbed":
+            addr = 0x20000001
+            size = 0x502
+            addr_flash = 0x10000
+        elif target_type == "w7500":
+            addr = 0x20000001
+            size = 0x1102
+            addr_flash = 0x00000000
+        else:
+            raise Exception("A board is not supported by this test script.")
+
+        target = board.target
+        transport = board.transport
+        flash = board.flash
+        interface = board.interface
+
+
+        print "\r\n\r\n------ GET Unique ID ------"
+        print "Unique ID: %s" % board.getUniqueID()
+
+        print "\r\n\r\n------ TEST READ / WRITE CORE REGISTER ------"
+        pc = target.readCoreRegister('pc')
+        print "initial pc: 0x%X" % target.readCoreRegister('pc')
+        # write in pc dummy value
+        target.writeCoreRegister('pc', 0x3D82)
+        print "now pc: 0x%X" % target.readCoreRegister('pc')
+        # write initial pc value
+        target.writeCoreRegister('pc', pc)
+        print "initial pc value rewritten: 0x%X" % target.readCoreRegister('pc')
+
+        msp = target.readCoreRegister('msp')
+        psp = target.readCoreRegister('psp')
+        print "MSP = 0x%08x; PSP = 0x%08x" % (msp, psp)
+
+        control = target.readCoreRegister('control')
+        faultmask = target.readCoreRegister('faultmask')
+        basepri = target.readCoreRegister('basepri')
+        primask = target.readCoreRegister('primask')
+        print "CONTROL = 0x%02x; FAULTMASK = 0x%02x; BASEPRI = 0x%02x; PRIMASK = 0x%02x" % (control, faultmask, basepri, primask)
+
+        target.writeCoreRegister('primask', 1)
+        newPrimask = target.readCoreRegister('primask')
+        print "New PRIMASK = 0x%02x" % newPrimask
+        target.writeCoreRegister('primask', primask)
+        newPrimask = target.readCoreRegister('primask')
+        print "Restored PRIMASK = 0x%02x" % newPrimask
+
+        if target.has_fpu:
+            s0 = target.readCoreRegister('s0')
+            print "S0 = %g (0x%08x)" % (s0, float32beToU32be(s0))
+            target.writeCoreRegister('s0', math.pi)
+            newS0 = target.readCoreRegister('s0')
+            print "New S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0))
+            target.writeCoreRegister('s0', s0)
+            newS0 = target.readCoreRegister('s0')
+            print "Restored S0 = %g (0x%08x)" % (newS0, float32beToU32be(newS0))
+
+
+        print "\r\n\r\n------ TEST HALT / RESUME ------"
+
+        print "resume"
+        target.resume()
+        sleep(0.2)
+
+        print "halt"
+        target.halt()
+        print "HALT: pc: 0x%X" % target.readCoreRegister('pc')
+        sleep(0.2)
+
+
+        print "\r\n\r\n------ TEST STEP ------"
+
+        print "reset and halt"
+        target.resetStopOnReset()
+        currentPC = target.readCoreRegister('pc')
+        print "HALT: pc: 0x%X" % currentPC
+        sleep(0.2)
+
+        for i in range(4):
+            print "step"
+            target.step()
+            newPC = target.readCoreRegister('pc')
+            print "STEP: pc: 0x%X" % newPC
+            currentPC = newPC
+            sleep(0.2)
+
+
+        print "\r\n\r\n------ TEST READ / WRITE MEMORY ------"
+        target.halt()
+        print "READ32/WRITE32"
+        val = randrange(0, 0xffffffff)
+        print "write32 0x%X at 0x%X" % (val, addr)
+        target.writeMemory(addr, val)
+        res = target.readMemory(addr)
+        print "read32 at 0x%X: 0x%X" % (addr, res)
+        if res != val:
+            print "ERROR in READ/WRITE 32"
+
+        print "\r\nREAD16/WRITE16"
+        val = randrange(0, 0xffff)
+        print "write16 0x%X at 0x%X" % (val, addr + 2)
+        target.writeMemory(addr + 2, val, 16)
+        res = target.readMemory(addr + 2, 16)
+        print "read16 at 0x%X: 0x%X" % (addr + 2, res)
+        if res != val:
+            print "ERROR in READ/WRITE 16"
+
+        print "\r\nREAD8/WRITE8"
+        val = randrange(0, 0xff)
+        print "write8 0x%X at 0x%X" % (val, addr + 1)
+        target.writeMemory(addr + 1, val, 8)
+        res = target.readMemory(addr + 1, 8)
+        print "read8 at 0x%X: 0x%X" % (addr + 1, res)
+        if res != val:
+            print "ERROR in READ/WRITE 8"
+
+
+        print "\r\n\r\n------ TEST READ / WRITE MEMORY BLOCK ------"
+        data = [randrange(1, 50) for x in range(size)]
+        target.writeBlockMemoryUnaligned8(addr, data)
+        block = target.readBlockMemoryUnaligned8(addr, size)
+        error = False
+        for i in range(len(block)):
+            if (block[i] != data[i]):
+                error = True
+                print "ERROR: 0x%X, 0x%X, 0x%X!!!" % ((addr + i), block[i], data[i])
+        if error:
+            print "TEST FAILED"
+        else:
+            print "TEST PASSED"
+
+
+        print "\r\n\r\n------ TEST RESET ------"
+        target.reset()
+        sleep(0.1)
+        target.halt()
+
+        for i in range(5):
+            target.step()
+            print "pc: 0x%X" % target.readCoreRegister('pc')
+
+        print "\r\n\r\n------ TEST PROGRAM/ERASE PAGE ------"
+        # Fill 3 pages with 0x55
+        page_size = flash.getPageInfo(addr_flash).size
+        fill = [0x55] * page_size
+        flash.init()
+        for i in range(0, 3):
+            address = addr_flash + page_size * i
+            # Test only supports a location with 3 aligned
+            # pages of the same size
+            current_page_size = flash.getPageInfo(addr_flash).size
+            assert page_size == current_page_size
+            assert address % current_page_size == 0
+            flash.erasePage(address)
+            flash.programPage(address, fill)
+        # Erase the middle page
+        flash.erasePage(addr_flash + page_size)
+        # Verify the 1st and 3rd page were not erased, and that the 2nd page is fully erased
+        data = target.readBlockMemoryUnaligned8(addr_flash, page_size * 3)
+        expected = fill + [0xFF] * page_size + fill
+        if data == expected:
+            print "TEST PASSED"
+        else:
+            print "TEST FAILED"
+
+        print "\r\n\r\n----- FLASH NEW BINARY -----"
+        flash.flashBinary(binary_file, addr_bin)
+
+        target.reset()
+        print "HID test complete"
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='A CMSIS-DAP python debugger')
+    parser.add_argument('-f', help='binary file', dest="file")
+    parser.add_argument('-d', '--debug', action="store_true", help='Enable debug logging')
+    args = parser.parse_args()
+    level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=level)
+    file = args.file
+    basic_test("1050e72fef76000000000000000000000000f77fef76", file)

--- a/test/mbedapi.py
+++ b/test/mbedapi.py
@@ -1,0 +1,155 @@
+# CMSIS-DAP Interface Firmware
+# Copyright (c) 2009-2013 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+
+Usage example:
+
+python mbedapi.py  --repo http://developer.mbed.org/users/dan/code/pubtest/
+--user dan --api http://developer.mbed.org --platform mbed-LPC1768
+--destdir /tmp/ --debug 2
+
+This will compile http://developer.mbed.org/users/dan/code/pubtest/
+for the 1768 and download the result.
+
+Examples of options:
+--extra_symbols "foo=bar,x=y"
+
+--replace_file "main.cpp:/tmp/replace_main.cpp"
+(can be repeated)
+
+"""
+import os
+import getpass
+import json
+import time
+import requests
+import logging
+
+MBED_API_SERVER = 'https://developer.mbed.org'
+
+
+def build_repo(user, password, repo, platform, destdir,
+               replace='', symbols='', clean=False, api=MBED_API_SERVER):
+
+    payload = {
+        'clean': clean,
+        'platform': platform,
+        'repo': repo,
+        'extra_symbols': symbols
+    }
+
+    if replace:
+        replace = []
+        for pair in replace:
+            dest = pair.split(':')[0]
+            src = pair.split(':')[1]
+            print dest
+            cwd = os.getcwd()
+            srcfile = open(os.path.join(cwd, src), 'r')
+            replace.append({dest: srcfile.read()})
+
+        payload['replace'] = json.dumps(replace)
+        logging.debug("Payload is: %s" % payload)
+
+    auth = (user, password,)
+
+    # send task to api
+    logging.debug(api + "/api/v2/tasks/compiler/start/" + "| data: " +
+                  str(payload))
+    r = requests.post(api + "/api/v2/tasks/compiler/start/",
+                      data=payload, auth=auth)
+
+    logging.debug(r.content)
+
+    if r.status_code != 200:
+        raise Exception("Error while talking to the mbed API")
+
+    uuid = json.loads(r.content)['result']['data']['task_id']
+    logging.debug("Task accepted and given ID: %s" % uuid)
+    success = False
+
+    # poll for output
+    for check in range(0, 40):
+        logging.debug("Checking for output: cycle %s of %s" % (check, 10))
+        time.sleep(2)
+        r = requests.get(api + "/api/v2/tasks/compiler/output/%s" %
+                         uuid, auth=auth)
+        logging.debug(r.content)
+        response = json.loads(r.content)
+        messages = response['result']['data']['new_messages']
+        percent = 0
+        for message in messages:
+            if message.get('message'):
+                if message.get('type') != 'debug':
+                    logging.info("[%s] %s" % (message['type'],
+                                              message['message']))
+            if message.get('action'):
+                if message.get('percent'):
+                    percent = message['percent']
+                logging.info("[%s%% - %s] %s " % (percent, message['action'],
+                                                  message.get('file', '')))
+
+        if response['result']['data']['task_complete']:
+            logging.info("Task completed.")
+            success = response['result']['data']['compilation_success']
+            logging.info("Compile success: %s" % (success))
+            break
+
+    # now download
+    if success:
+        logging.info("Downloading your binary")
+        params = {
+            'repomode': True,
+            'program': response['result']['data']['program'],
+            'binary': response['result']['data']['binary'],
+            'task_id': uuid
+        }
+        r = requests.get(api + "/api/v2/tasks/compiler/bin/",
+                         params=params, auth=auth)
+        destination = os.path.join(destdir,
+                                   response['result']['data']['binary'])
+
+        with open(destination, 'wb') as fd:
+            for chunk in r.iter_content(1024):
+                fd.write(chunk)
+
+        logging.info("Finished!")
+    return destination
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Build an mbed repository.')
+    parser.add_argument('--user', type=str, help='Your username on mbed.', required=True)
+    parser.add_argument('--password', type=str, help='Your password on mbed.', default=None, required=False)
+    parser.add_argument('--api', type=str, help='URL to API server', required=False, default=MBED_API_SERVER)
+    parser.add_argument('--repo', type=str, help='URL of repository to build.', required=True)
+    parser.add_argument('--platform', type=str, help='Platform name', required=True)
+    parser.add_argument('--destdir', type=str, help='Binary destination directory', required=True)
+    parser.add_argument('--replace_file', type=str, help='Replace file and build. Can be repeated. Syntax: remotepath:localpath', required=False, action='append')
+    parser.add_argument('--extra_symbols', type=str, help='Provide extra symbols to build system', required=False, action='append')
+    parser.add_argument('--clean', action='store_true', help='Force clean build')
+    parser.add_argument('--debug', help='Show debugging info', required=False)
+
+    args = parser.parse_args()
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+    if args.password is None:
+        args.password = getpass.getpass('mbed password: ')
+    build_repo(args.user, args.password, args.repo, args.platform,
+               args.destdir, args.replace_file, args.extra_symbols,
+               args.clean, args.api)

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -1,0 +1,308 @@
+# CMSIS-DAP Interface Firmware
+# Copyright (c) 2009-2013 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+DAPLink validation and testing tool
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --user USER          MBED username
+  --password PASSWORD  MBED password
+
+This script runs test to validate that the DAPLink firmware running
+on all boards attached to this pc is working correctly.  In specific
+this patch validates that the MSD, CDC and HID endpoints are
+functioning correctly.
+
+To run this script the user name and password to a valid MBED account
+must be supplied.  This is so test firmware for the board being tested
+can be built using the mbed build api, which requires a valid username
+and password.
+"""
+import os
+import serial
+import shutil
+import argparse
+import mbedapi
+import mbed_lstools
+import basic_test
+
+TEST_REPO = 'https://developer.mbed.org/users/c1728p9/code/daplink-validation/'
+
+name_to_build_target = {
+    'K22F': 'FRDM-K22F',
+    'LPC812': 'NXP-LPC800-MAX'
+}
+
+
+def same(d1, d2):
+    d1 = bytearray(d1)
+    d2 = bytearray(d2)
+
+    for i in range(min(len(d1), len(d2))):
+        if d1[i] != d2[i]:
+            print("at %i %i != %i" % (i, d1[i], d2[i]))
+            return False
+    if len(d1) != len(d2):
+        print("Lengths differ: %i, %i" % (len(d1), len(d2)))
+        return False
+    return True
+
+# http://digital.ni.com/public.nsf/allkb/D37754FFA24F7C3F86256706005B9BE7
+standard_baud = [
+    9600,
+    14400,
+    19200,
+    28800,
+    38400,
+    56000,
+    57600,
+    115200,
+    ]
+
+low_standard_baud = [
+    110,
+    300,
+    600,
+    1200,
+    2400,
+    4800,
+]
+
+high_standard_baud = [
+    128000,
+    153600,
+    230400,
+    256000,
+    460800,
+    921600,
+    ]
+
+
+def calc_timeout(data, baud):
+    """Calculate a timeout given the data and baudrate
+
+    Positional arguments:
+        data - data to be sent
+        baud - baud rate to send data
+
+    Calculate a reasonable timeout given the supplied parameters.
+    This function adds slightly more time then is needed, to accont
+    for latency and various configurations.
+    """
+    return 12 * len(data) / float(baud) + 0.2
+
+
+def test_serial(port):
+    """Test the serial port endpoint
+
+    Requirements:
+        -daplink-validation must be loaded for the target.
+
+    Positional arguments:
+        port - the serial port to open as a string
+
+    Return:
+        True if the test passed, False otherwise
+    """
+    test_passed = True
+
+    # Generate a 8 KB block of dummy data
+    # and test a large block transfer
+    test_data = [i for i in range(0, 256)] * 4 * 8
+    baud = 115200
+    timeout = calc_timeout(test_data, baud)
+    with serial.Serial(port, baudrate=baud, timeout=timeout) as sp:
+
+        # Reset the target
+        sp.sendBreak()
+
+        # Wait until the target is initialized
+        expected_resp = "{init}"
+        resp = sp.read(len(expected_resp))
+        if not same(resp, expected_resp):
+            print "Fail on init: %s" % resp
+            test_passed = False
+
+        sp.write(test_data)
+        resp = sp.read(len(test_data))
+        if same(resp, test_data):
+            print "Block test passed"
+        else:
+            print "Block test failed"
+            test_passed = False
+
+    # Generate a 4KB block of dummy data
+    # and test supported baud rates
+    test_data = [i for i in range(0, 256)] * 4 * 4
+    for baud in standard_baud:
+        # Setup with a baud of 115200
+        with serial.Serial(port, baudrate=115200, timeout=1) as sp:
+
+            # Reset the target
+            sp.sendBreak()
+
+            # Wait until the target is initialized
+            expected_resp = "{init}"
+            resp = sp.read(len(expected_resp))
+            if not same(resp, expected_resp):
+                print "Fail on init: %s" % resp
+                test_passed = False
+                continue
+
+            # Change baudrate to that of the first test
+            command = "{baud:%i}" % baud
+            sp.write(command)
+            resp = sp.read(len(command))
+            if not same(resp, command):
+                print "Fail on baud command: %s" % resp
+                test_passed = False
+                continue
+
+        # Open serial port at the new baud
+        print("Testing baud %i" % baud)
+        test_time = calc_timeout(test_data, baud)
+        with serial.Serial(port, baudrate=baud, timeout=test_time) as sp:
+
+            # Read the response indicating that the baudrate
+            # on the target has changed
+            expected_resp = "{change}"
+            resp = sp.read(len(expected_resp))
+            if not same(resp, expected_resp):
+                sp.write("Baud test")
+                print "Fail on baud change %s" % resp
+                test_passed = False
+                continue
+
+            # Perform test
+            sp.write(test_data)
+            resp = sp.read(len(test_data))
+            resp = bytearray(resp)
+            if same(test_data, resp):
+                print "Pass"
+            else:
+                print "Fail"
+                test_passed = False
+
+    return test_passed
+
+
+def test_mass_storage(filename):
+    """Test the mass storage endpoint
+
+    Requirements:
+        None
+
+    Positional arguments:
+        filename - A string containing the name of the file to load
+
+    Return:
+        True if the test passed, False otherwise
+    """
+    # TODO - parse filesystem
+    shutil.copy(filename, mount_point)
+    # TODO - verify binary is correct
+    # TODO - test copy speed
+    # TODO - test all supported file formats
+    # TODO - test expected failure cases / corrupt files
+    return True
+
+
+def test_hid(target_id, filename):
+    """Test the HID endpoint
+
+    Requirements:
+        None
+
+    Positional arguments:
+        target_id - A string containing board identifier
+        filename - A string containing the name of the file to load
+
+    Return:
+        True if the test passed, False otherwise
+    """
+    basic_test.basic_test(target_id, filename)
+    # TODO - make a dedicated test
+    # TODO - test all DapLink commands
+    # TODO - test various clock speeds
+    # TODO - test turnaround settings
+    # TODO - test HID speed
+    # TODO - test ram/rom transfer speeds
+    return True
+
+
+def test_board(user, password, target_id, serial_port,
+               mount_point, platform_name):
+    """Run tests to validate DAPLINK fimrware"""
+    print("**Testing board %s**" % platform_name)
+    test_passed = True
+    try:
+        platform = name_to_build_target[platform_name]
+        repo = TEST_REPO
+        destdir = 'tmp'
+        if not os.path.isdir(destdir):
+            os.mkdir(destdir)
+
+        # TODO - cache build?
+        print
+        print 'Starting remote build'
+        filename = mbedapi.build_repo(user, password, repo, platform, destdir)
+        print 'Remote build finished'
+        # TODO - Load boot block
+        # TODO - Load interface
+        print
+        print 'Starting Mass storage test'
+        test_passed &= test_mass_storage(filename)
+        print
+        print 'Starting Serial port test'
+        test_passed &= test_serial(serial_port)
+        print
+        print '\r\n\r\nStarting HID'
+        test_passed &= test_hid(target_id, filename)
+    except Exception:
+        test_passed = False
+
+    if test_passed:
+        print "Board %s passed" % platform_name
+    else:
+        print "Board %s failed" % platform_name
+    return test_passed
+
+
+if __name__ == "__main__":
+    description = 'DAPLink validation and testing tool'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('--user', type=str,
+                        help='MBED username', required=True)
+    parser.add_argument('--password', type=str,
+                        help='MBED password', required=True)
+    args = parser.parse_args()
+
+    test_passed = True
+    lstools = mbed_lstools.create()
+    mbed_list = lstools.list_mbeds()
+    for mbed in mbed_list:
+        target_id = mbed['target_id']
+        serial_port = mbed['serial_port']
+        mount_point = mbed['mount_point']
+        platform_name = mbed['platform_name']
+        test_passed &= test_board(args.user, args.password, target_id,
+                                  serial_port, mount_point, platform_name)
+    if test_passed:
+        print "All boards passed"
+        exit(0)
+    else:
+        print "Test Failed"
+        exit(-1)


### PR DESCRIPTION
Add the script test_all.py to test the firmware of all connected
daplink boards.  In specific this script tests the following:
1. Mass storage is functioning
2. Serial port is working
3. HID is working

This patch is the first pass of automated dap testing.  In
the future the tests will be expanded for all endpoints.  TODOs have
been left to indicate desired future changes.

Note:
-The file basic_test.py was taking from pyOCD and is used as a
starting point for HID testing.  In the future this test will be
heavily modified.
-The file mbedapi.py was taken from
https://developer.mbed.org/teams/mbed/code/mbed-API-helper/
and modified to to be more usable as a script.  It was also
modified to more closely match pep8.
