### PR TITLE
Disable interrupts when performing flash ops

### DIFF
--- a/source/hic_hal/atmel/sam3u2c/flash_hal_SAM3U.c
+++ b/source/hic_hal/atmel/sam3u2c/flash_hal_SAM3U.c
@@ -21,6 +21,7 @@
 
 //#include "flash_hal.h"        // FlashOS Structures       //TODO - uncomment
 #include "target_config.h"    // target_device
+#include "cortex_m.h"
 
 #define KEY_VALUE             (0x5A)
 #define FCMD_WP               (0x1)           // "Write page" command
@@ -146,10 +147,12 @@ uint32_t EraseChip(void)
     // Erase complete chip by erasing sector-by-sector
     Addr = target_device.flash_start;
 
+    cortex_int_state_t state = cortex_int_get_and_disable();
     do {
         _WritePage(Addr, (volatile uint32_t *)0, 1);
         Addr += (1 << 8);
     } while (Addr < target_device.flash_end);
+    cortex_int_restore(state);
 
     return (0);  // O.K.
 }
@@ -166,10 +169,12 @@ uint32_t EraseSector(uint32_t adr)
     //
     NumPagesLeft = 0x400 >> 8;                                         // SAM3U has 256 byte pages, DAPLink BTL/FW assumes 1 KB sectors
 
+    cortex_int_state_t state = cortex_int_get_and_disable();
     do {
         _WritePage(adr, (volatile uint32_t *)0, 1);
         adr += (1 << 8);
     } while (--NumPagesLeft);
+    cortex_int_restore(state);
 
     return (0);  // O.K.
 }
@@ -194,11 +199,13 @@ uint32_t ProgramPage(uint32_t adr, uint32_t sz, uint32_t *buf)
         return 1;
     }
 
+    cortex_int_state_t state = cortex_int_get_and_disable();
     do {
         _WritePage(adr, (volatile uint32_t *)temp_buf, 0);
         adr += (1 << 8);
         temp_buf += (1 << 8);
     } while (--NumPagesLeft);
+    cortex_int_restore(state);
 
     return (0);                                  // Finished without Errors
 }

--- a/source/hic_hal/freescale/iap/FlashPrg.c
+++ b/source/hic_hal/freescale/iap/FlashPrg.c
@@ -22,11 +22,13 @@
 #include "FlashOS.h"        // FlashOS Structures
 #include "fsl_flash.h"
 #include "string.h"
+#include "cortex_m.h"
 
 flash_config_t g_flash; //!< Storage for flash driver.
 
 uint32_t Init(uint32_t adr, uint32_t clk, uint32_t fnc)
 {
+    cortex_int_state_t state = cortex_int_get_and_disable();
 #if defined (WDOG)
     /* Write 0xC520 to the unlock register */
     WDOG->UNLOCK = 0xC520;
@@ -37,6 +39,7 @@ uint32_t Init(uint32_t adr, uint32_t clk, uint32_t fnc)
 #else
     SIM->COPC = 0x00u;
 #endif
+    cortex_int_restore(state);
 
     return (FLASH_Init(&g_flash) != kStatus_Success);
 }
@@ -97,11 +100,13 @@ uint32_t UnInit(uint32_t fnc)
  */
 uint32_t EraseChip(void)
 {
+    cortex_int_state_t state = cortex_int_get_and_disable();
     int status = FLASH_EraseAll(&g_flash, kFLASH_apiEraseKey);
     if (status == kStatus_Success)
     {
         status = FLASH_VerifyEraseAll(&g_flash, kFLASH_marginValueNormal);
     }
+    cortex_int_restore(state);
     return status;
 }
 
@@ -112,11 +117,13 @@ uint32_t EraseChip(void)
  */
 uint32_t EraseSector(uint32_t adr)
 {
+    cortex_int_state_t state = cortex_int_get_and_disable();
     int status = FLASH_Erase(&g_flash, adr, g_flash.PFlashSectorSize, kFLASH_apiEraseKey);
     if (status == kStatus_Success)
     {
         status = FLASH_VerifyErase(&g_flash, adr, g_flash.PFlashSectorSize, kFLASH_marginValueNormal);
     }
+    cortex_int_restore(state);
     return status;
 }
 
@@ -129,6 +136,7 @@ uint32_t EraseSector(uint32_t adr)
  */
 uint32_t ProgramPage(uint32_t adr, uint32_t sz, uint32_t *buf)
 {
+    cortex_int_state_t state = cortex_int_get_and_disable();
     int status = FLASH_Program(&g_flash, adr, buf, sz);
     if (status == kStatus_Success)
     {
@@ -137,6 +145,7 @@ uint32_t ProgramPage(uint32_t adr, uint32_t sz, uint32_t *buf)
                               buf, kFLASH_marginValueUser,
                               NULL, NULL);
     }
+    cortex_int_restore(state);
     return status;
 }
 


### PR DESCRIPTION
Update the atsam3u and kinetis flash drivers so they disable interrupts when erasing or programming flash. This prevents a crash from occurring if an interrupt occurs during flashing when the flash cannot be read.

This also fixes a watchdog reset on K20 interfaces which occurs when an interrupt interrupts the watchdog unlock sequence in the flash "Init" function.  The addition of this critical section prevents the watchdog operation from being interrupted.