### PR TITLE
Update readme with known windows flashing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ Look for an interesting feature or defect [under issues](https://github.com/mbed
 Information for setting up a development environment, running the tests or creating a release build [can be found in the developers guide.](docs/DEVELOPERS-GUIDE.md)
 
 ## Known Issues
-Drag-n-drop program or application flashing fails for the first time on Windows machine with failure message "File sent out of order by PC. Target might not be programmed correctly". Windows tries to create "System Volume Information" folder while sending program data, which results in out of order error. Solution to this issue is:
-* Disable creation of "System Volume Information" folder on [USB drives](http://www.thewindowsclub.com/prevent-system-volume-information-folder-usb).
+Drag-n-drop program or application flashing fails for the first time after firmware update on Windows machine with failure message "File sent out of order by PC. Target might not be programmed correctly". Windows tries to create "System Volume Information" folder while sending program data, which results in out of order error. Solution to this issue is:
+* Disable creation of "System Volume Information" folder on [USB drives](http://www.thewindowsclub.com/prevent-system-volume-information-folder-usb) and [disable Storage Service](https://www.veritas.com/support/en_US/article.000041497)
 * Re-try flashing once more.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ Look for an interesting feature or defect [under issues](https://github.com/mbed
 
 ## Develop
 Information for setting up a development environment, running the tests or creating a release build [can be found in the developers guide.](docs/DEVELOPERS-GUIDE.md)
+
+## Known Issues
+Drag-n-drop program or application flashing fails for the first time on Windows machine with failure message "File sent out of order by PC. Target might not be programmed correctly". Windows tries to create "System Volume Information" folder while sending program data, which results in out of order error. Solution to this issue is:
+* Disable creation of "System Volume Information" folder on [USB drives](http://www.thewindowsclub.com/prevent-system-volume-information-folder-usb).
+* Re-try flashing once more.


### PR DESCRIPTION
Drag and drop fails on Windows, for the first time after updating daplink firmware, and as a result spurious failures in CI were observed.
Root cause: Windows tries to create "System Volume Information" folder in between transferring the program data.