### PR TITLE
ADD SSCI TY51822r3 target

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -86,3 +86,7 @@ projects:
         - *module_if
         - *module_hdk_lpc11u35
         - records/target/efm32gg_stk.yaml
+    lpc11u35_ty51822r3_if:
+        - *module_if
+        - *module_hdk_lpc11u35
+        - records/target/ty51822r3.yaml

--- a/records/target/ty51822r3.yaml
+++ b/records/target/ty51822r3.yaml
@@ -1,0 +1,5 @@
+common:
+    sources:
+        target:
+            - source/target/ssci/nrf51822/ssci_app_config.c
+            - source/target/ssci/nrf51822/target_reset.c

--- a/source/target/ssci/nrf51822/flash_blob.c
+++ b/source/target/ssci/nrf51822/flash_blob.c
@@ -1,0 +1,47 @@
+/* CMSIS-DAP Interface Firmware
+ * Copyright (c) 2009-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flash_blob.h"
+
+static const uint32_t nRF51822AA_FLM[] = {
+    0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,
+
+    /*0x020*/ 0x47702000, 0x47702000, 0x4c26b570, 0x60602002, 0x60e02001, 0x68284d24, 0xd00207c0L, 0x60602000, 
+    /*0x040*/ 0xf000bd70L, 0xe7f6f82cL, 0x4c1eb570, 0x60612102, 0x4288491e, 0x2001d302, 0xe0006160L, 0x4d1a60a0, 
+    /*0x060*/ 0xf81df000L, 0x7c06828, 0x2000d0fa, 0xbd706060L, 0x4605b5f8, 0x4813088e, 0x46142101, 0x4f126041, 
+    /*0x080*/ 0xc501cc01L, 0x7c06838, 0x1e76d006, 0x480dd1f8, 0x60412100, 0xbdf84608L, 0xf801f000L, 0x480ce7f2, 
+    /*0x0A0*/ 0x6006840, 0xd00b0e00L, 0x6849490a, 0xd0072900L, 0x4a0a4909, 0xd00007c3L, 0x1d09600a, 0xd1f90840L, 
+    /*0x0C0*/ 0x4770, 0x4001e500, 0x4001e400, 0x10001000, 0x40010400, 0x40010500, 0x40010600, 0x6e524635, 
+    /*0x0E0*/ 0x0, 
+};
+
+static const program_target_t flash = {
+    .init = 0x20000021,
+    .uninit = 0x20000025,
+    .erase_chip = 0x20000029,
+    .erase_sector = 0x20000049,
+    .program_page = 0x20000071,
+    {
+        .breakpoint = 0x20000001,
+        .static_base = 0x20000020 + 0x00000150,
+        .stack_pointer = 0x20001000
+    },
+    .program_buffer = 0x20000200,
+    .algo_start = 0x20000000,
+    .algo_size = 0x00000150,
+    .algo_blob = nRF51822AA_FLM,
+    .program_buffer_size = 512 // should be USBD_MSC_BlockSize
+};

--- a/source/target/ssci/nrf51822/ssci_app_config.c
+++ b/source/target/ssci/nrf51822/ssci_app_config.c
@@ -1,0 +1,36 @@
+/* CMSIS-DAP Interface Firmware
+ * Copyright (c) 2009-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_config.h"
+
+// The file flash_blob.c must only be included in app_config
+#include "flash_blob.c"
+
+// nrf51822-mkit target information
+const target_cfg_t target_device = {
+    .board_id   = "xxxx",
+    .secret     = "xxxxxxxx",
+    .sector_size    = 1024,
+    // Assume memory is regions are same size (smallest). Flash algo should ignore requests
+    //  when variable sized sectors exist
+    // .sector_cnt = ((.flash_end - .flash_start) / .sector_size);
+    .sector_cnt     = (KB(256)/1024),
+    .flash_start    = 0,
+    .flash_end      = KB(256),
+    .ram_start      = 0x20000000,
+    .ram_end        = 0x20008000,
+    .flash_algo     = (program_target_t*)&flash,
+};

--- a/source/target/ssci/nrf51822/target_reset.c
+++ b/source/target/ssci/nrf51822/target_reset.c
@@ -1,0 +1,192 @@
+/* CMSIS-DAP Interface Firmware
+ * Copyright (c) 2009-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "RTL.h"
+#include "debug_cm.h"
+#include "target_reset.h"
+#include "swd_host.h"
+#include "DAP_Config.h"
+
+/*static const uint32_t nrfBlinkyApp[200] = {0x20000810,0x000000F5,0x00000107,0x00000109,0x00000000,
+		0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x00000000,0x0000010B,0x00000000,
+		0x00000000,0x0000010D,0x0000010F,0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,
+		0x00000000,0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,
+		0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,
+		0x00000111,0x00000111,0x00000111,0x00000111,0x00000111,0x00000000,0x00000000,0x00000000,
+		0x00000000,0x00000000,0x00000000,0x46854803,0xF82CF000,0x47004800,0x00000235,0x20000810,
+		0xBF001E40,0xBF00BF00,0xBF00BF00,0xBF00BF00,0xBF00BF00,0xBF00BF00,0xD1F1BF00,0x00004770,
+		0x68024807,0x430A210F,0x48066002,0x48064780,0xE7FE4700,0xE7FEE7FE,0xE7FEE7FE,0x0000E7FE,
+		0x40000524,0x00000145,0x000000C1,0x25014C06,0xE0054E06,0x68E34620,0x432BC807,0x34104798,
+		0xD3F742B4,0xFFC6F7FF,0x000002F8,0x00000308,0xF000B510,0x2800F843,0x4807D005,0x60484907,
+		0x490713C8,0xF0006188,0x2800F81F,0x2001D002,0x60884904,0x0000BD10,0xC007FFDF,0x40000500,
+		0x40006C00,0x40000600,0xC808E002,0xC1081F12,0xD1FA2A00,0x47704770,0xE0012000,0x1F12C101,
+		0xD1FB2A00,0x00004770,0x8C00480B,0x2801B2C0,0x4809D110,0x07008C80,0xD10B0F00,0x6A804806,
+		0x400821F0,0xD1052840,0x6AC04803,0xD1014208,0x47702001,0xE7FC2000,0xF0000FC0,0x8C004817,
+		0x2801B2C0,0x4815D127,0x07008C80,0xD1220F00,0x6A804812,0x420821F0,0x4810D105,0x42086AC0,
+		0x2001D101,0x480D4770,0x21F06A80,0x28104008,0x480AD105,0x42086AC0,0x2001D101,0x4807E7F2,
+		0x21F06A80,0x28304008,0x4804D105,0x42086AC0,0x2001D101,0x2000E7E6,0x0000E7E4,0xF0000FC0,
+		0x68004819,0xF844F000,0x68004818,0xF840F000,0x68004815,0xF84EF000,0x68004814,0xF84AF000,
+		0x0100207D,0xF826F000,0x480FE01D,0xF0006800,0x480EF839,0xF0006800,0x20C8F83D,0xF81AF000,
+		0x6800480A,0xF82EF000,0x68004807,0xF832F000,0xF0002064,0x2000F80F,0xBF00E002,0x1C40BF00,
+		0x42884903,0xE7E0DBF9,0x20000000,0x20000004,0x00001388,0xE005B501,0x1E409800,0x48039000,
+		0xFF0EF7FF,0x28009800,0xBD08D1F6,0x000003E7,0x22052101,0x23070712,0x18D2021B,0x50D10083,
+		0x00004770,0x40812101,0x60D14A01,0x00004770,0x50000500,0x40812101,0x60914A01,0x00004770,
+		0x50000500,0x00000308,0x20000000,0x0000000C,0x0000017C,0x00000012,0x00000013,0x00F42400,
+		0xFFFFFFFF,0xFFFFFFFF,0xFFFFFFFF};*/
+	
+//	//Blink with 50ms interval
+//static void blinkLED(){
+//    gpio_set_hid_led(GPIO_LED_ON);
+//    os_dly_wait(5);
+//    gpio_set_hid_led(GPIO_LED_OFF);
+//    os_dly_wait(5);
+//    gpio_set_hid_led(GPIO_LED_ON);
+//}
+
+
+
+////Erase NRF and blink every 50ms in the process
+//static void nrf_Emergency_Erase(){
+//    //make sure SWD is initialized
+//    if (!swd_init_debug()) {
+//		return;
+//	}
+//    
+//    blinkLED();    
+//    
+//    //Set NVMC->CONFIG on NRF to 2    
+//    if (!swd_write_ap(AP_TAR, 0x4001E000 + 0x504)) {
+//		return;
+//	}
+//    if (!swd_write_ap(AP_DRW, 2)) {
+//		return;
+//	}
+
+//    blinkLED();
+//    blinkLED();
+//   
+
+//    //Set NVMC->ERASEALL on NRF to 1 to start chip erase
+//    if (!swd_write_ap(AP_TAR, 0x4001E000 + 0x50C)) {
+//		return;
+//	}
+//    if (!swd_write_ap(AP_DRW, 1)) {
+//		return;
+//	}
+//    
+//    blinkLED();
+//    blinkLED();
+//    blinkLED();
+//    blinkLED();
+//    
+//    //Set NVMC->CONFIG on NRF to 0
+//    if (!swd_write_ap(AP_TAR, 0x4001E000 + 0x504)) {
+//		return;
+//	}
+//    if (!swd_write_ap(AP_DRW, 0)) {
+//		return;
+//	}
+//    
+//    blinkLED();
+//    blinkLED();
+
+//	//swd_set_target_state(RESET_PROGRAM);
+//	//target_flash_init(SystemCoreClock);
+//	//target_flash_program_page(0,(uint8_t *)nrfBlinkyApp,800);
+
+//}
+
+void target_before_init_debug(void) {
+    return;
+}
+
+uint8_t target_unlock_sequence(void) {
+    return 1;
+}
+
+uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size) {
+    return 0;
+}
+
+uint8_t target_set_state(TARGET_RESET_STATE state) {
+// THIS SHOULD BE IMPLEMENTED IN MAIN FOR ALL TARGETS
+//	uint32_t  count=0;
+//	//Check for 5 Second emergency erase routine
+//	while(0 == gpio_get_sw_reset()){
+//        os_dly_wait(1);
+//        count++;
+//        gpio_set_hid_led((gpio_led_state_t)(count>>4&1));//Blink every 160ms
+//        if(count>500){            
+//            nrf_Emergency_Erase();
+//            return swd_set_target_state(state);
+//        }
+//    }
+//    gpio_set_hid_led(GPIO_LED_ON);
+    return swd_set_target_state_sw(state);
+}
+
+
+//static __forceinline void     PIN_nRESET_OUT (uint32_t bit) {
+//	
+// /**There is no reset pin on the nRF51822, so we need to use a reset routine:
+//	Enable reset through the RESET register in the POWER peripheral. 
+//	Hold the SWDCLK and SWDIO/nRESET line low for a minimum of 100 µs. 
+//  */
+//  if (bit & 1) {
+//      PIOA->PIO_SODR = PIN_SWDIO;
+//      PIOA->PIO_MDER = PIN_SWDIO | PIN_SWCLK | PIN_nRESET;
+//	} else {
+//        swd_init_debug();
+//        //Set POWER->RESET on NRF to 1
+//        if(!swd_write_ap(AP_TAR, 0x40000000 + 0x544)){
+//            return;
+//        }
+//        
+//		if(!swd_write_ap(AP_DRW, 1)){
+//            return;
+//        }
+//        
+//        //Hold RESET and SWCLK low for a minimum of 100us
+//        PIOA->PIO_OER = PIN_SWDIO;
+//        PIOA->PIO_OER = PIN_SWCLK;     
+//        PIOA->PIO_CODR = PIN_SWDIO;
+//        PIOA->PIO_CODR = PIN_SWCLK;
+//        os_dly_wait(1);
+//	}
+//}
+
+
+void swd_set_target_reset(uint8_t asserted)
+{
+    if (asserted) {
+        swd_init_debug();
+        //Set POWER->RESET on NRF to 1
+        if(!swd_write_ap(AP_TAR, 0x40000000 + 0x544)) {
+            return;
+        }
+        
+		if(!swd_write_ap(AP_DRW, 1)){
+            return;
+        }
+        //Hold RESET and SWCLK low for a minimum of 100us
+        PIN_SWCLK_TCK_CLR();
+        PIN_SWDIO_TMS_CLR();
+        //os_dly_wait(1);
+    } else {
+        PIN_SWCLK_TCK_SET();
+        PIN_SWDIO_TMS_SET();
+    }
+}


### PR DESCRIPTION
- Add Switch Science mbed TY51822r3 target
- LPC11U35 interface refactor
  - Change SW_RESET_BUTTON port (it should also work with SWDAP since BL and ISP signal is shorted)
  - Remove unused functions and variables
  - gpio_get_sw_reset() now uses Port In register to read signal level which wrongly used W register
