### PR TITLE
Only update version file if it changes

### DIFF
--- a/tools/pre_build_script.bat
+++ b/tools/pre_build_script.bat
@@ -18,14 +18,20 @@
 
 @set TOOLS=..\..\..\tools
 @set DIR=..\..\..\source\daplink
-@REM  Create default version_git.h.  This is so the project 
-@REM  builds if python is not installed
-copy %DIR%\version_git_tmpl.txt %DIR%\version_git.h
-@if %errorlevel% neq 0 exit /B %errorlevel%
 
 @python --version 2> nul
-@if %errorlevel% neq 0 echo Error: python not in PATH. If you are manually building the project, make sure to launch uVision from the python venv && exit /B %errorlevel%
+@if %errorlevel% neq 0 goto nopython
 
-@REM  Run python script to delete default version_git.h and create the real one
+@REM  Run python script to create or update version_git.h
 python %TOOLS%\pre_build_script.py
 @if %errorlevel% neq 0 exit /B %errorlevel%
+
+@exit /B 0
+
+:nopython
+echo Error: python not in PATH. If you are manually building the project, make sure to launch uVision from the python venv
+@REM  Create default version_git.h.  This is so the project
+@REM  builds if python is not installed
+copy %DIR%\version_git_tmpl.txt %DIR%\version_git.h
+exit /B %errorlevel%
+

--- a/tools/pre_build_script.py
+++ b/tools/pre_build_script.py
@@ -58,14 +58,6 @@ GIT_VERSION_FILE_PATH = "../../../source/daplink/version_git.h"
 def pre_build():
     print "#> Pre-build script start"
 
-    # First thing to do is delete any existing generated files.
-    try:
-        os.remove(GIT_VERSION_FILE_PATH)
-        print "#> Old git version file removed"
-    except OSError:
-        print "#> No git version file to remove"
-        pass
-
     # Get the git SHA.
     print "#> Getting git SHA"
     try:
@@ -85,11 +77,19 @@ def pre_build():
         git_has_changes = 0
 
 
-    #Create the version file.
-    print "#> Creating new git version file"
-    version_file = open(GIT_VERSION_FILE_PATH, 'a')
-    version_file.write(VERSION_GIT_FILE_TEMPLATE % (git_sha, git_has_changes))
-    version_file.close()
+    # Create the version file. Only overwrite an existing file if it changes.
+    version_text = VERSION_GIT_FILE_TEMPLATE % (git_sha, git_has_changes)
+    try:
+        with open(GIT_VERSION_FILE_PATH, 'r') as version_file:
+            current_version_text = version_file.read()
+    except IOError:
+        current_version_text = ''
+    if version_text != current_version_text:
+        print "#> Writing git version file"
+        with open(GIT_VERSION_FILE_PATH, 'w+') as version_file:
+            version_file.write(version_text)
+    else:
+        print "#> Keeping git version file since it didn't need to change"
 
     print "#> Pre-build script completed"
 


### PR DESCRIPTION
This change is to prevent always rebuilding vfs_manager.c and vfs_user.c.

`pre_build_script.bat` only copies `version_git_tmpl.txt` if the call to `python --version` returns an error. `pre_build_script.py` no longer deletes `version_git.h`, and only overwrites it if the content would change.