### PR TITLE
Support legacy bootloader offset

### DIFF
--- a/source/daplink_if/main.c
+++ b/source/daplink_if/main.c
@@ -29,6 +29,7 @@
 #include "info.h"
 #include "virtual_fs_user.h"
 #include "config_settings.h"
+#include "daplink.h"
 
 // Event flags for main task
 // Timers events
@@ -510,5 +511,10 @@ __task void main_task(void)
 
 int main (void)
 {
+    // Explicitly set the vector table since the bootloader might not set
+    // it to what we expect.
+    #if DAPLINK_ROM_BL_SIZE > 0
+        SCB->VTOR = SCB_VTOR_TBLOFF_Msk & DAPLINK_ROM_IF_START;
+    #endif
     os_sys_init_user(main_task, MAIN_TASK_PRIORITY, stk_main_task, MAIN_TASK_STACK);
 }

--- a/tools/offset_update.py
+++ b/tools/offset_update.py
@@ -1,0 +1,37 @@
+import argparse
+
+
+def dec_or_hex(val):
+    return int(val, 0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='File Padder')
+    parser.add_argument("bin", type=str, default=None, help="Input binary file")
+    parser.add_argument("--start", type=dec_or_hex, default=0x8000,
+                        help="Starting address of input binary file")
+    parser.add_argument("--padded_start", type=dec_or_hex, default=0x5000,
+                        help="Starting address after padding.")
+    parser.add_argument("--output", type=str, required=True,
+                        help="Output file")
+    parser.add_argument("--copysize", type=str, default=0x40,
+                        help="Size of original binary to copy")
+    args = parser.parse_args()
+
+    # Data is appened to front so padded start must be less than start
+    assert args.start > args.padded_start
+
+    pad_size = args.start - args.padded_start
+    copy_size = args.copysize
+    input_file = args.bin
+    output_file = args.output
+    with open(input_file, 'rb') as file_handle:
+        data = file_handle.read()
+
+    output_data = data[0:copy_size] + '\xff' * (pad_size - copy_size) + data
+    with open(output_file, 'wb') as file_handle:
+        data = file_handle.write(output_data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add support for bootloaders expecting the application offset to be
0x5000 by adding a script to copy the vector table and pad as
necessary.  Update the interface code to always set the VTOR on boot
since the bootloader does not always set this to the correct location.
