### PR TITLE
Add checksum to NVIC in template.

### DIFF
--- a/records/tools/uvision.uvproj.tmpl
+++ b/records/tools/uvision.uvproj.tmpl
@@ -75,9 +75,9 @@
           </BeforeMake>
           <AfterMake>
             <RunUserProg1>1</RunUserProg1>
-            <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>fromelf --bin $L@L.axf -o $L@L.bin</UserProg1Name>
-            <UserProg2Name></UserProg2Name>
+            <RunUserProg2>1</RunUserProg2>
+            <UserProg1Name>$KARM\BIN\ElfDwT.exe #L</UserProg1Name>
+            <UserProg2Name>fromelf --bin $L@L.axf -o $L@L.bin</UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
           </AfterMake>


### PR DESCRIPTION
This is not ideal as only NXP devices need it and it seems projgen removed the ability to set this on a per project basis. Without all .bin for NXP builds are considered invalid by the bootloader.

This is just a reminder to look into in the future
