### PR TITLE
Change mode by creating file rather than deleting

### DIFF
--- a/source/common/endpoints/drag-n-drop/usbd_user_msc.c
+++ b/source/common/endpoints/drag-n-drop/usbd_user_msc.c
@@ -177,6 +177,16 @@ static bool check_file_deleted(const FatDirectoryEntry_t * dir_entry, const char
     return false;
 }
 
+static bool check_file_created(const FatDirectoryEntry_t * dir_entry, const char * filename)
+{
+    //  the correct name
+    const uint32_t size = sizeof(dir_entry->filename);
+    if (data_same_ignore_case(&filename[0], (const char *)&dir_entry->filename[0], size)) {
+        return true;
+    }
+    return false;
+}
+
 static extension_t identify_start_sequence(uint8_t *buf)
 {
     if (1 == validate_bin_nvic(buf)) {
@@ -255,7 +265,7 @@ void usbd_msc_write_sect(uint32_t block, uint8_t *buf, uint32_t num_of_blocks)
                 config_set_auto_rst(true);
                 tranfer_complete(TARGET_OK);
                 return;
-            } else if (check_file_deleted(&tmp_file, daplink_mode_file_name)) {
+            } else if (check_file_created(&tmp_file, daplink_mode_file_name)) {
                 debug_msg("%s", "USER CFG ACTION DETECTED\r\n");
                 if (daplink_is_interface()) {
                     config_ram_set_hold_in_bl(true);

--- a/source/common/endpoints/drag-n-drop/virtual_fs.c
+++ b/source/common/endpoints/drag-n-drop/virtual_fs.c
@@ -95,7 +95,7 @@ static const file_allocation_table_t fat = {
     .f = {
         0xF8, 0xFF, 0xFF, // Sector 0, 1
         0xFF, 0xFF, 0xFF, // Sector 2, 3
-        0xFF, 0xFF, 0xFF, // Sector 4, 5
+        0xFF, 0x0F, 0x00, // Sector 4, 5
         0x00, 0x00, 0x00, // Sector 6, 7
     }
 };
@@ -105,7 +105,7 @@ static const file_allocation_table_t fat_fail = {
         0xF8, 0xFF, 0xFF, // Sector 0, 1
         0xFF, 0xFF, 0xFF, // Sector 2, 3
         0xFF, 0xFF, 0xFF, // Sector 4, 5
-        0xFF, 0x0F, 0x00, // Sector 6, 7
+        0x00, 0x00, 0x00, // Sector 6, 7
     }
 };
 
@@ -140,9 +140,6 @@ static const uint8_t hardware_rst_file[512] =
     "# Delete this file to toggle the behavior\r\n"
     "# This setting can only be changed in maintenance mode\r\n";
 
-static const uint8_t switch_mode_file[512] = 
-    "# Delete this file to switch between DAPLINK and MAINTENANCE mode\r\n";
-
 static const uint8_t fail_file[512] =
     "Placeholder for fail.txt data\r\n";
 
@@ -157,7 +154,7 @@ static FatDirectoryEntry_t const fail_txt_dir_entry = {
 /*uint16_t*/ .first_cluster_high_16 = 0x0000,
 /*uint16_t*/ .modification_time = 0x83dc,
 /*uint16_t*/ .modification_date = 0x34bb,
-/*uint16_t*/ .first_cluster_low_16 = 0x0006,    // always must be last sector
+/*uint16_t*/ .first_cluster_low_16 = 0x0005,    // always must be last sector
 /*uint32_t*/ .filesize = sizeof(fail_file)
 };
 
@@ -236,21 +233,8 @@ static root_dir_t dir1 = {
     /*uint16_t*/ .first_cluster_low_16 = 0x0004,
     /*uint32_t*/ .filesize = sizeof(hardware_rst_file)
     },
-    .f4 = {
-    /*uint8_t[13] */ .filename = {""}, // daplink_mode_file_name
-    /*uint8_t */ .attributes = 0x02,
-    /*uint8_t */ .reserved = 0x00,
-    /*uint8_t */ .creation_time_ms = 0x00,
-    /*uint16_t*/ .creation_time = 0x0000,
-    /*uint16_t*/ .creation_date = 0x0021,
-    /*uint16_t*/ .accessed_date = 0xbb32,
-    /*uint16_t*/ .first_cluster_high_16 = 0x0000,
-    /*uint16_t*/ .modification_time = 0x83dc,
-    /*uint16_t*/ .modification_date = 0x30bb,
-    /*uint16_t*/ .first_cluster_low_16 = 0x0005,
-    /*uint32_t*/ .filesize = 0x00000000,
-    },
-    .f5  = {0}, // fail.txt or empty
+    .f4  = {0}, // fail.txt or empty
+    .f5  = {0},
     .f6  = {0},
     .f7  = {0},
     .f8  = {0},
@@ -309,10 +293,10 @@ virtual_media_t fs[] = {
     {(uint8_t *)&hardware_rst_file, sizeof(hardware_rst_file)},
     {(uint8_t *)&blank_reigon, sizeof(blank_reigon)},
     //f4 [11]
-    {(uint8_t *)&switch_mode_file, sizeof(switch_mode_file)},
+    {(uint8_t *)&fail_file, sizeof(fail_file)},
     {(uint8_t *)&blank_reigon, sizeof(blank_reigon)},
     //f5 [13]
-    {(uint8_t *)&fail_file,    sizeof(fail_file)},
+    {(uint8_t *)&blank_reigon, sizeof(blank_reigon)},
     {(uint8_t *)&blank_reigon, sizeof(blank_reigon)},
     //f6 [15]
     {(uint8_t *)&blank_reigon, sizeof(blank_reigon)},
@@ -356,12 +340,12 @@ void configure_fail_txt(target_flash_status_t reason)
 {
     const uint8_t * fat_ptr;
     // set the dir entry to a file or empty it
-    dir1.f5 = (TARGET_OK == reason) ? empty_dir_entry : fail_txt_dir_entry;
+    dir1.f4 = (TARGET_OK == reason) ? empty_dir_entry : fail_txt_dir_entry;
     fat_ptr = (TARGET_OK == reason) ? fat.f : fat_fail.f;
     // update the filesize (pass/fail)
-    dir1.f5.filesize = strlen((const char *)fail_txt_contents[reason]);
+    dir1.f4.filesize = strlen((const char *)fail_txt_contents[reason]);
     // and the memory that we point to (file contents)
-    fs[13].sect = (uint8_t *)fail_txt_contents[reason];
+    fs[11].sect = (uint8_t *)fail_txt_contents[reason];
 
     fs[1].sect = (uint8_t*) fat_ptr;
     fs[2].sect = (uint8_t*)fat_ptr;
@@ -391,8 +375,6 @@ void virtual_fs_init(void)
     str = config_get_auto_rst() ? virtual_fs_auto_rstcfg : virtual_fs_hard_rstcfg;
     str_len = strlen(str);
     memcpy(dir1.f3.filename, str, str_len);
-    memcpy(dir1.f4.filename, daplink_mode_file_name, sizeof(daplink_mode_file_name));
-    dir1.f4.filesize = strlen((const char *)switch_mode_file);
 
     // patch fs entries (fat sizes and all blank regions)
     fs[1].length  = sizeof(fat) * mbr.logical_sectors_per_fat;

--- a/test/daplink_board.py
+++ b/test/daplink_board.py
@@ -139,10 +139,10 @@ class DaplinkBoard:
 
     def get_mode(self):
         """Return either MODE_IF or MODE_BL"""
-        if os.path.isfile(self.start_bl_path):
-            return self.MODE_IF
-        elif os.path.isfile(self.start_if_path):
+        if os.path.isfile(self.check_bl_path):
             return self.MODE_BL
+        elif os.path.isfile(self.check_if_path):
+            return self.MODE_IF
         else:
             raise Exception("Unsupported board - cannot change mode!")
 
@@ -163,12 +163,16 @@ class DaplinkBoard:
             # No mode change needed
             return
 
-        if mode is self.MODE_IF:
+        if mode is self.MODE_BL:
             test_info.info("changing mode IF -> BL")
-            os.remove(self.start_if_path)
-        elif mode is self.MODE_BL:
+            # Create file to enter BL mode
+            with open(self.start_bl_path, 'wb') as _:
+                pass
+        elif mode is self.MODE_IF:
             test_info.info("changing mode BL -> IF")
-            os.remove(self.start_bl_path)
+            # Create file to enter BL mode
+            with open(self.start_if_path, 'wb') as _:
+                pass
         else:
             test_info.warning("Board is in unknown mode")
         self.wait_for_remount(test_info)
@@ -348,6 +352,10 @@ class DaplinkBoard:
         assert self.unique_id is not None
         assert self.mount_point is not None
         self.board_id = int(self.unique_id[0:4], 16)
+        self.check_bl_path = os.path.normpath(self.mount_point +
+                                              os.sep + 'HELP_FAQ.HTM')
+        self.check_if_path = os.path.normpath(self.mount_point +
+                                              os.sep + 'MBED.HTM')
         self.start_bl_path = os.path.normpath(self.mount_point +
                                               os.sep + 'START_BL.CFG')
         self.start_if_path = os.path.normpath(self.mount_point +


### PR DESCRIPTION
Change between the bootloader and interface by copying or creating
the file START_BL.CFG or START_IF.CFG to the file system, rather than
by deleting it.

This patch also reverts the file system change for START_*.CFG since
these files are no longer present on the operating system.  These
changes were done in the following patch:
b678f0ca38c9a1a5f81cd7a5925f9be1db08e9bf -
"Switch between BL and IF by deleting file"
