### PR TITLE
Switch between BL and IF by deleting file

### DIFF
--- a/source/common/cmsis-core/freescale/k20dx/armcc/k20dx_daplink_bl.sct
+++ b/source/common/cmsis-core/freescale/k20dx/armcc/k20dx_daplink_bl.sct
@@ -6,10 +6,13 @@ LR_IROM1 0x00000000 0x8000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  RW_IRAM1 0x1FFFE000 0x00004000  {  ; RW data
+  RW_IRAM1 0x1FFFE000 0x00003F00  {  ; RW data
    .ANY (+RW +ZI)
   }
 
+  RW_CONFIG 0x20001F00 UNINIT 0x100 {
+    .ANY (cfgram)
+  }
 }
 LR_CONFIG 0x0001FC00 0x400 {	 ; reserve last sector for config data
   ER_CONFIG 0x0001FC00 UNINIT 0x400 {

--- a/source/common/cmsis-core/freescale/k20dx/armcc/k20dx_daplink_if.sct
+++ b/source/common/cmsis-core/freescale/k20dx/armcc/k20dx_daplink_if.sct
@@ -10,8 +10,12 @@ LR_IROM1 0x00008000 0x17C00  {    ; load region size_region (96k - 1k)
    .ANY (+RW +ZI)
   }
   
-  RW_IRAM2 0x20000000 0x00002000  {
+  RW_IRAM2 0x20000000 0x00001F00  {
    .ANY (+RW +ZI)
+  }
+
+  RW_CONFIG 0x20001F00 UNINIT 0x100 {
+    .ANY (cfgram)
   }
 }
 LR_CONFIG 0x0001FC00 0x400 {	 ; reserve last sector for config data

--- a/source/common/cmsis-core/freescale/kl26z/armcc/kl26z_daplink_bl.sct
+++ b/source/common/cmsis-core/freescale/kl26z/armcc/kl26z_daplink_bl.sct
@@ -5,8 +5,11 @@ LR_IROM1 0x00000000 0x8000  {    ; load region size_region (32k)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  RW_IRAM1 0x1FFFF000 0x4000 {   ; RAM (16k)
+  RW_IRAM1 0x1FFFF000 0x3F00 {   ; RAM (16k)
    .ANY (+RW +ZI)
+  }
+  RW_CONFIG 0x20002F00 UNINIT 0x100 {
+    .ANY (cfgram)
   }
 }
 LR_CONFIG 0x0001FC00 0x400 {	 ; reserve last sector for config data

--- a/source/common/cmsis-core/freescale/kl26z/armcc/kl26z_daplink_if.sct
+++ b/source/common/cmsis-core/freescale/kl26z/armcc/kl26z_daplink_if.sct
@@ -4,8 +4,11 @@ LR_IROM1 0x00008000 0x17C00  {   ; load region size_region (96k - 1k)
     * (InRoot$$Sections)
     .ANY (+RO)
   }
-  RW_IRAM1 0x1FFFF000 0x4000 {   ; RAM (16k)
+  RW_IRAM1 0x1FFFF000 0x3F00 {   ; RAM (16k)
     .ANY (+RW +ZI)
+  }
+  RW_CONFIG 0x20002F00 UNINIT 0x100 {
+    .ANY (cfgram)
   }
 }
 LR_CONFIG 0x0001FC00 0x400 {	 ; reserve last sector for config data

--- a/source/common/cmsis-core/nxp/lpc11u35/armcc/lpc11u35_daplink_if.sct
+++ b/source/common/cmsis-core/nxp/lpc11u35/armcc/lpc11u35_daplink_if.sct
@@ -11,10 +11,12 @@ LR_IROM1 0x00000000 0xFF00  {    ; load region size_region (64k - 256)
     .ANY (+RW +ZI)
   }
   
-  RW_IRAM2 0x20000000 0x800  {
+  RW_IRAM2 0x20000000 0x700  {
     .ANY (+RW +ZI)
   } 
-  
+  RW_CONFIG 0x20000700 UNINIT 0x100 {
+    .ANY (cfgram)
+  }
 }
 LR_CONFIG 0x0000FF00 0x100 {	 ; reserve last sector for config data
   ER_CONFIG 0x0000FF00 UNINIT 0x100 {

--- a/source/common/endpoints/drag-n-drop/virtual_fs.h
+++ b/source/common/endpoints/drag-n-drop/virtual_fs.h
@@ -115,9 +115,13 @@ extern const uint32_t disc_size;
 extern virtual_media_t fs[];
 extern const uint8_t mbed_redirect_file[];
 
+extern const char daplink_mode_file_name[11];
 extern const char daplink_drive_name[11];
 extern const char daplink_url_name[11];
 extern const char * const daplink_target_url;
+
+extern const char * const virtual_fs_auto_rstcfg;
+extern const char * const virtual_fs_hard_rstcfg;
 
 void configure_fail_txt(target_flash_status_t reason);
 void virtual_fs_init(void);

--- a/source/common/hal/config_settings.c
+++ b/source/common/hal/config_settings.c
@@ -18,8 +18,7 @@
 #include "config_settings.h"
 #include "target_flash.h"
 #include "target_config.h"
-
-#define MIN(a,b) ((a) < (b) ? a : b)
+#include "compiler.h"
 
 // Setting/flash should only be changed in the
 // bootloader
@@ -29,14 +28,72 @@
     #include "FlashPrg.h"
 #endif
 
+#define MIN(a,b) ((a) < (b) ? a : b)
+
+
+// 'kvld' in hex - key valid
+#define CFG_KEY             0x6b766c64
+#define SECTOR_BUFFER_SIZE  16
+
+// WARNING - THIS STRUCTURE RESIDES IN NON-VOLATILE STORAGE!
+// Be careful with changes:
+// -Only add new members to end end of this structure
+// -Do not change the order of members in this structure
+// -Structure must remain packed so no padding bytes are added
+typedef struct __attribute__ ((__packed__)) cfg_setting {
+    uint32_t key;               // Magic key to indicate a valid record
+    uint16_t size;              // Size of cfg_setting_t
+
+    // Configurable values
+    uint8_t auto_rst;
+
+    // Add new members here
+
+} cfg_setting_t;
+
+// Make sure FORMAT in generate_config.py is updated if size changes
+COMPILER_ASSERT(sizeof(cfg_setting_t) == 7);
+
+// Sector buffer must be as big or bigger than settings
+COMPILER_ASSERT(sizeof(cfg_setting_t) < SECTOR_BUFFER_SIZE);
+// Sector buffer must be a multiple of 4 bytes at least.
+// ProgramPage for some interfaces, like the k20dx, require that 
+// the data is a multiple of 4 bytes, otherwise programming will
+// fail.  Assert 8 byte alignement just to be safe.
+COMPILER_ASSERT(SECTOR_BUFFER_SIZE % 8 == 0);
+
+// WARNING - THIS STRUCTURE RESIDES IN RAM STORAGE!
+// Be careful with changes:
+// -Only add new members to end end of this structure
+// -Do not change the order of members in this structure
+// -Structure must remain packed so no padding bytes are added
+typedef struct __attribute__ ((__packed__)) cfg_ram {
+    uint32_t key;               // Magic key to indicate a valid record
+    uint16_t size;              // Offset of the last member from the start
+
+    // Configurable values
+    uint8_t hold_in_bl;
+
+    // Add new members here
+
+} cfg_ram_t;
+
 // Configuration ROM
 static volatile const cfg_setting_t config_rom __attribute__((section("cfgrom"), zero_init));
-// Ram copy of config
-static cfg_setting_t config_ram;
+// Ram copy of ROM config
+static cfg_setting_t config_rom_copy;
+// Buffer for data to flash
+#if FLASH_WRITE_ALLOWED
+    static uint32_t write_buffer[SECTOR_BUFFER_SIZE/4];
+#endif
+
+// Configuration RAM
+static volatile cfg_ram_t config_ram __attribute__((section("cfgram"), zero_init));
+// Ram copy of RAM config
+static cfg_ram_t config_ram_copy;
 
 // Configuration defaults in flash
-__attribute__((weak))
-const cfg_setting_t config_default = 
+static const cfg_setting_t config_default =
 {
     .auto_rst = 0,
 };
@@ -51,10 +108,10 @@ static bool config_needs_update()
 
     // Update if the config key is valid but
     // has a smaller size.
-    if (config_rom.offset_of_end < CFG_SIZE_CURRENT) {
+    if (config_rom.size < sizeof(config_rom)) {
         return true;
     }
-    
+
     // The config is valid and has the right
     // size so it does not need to be updated
     return false;
@@ -66,18 +123,20 @@ static void program_cfg(cfg_setting_t* new_cfg)
 #if FLASH_WRITE_ALLOWED
     uint32_t status;
     uint32_t addr;
-    
+
     addr = (uint32_t)&config_rom;
-    
+
     __disable_irq();
     status = EraseSector(addr);
     __enable_irq();
     if(status != 0) {
         return;
     }
-    
+
+    memset(write_buffer, 0xFF, sizeof(write_buffer));
+    memcpy(write_buffer, new_cfg, sizeof(cfg_setting_t));
     __disable_irq();
-    status = ProgramPage(addr, sizeof(cfg_setting_t), (uint32_t*)new_cfg);
+    status = ProgramPage(addr, sizeof(write_buffer), write_buffer);
     __enable_irq();
     if (0 != status) {
         return;
@@ -91,37 +150,69 @@ void config_init()
     Init(0,0,0);
 #endif
 
+    /* Initialize ROM */
+
     // Fill in the ram copy with the defaults
-    memcpy(&config_ram, &config_default, sizeof(config_ram));
+    memcpy(&config_rom_copy, &config_default, sizeof(config_rom_copy));
 
     // Read settings from flash if the key is valid
     if (CFG_KEY == config_rom.key) {
-        uint32_t size = MIN(config_rom.offset_of_end, CFG_SIZE_CURRENT);
-        memcpy(&config_ram, (void*)&config_rom, size);
+        uint32_t size = MIN(config_rom.size, sizeof(config_rom));
+        memcpy(&config_rom_copy, (void*)&config_rom, size);
     }
 
     // Fill in special values
-    config_ram.key = CFG_KEY;
-    config_ram.offset_of_end = CFG_SIZE_CURRENT;
-    config_ram.end = 0;
+    config_rom_copy.key = CFG_KEY;
+    config_rom_copy.size = sizeof(config_rom);
 
     // Write settings back to flash if they are out of date
     // Note - program_cfg only programs data in bootloader mode
     if (config_needs_update()) {
         // Program with defaults if none are set
-        program_cfg(&config_ram);
+        program_cfg(&config_rom_copy);
     }
+
+    /* Initialize RAM */
+
+    // Initialize RAM copy
+    memset(&config_ram_copy, 0, sizeof(config_ram_copy));
+
+    // Read settings from RAM if the key is valid
+    if (CFG_KEY == config_ram.key) {
+        uint32_t size = MIN(config_ram.size, sizeof(config_ram));
+        memcpy(&config_ram_copy, (void*)&config_ram, size);
+    }
+
+    // Initialize RAM
+    memset((void*)&config_ram, 0, sizeof(config_ram));
+    config_ram.key = CFG_KEY;
+    config_ram.size = sizeof(config_ram);
 }
 
-void config_set_auto_rst(bool on) 
+void config_set_auto_rst(bool on)
 {
 #if FLASH_WRITE_ALLOWED
-    config_ram.auto_rst = on;
-    program_cfg(&config_ram);
+    config_rom_copy.auto_rst = on;
+    program_cfg(&config_rom_copy);
 #endif
 }
 
 bool config_get_auto_rst()
 {
-    return config_ram.auto_rst;
+    return config_rom_copy.auto_rst;
+}
+
+void config_ram_set_hold_in_bl(bool hold)
+{
+    config_ram.hold_in_bl = hold;
+}
+
+bool config_ram_get_hold_in_bl()
+{
+    return config_ram.hold_in_bl;
+}
+
+bool config_ram_get_initial_hold_in_bl()
+{
+    return config_ram_copy.hold_in_bl;
 }

--- a/source/common/hal/config_settings.h
+++ b/source/common/hal/config_settings.h
@@ -16,37 +16,18 @@
 #ifndef CONFIG_SETTINGS_H
 #define CONFIG_SETTINGS_H
 
+#include<stdint.h>
 #include<stdbool.h>
-#include "target_config.h"
-
-// 'kvld' in hex - key valid
-#define CFG_KEY             0x6b766c64
-#define CFG_VALID(dev)      (NULL != (dev).cfg && CfG_KEY == (dev).cfg->key)
-// Size of the structure not including the member 'end'.  This define is used
-// instead of sizeof() so the exact size can be obtained, rather than
-// the 4 byte aligned size that sizeof() returns.
-#define CFG_SIZE_CURRENT    (offsetof(cfg_setting_t, end))
-
-// WARNING - THIS STRUCTURE RESIDES IN NON-VOLATILE STORAGE! 
-// Be careful with changes:
-// -Only add new members to end end of this structure
-// -Do not change the order of members in this structure
-typedef struct cfg_setting {
-    uint32_t key;               // Magic key to indicate a valid record
-    uint16_t offset_of_end;     // Offset of the last member from the start
-
-    // Configurable values
-    uint8_t auto_rst;
-    
-    // Add new members here
-    
-    uint8_t end; // Must be last member
-} cfg_setting_t;
-
-extern const cfg_setting_t config_default;
 
 void config_init(void);
+
+// Get/set settings residing in flash
 void config_set_auto_rst(bool on);
 bool config_get_auto_rst(void);
+
+// Get/set settings residing in shared ram
+void config_ram_set_hold_in_bl(bool hold);
+bool config_ram_get_hold_in_bl(void);
+bool config_ram_get_initial_hold_in_bl(void);
 
 #endif

--- a/source/common/hal/freescale/k20dx/gpio.c
+++ b/source/common/hal/freescale/k20dx/gpio.c
@@ -20,6 +20,13 @@
 #include "target_reset.h"
 #include "daplink.h"
 
+static void busy_wait(uint32_t cycles)
+{
+    volatile uint32_t i;
+    i = cycles;
+    while (i > 0) i--;
+}
+
 void gpio_init(void)
 {
     // enable clock to ports
@@ -49,6 +56,14 @@ void gpio_init(void)
         PIN_POWER_EN_GPIO->PDOR |= 1UL << PIN_POWER_EN_BIT;
         PIN_POWER_EN_GPIO->PDDR |= 1UL << PIN_POWER_EN_BIT;
     }
+
+    // Let the voltage rails stabilize.  This is especailly important
+    // during software resets, since the target's 3.3v rail can take
+    // 20-50ms to drain.  During this time the target could be driving
+    // the reset pin low, causing the bootloader to think the reset
+    // button is pressed.
+    // Note: With optimization set to -O2 the value 1000000 delays for ~85ms
+    busy_wait(1000000);
 }
 
 void gpio_set_hid_led(gpio_led_state_t state)

--- a/source/common/hal/nxp/lpc11u35/IO_Config.h
+++ b/source/common/hal/nxp/lpc11u35/IO_Config.h
@@ -17,4 +17,6 @@
 #ifndef __IO_CONFIG_H__
 #define __IO_CONFIG_H__
 
+#include "LPC11Uxx.h"
+
 #endif

--- a/source/daplink_bl/daplink.c
+++ b/source/daplink_bl/daplink.c
@@ -17,10 +17,12 @@
 #include "daplink.h"
 #include "virtual_fs.h"
 
-// daplink_url_name and daplink_drive_name strings must 
-// be 11 characters excluding the null terminated character
-const char daplink_url_name[11] =   "HELP_FAQHTM";
-const char daplink_drive_name[11] = "MAINTENANCE";
+// daplink_mode_file_name, daplink_url_name and 
+// daplink_drive_name strings must be 11 characters 
+// excluding the null terminated character
+const char daplink_mode_file_name[11] = "START_IFCFG";
+const char daplink_url_name[11] =       "HELP_FAQHTM";
+const char daplink_drive_name[11] =     "MAINTENANCE";
 const char * const daplink_target_url = "https://mbed.com/daplink";
 
 bool daplink_is_bootloader()

--- a/source/daplink_bl/main.c
+++ b/source/daplink_bl/main.c
@@ -113,6 +113,11 @@ __task void main_task(void)
     // USB
     uint32_t usb_state_count;
 
+    if (config_ram_get_initial_hold_in_bl()) {
+        // Delay for 3 seconds for VMs
+        os_dly_wait(300);
+    }
+
     // Get a reference to this task
     main_task_id = os_tsk_self();
     
@@ -238,8 +243,9 @@ int main (void)
     gpio_init();
     // init settings
     config_init();
-    // check for invalid app image or rst button press. Should be checksum or CRC but NVIC validation is better than nothing
-    if (gpio_get_sw_reset() && validate_bin_nvic((uint8_t*)target_device.flash_start)) {
+    // check for invalid app image or rst button press. Should be checksum or CRC but NVIC validation is better than nothing.
+    // If the interface has set the hold in bootloader setting don't jump to app
+    if (gpio_get_sw_reset() && validate_bin_nvic((uint8_t*)target_device.flash_start) && !config_ram_get_initial_hold_in_bl()) {
         // change to the new vector table
         SCB->VTOR = target_device.flash_start;
         // modify stack pointer and start app

--- a/source/daplink_if/daplink.c
+++ b/source/daplink_if/daplink.c
@@ -17,12 +17,14 @@
 #include "daplink.h"
 #include "virtual_fs.h"
 
-// daplink_url_name and daplink_drive_name strings must 
-// be 11 characters excluding the null terminated character
+// daplink_mode_file_name, daplink_url_name and 
+// daplink_drive_name strings must be 11 characters 
+// excluding the null terminated character
+const char daplink_mode_file_name[11] = "START_BLCFG";
 __attribute__((weak))
-const char daplink_url_name[11] =   "MBED    HTM";
+const char daplink_url_name[11] =       "MBED    HTM";
 __attribute__((weak))
-const char daplink_drive_name[11] = "DAPLINK    ";
+const char daplink_drive_name[11] =     "DAPLINK    ";
 __attribute__((weak))
 const char * const daplink_target_url = "https://mbed.org/device/?code=@A";
 

--- a/source/daplink_if/main.c
+++ b/source/daplink_if/main.c
@@ -367,6 +367,10 @@ __task void main_task(void)
                 case USB_DISCONNECT_CONNECT:
                     // Wait until USB is idle before disconnecting
                     if ((usb_busy == USB_IDLE) && (DECZERO(usb_state_count) == 0)) {
+                        // If hold in bootloader has been set then reset after usb is disconnected
+                        if (config_ram_get_hold_in_bl()) {
+                            NVIC_SystemReset();
+                        }
                         usb_state = USB_CONNECTING;
                         // Delay the connecting state before reconnecting to the host - improved usage with VMs
                         usb_state_count = USB_BUSY_TIME;


### PR DESCRIPTION
Add the ability to switch between bootloader and interface by deleting
a file on the filesystem.  This enables new interface code to be loaded
from automated test scripts.  Rebooting into bootloader mode is done
through a shared RAM region that the interface uses to signal to
the bootloader to stay in bootloader mode.

This patch also simplifies the configuration settings by making them
a packed struct and using sizeof directly, rather than obtaining
the size by getting the position of the last member.  This change
retains compatibility with the previous settings format, but makes
the code easier to understand.

Finally, this patch adds a delay to the K20DX family of boards
when booting.  This allows the target voltage rails to fully drain
if they had been previously powered, preventing reset from being
driven low by the target.
