### PR TITLE
Hid without driver

### DIFF
--- a/source/common/hal/atmel/sam3u2c/usb_config.c
+++ b/source/common/hal/atmel/sam3u2c/usb_config.c
@@ -325,7 +325,7 @@
 /* USB Device Calculations ---------------------------------------------------*/
 
 #define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (0)//USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
 #define MAX(x, y)                (((x) < (y)) ? (y) : (x))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))

--- a/source/common/hal/freescale/k20dx/usb_config.c
+++ b/source/common/hal/freescale/k20dx/usb_config.c
@@ -348,7 +348,7 @@
 /* USB Device Calculations ---------------------------------------------------*/
 
 #define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (0)//USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
 #define MAX(x, y)                (((x) < (y)) ? (y) : (x))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))

--- a/source/common/hal/freescale/kl26z/usb_config.c
+++ b/source/common/hal/freescale/kl26z/usb_config.c
@@ -348,7 +348,7 @@
 /* USB Device Calculations ---------------------------------------------------*/
 
 #define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (0)//USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
 #define MAX(x, y)                (((x) < (y)) ? (y) : (x))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))

--- a/source/common/hal/nxp/lpc11u35/usb_config.c
+++ b/source/common/hal/nxp/lpc11u35/usb_config.c
@@ -332,7 +332,7 @@
 /* USB Device Calculations ---------------------------------------------------*/
 
 #define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (0)//USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
 #define MAX(x, y)                (((x) < (y)) ? (y) : (x))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))

--- a/source/common/hal/nxp/lpc4322/usb_config.c
+++ b/source/common/hal/nxp/lpc4322/usb_config.c
@@ -325,7 +325,7 @@
 /* USB Device Calculations ---------------------------------------------------*/
 
 #define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (0)//USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
 #define MAX(x, y)                (((x) < (y)) ? (y) : (x))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))

--- a/source/common/usb/usb_lib.c
+++ b/source/common/usb/usb_lib.c
@@ -1348,13 +1348,24 @@ void USBD_RTX_TaskInit (void) {
 #endif
 }
 
+/*------------------------------------------------------------------------------
+ *      CDC Sizes
+ *----------------------------------------------------------------------------*/
+#define CDC_HEADER_SIZE                         5
+#define CDC_CALL_MANAGEMENT_SIZE                5
+#define CDC_ABSTRACT_CONTROL_MANAGEMENT_SIZE    4
+#define CDC_UNION_SIZE                          5
 
 /*------------------------------------------------------------------------------
  *      USB Device Descriptors
  *----------------------------------------------------------------------------*/
 #define USBD_MSC_DESC_LEN                 (USB_INTERFACE_DESC_SIZE + 2*USB_ENDPOINT_DESC_SIZE)
-#define USBD_CDC_ACM_DESC_LEN             (USB_INTERFACE_DESC_SIZE + /*USBD_MULTI_IF * USB_INTERFACE_ASSOC_DESC_SIZE +*/ 0x0013                 + \
-                                           USB_ENDPOINT_DESC_SIZE + USB_INTERFACE_DESC_SIZE + 2*USB_ENDPOINT_DESC_SIZE)
+#define USBD_CDC_ACM_DESC_LEN             (USBD_MULTI_IF * USB_INTERFACE_ASSOC_DESC_SIZE                                                        + \
+                                           /* CDC Interface 1 */                                                                                  \
+                                           USB_INTERFACE_DESC_SIZE + CDC_HEADER_SIZE + CDC_CALL_MANAGEMENT_SIZE                                 + \
+                                           CDC_ABSTRACT_CONTROL_MANAGEMENT_SIZE + CDC_UNION_SIZE + USB_ENDPOINT_DESC_SIZE                       + \
+                                           /* CDC Interface 2 */                                                                                  \
+                                           USB_INTERFACE_DESC_SIZE + USB_ENDPOINT_DESC_SIZE + USB_ENDPOINT_DESC_SIZE)
 #define USBD_HID_DESC_LEN                 (USB_INTERFACE_DESC_SIZE + USB_HID_DESC_SIZE                                                          + \
                                           (USB_ENDPOINT_DESC_SIZE*(1+(USBD_HID_EP_INTOUT != 0))))
 #define USBD_HID_DESC_OFS                 (USB_CONFIGUARTION_DESC_SIZE + USB_INTERFACE_DESC_SIZE                                                + \
@@ -1779,23 +1790,23 @@ const U8 USBD_DeviceQualifier_HS[] = { 0 };
   USBD_CDC_ACM_CIF_STR_NUM,             /* iInterface: */                                                   \
                                                                                                             \
 /* Header Functional Descriptor */                                                                          \
-  0x05,                                 /* bLength: Endpoint Descriptor size */                             \
+  CDC_HEADER_SIZE,                      /* bLength: Endpoint Descriptor size */                             \
   CDC_CS_INTERFACE,                     /* bDescriptorType: CS_INTERFACE */                                 \
   CDC_HEADER,                           /* bDescriptorSubtype: Header Func Desc */                          \
   WBVAL(CDC_V1_10), /* 1.10 */          /* bcdCDC */                                                        \
 /* Call Management Functional Descriptor */                                                                 \
-  0x05,                                 /* bFunctionLength */                                               \
+  CDC_CALL_MANAGEMENT_SIZE,             /* bFunctionLength */                                               \
   CDC_CS_INTERFACE,                     /* bDescriptorType: CS_INTERFACE */                                 \
   CDC_CALL_MANAGEMENT,                  /* bDescriptorSubtype: Call Management Func Desc */                 \
   0x03,                                 /* bmCapabilities: device handles call management */                \
   0x02,                                 /* bDataInterface: CDC data IF ID */                                \
 /* Abstract Control Management Functional Descriptor */                                                     \
-  0x04,                                 /* bFunctionLength */                                               \
+  CDC_ABSTRACT_CONTROL_MANAGEMENT_SIZE, /* bFunctionLength */                                               \
   CDC_CS_INTERFACE,                     /* bDescriptorType: CS_INTERFACE */                                 \
   CDC_ABSTRACT_CONTROL_MANAGEMENT,      /* bDescriptorSubtype: Abstract Control Management desc */          \
   0x06,                                 /* bmCapabilities: SET_LINE_CODING, GET_LINE_CODING, SET_CONTROL_LINE_STATE supported */ \
 /* Union Functional Descriptor */                                                                           \
-  0x05,                                 /* bFunctionLength */                                               \
+  CDC_UNION_SIZE,                       /* bFunctionLength */                                               \
   CDC_CS_INTERFACE,                     /* bDescriptorType: CS_INTERFACE */                                 \
   CDC_UNION,                            /* bDescriptorSubtype: Union func desc */                           \
   USBD_CDC_ACM_CIF_NUM,                 /* bMasterInterface: Communication class interface is master */     \


### PR DESCRIPTION
Turn on USB multi interface support to allow HID to be used
without having the mbed serial driver installed.  Also fix the size
calculation of the USB configuration descriptor when USBD_MULTI_IF
is set.
