### PR TITLE
Prevents concurrent access to the JTAG/SWD DAP.

### DIFF
--- a/source/daplink/cmsis-dap/DAP.h
+++ b/source/daplink/cmsis-dap/DAP.h
@@ -244,6 +244,10 @@ extern uint32_t DAP_ExecuteCommand       (const uint8_t *request, uint8_t *respo
 
 extern void     DAP_Setup (void);
 
+extern uint8_t	DAP_Lock_Verify	(void *param);
+extern uint8_t	DAP_Lock				(void *param);
+extern uint8_t	DAP_Unlock			(void *param);
+
 // Configurable delay for clock generation
 #ifndef DELAY_SLOW_CYCLES
 #define DELAY_SLOW_CYCLES       3U      // Number of cycles for one iteration

--- a/source/daplink/cmsis-dap/DAP_vendor.c
+++ b/source/daplink/cmsis-dap/DAP_vendor.c
@@ -49,6 +49,8 @@ file to the MDK-ARM project under the file group Configuration.
                  number of bytes in request (upper 16 bits)
 */
 uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
+	if (!DAP_Lock_Verify(0)) return 0;
+	
   uint32_t num = (1U << 16) | 1U;
 
   *response++ = *request;        // copy Command ID

--- a/source/daplink/error.c
+++ b/source/daplink/error.c
@@ -34,6 +34,8 @@ static const char *const error_message[] = {
     "An error has occurred",
     // ERROR_INTERNAL
     "An internal error has occurred",
+		// ERROR_BUSY
+		"Requested Resource Busy",
 
     /* VFS user errors */
 

--- a/source/daplink/error.h
+++ b/source/daplink/error.h
@@ -32,6 +32,7 @@ typedef enum {
     ERROR_SUCCESS = 0,
     ERROR_FAILURE,
     ERROR_INTERNAL,
+		ERROR_BUSY,
 
     /* VFS user errors */
     ERROR_ERROR_DURING_TRANSFER,

--- a/source/daplink/interface/dap_lock.c
+++ b/source/daplink/interface/dap_lock.c
@@ -1,0 +1,215 @@
+/**
+ * @file    dap_lock.c
+ * @brief   Implementation of swd_host lock in multithreaded environment.
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * Locking DAP prevents concurrent thread access to SWD/JTAG DAP operations.
+ * Lock may be assigned to Task (prevents concurrency) and to mark Operation.
+ * Task Lock is tied to OS and has precedence over user set Operation Lock.
+ * All underlying DAP/SWD/JTAG operations should be protected internally with
+ * provided lock verify mechanisms (TID based) that tells if DAP is available.
+ * By setting Operation Lock user also locks DAP for a given TID. No other TID
+ * can access DAP in that time, nor other Operation Lock can be set or clear,
+ * until ongoing Operation is unlocked from an originating owner thread/task. 
+ * Unlocking the Operation makes DAP again available for use by anyone.
+ * Functions return 1 for OK/GO/READY, 0 for ERROR/BUSY/FAIL.
+ * You need to initialize mutex by hand before any function can be called!
+ *  
+ */
+
+#include "swd_host.h"
+
+static OS_MUT _dap_lock_mutex;
+static OS_TID _dap_lock_tid;
+static dap_lock_operation_t _dap_lock_operation;
+
+/**
+ * You need to call this function first to initialize mutex.
+ */
+uint8_t dap_lock_mutex_init(void)
+{
+	rt_mut_init(&_dap_lock_mutex);
+	return 1;
+}
+
+/**
+ * Lock DAP for a given TID, with prior verification if applicable.
+ * @tid is the thread id that will get exclusive DAP access.
+ * @return 1 when TID has/gets the lock, 0 otherwise.
+ */
+uint8_t dap_lock_tid(OS_TID tid)
+{
+	uint8_t locked = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	if (dap_lock_verify_tid(tid))
+	{
+		_dap_lock_tid = tid;
+		locked = 1;
+	}
+	util_assert(locked);
+	os_mut_release(&_dap_lock_mutex);
+	return locked;
+}
+
+/**
+ * Lock DAP for a caller's thread. TID is obtained from the OS.
+ * @return 1 when TID has/gets the lock, 0 otherwise.
+ */
+uint8_t dap_lock_tid_self(void)
+{
+	uint8_t locked = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	locked = dap_lock_tid(os_tsk_self());
+	os_mut_release(&_dap_lock_mutex);
+	return locked;
+}
+
+/**
+ * Verify if given TID can access the DAP (free or already owned).
+ * @tid is the thread id that asks for exclusive DAP access.
+ * @return 1 when TID can access DAP, 0 otherwise.
+ */
+uint8_t dap_lock_verify_tid(OS_TID tid)
+{
+	uint8_t ready = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	// Check if given TID has already the port lock.
+	ready = (tid == _dap_lock_tid ? 1 : 0);
+	// Or port is free to use.
+	ready |= (0 == _dap_lock_tid ? 1 : 0);
+	os_mut_release(&_dap_lock_mutex);
+	return ready;
+}
+
+/**
+ * Verify if caller's thread can access the DAP (free or already owned).
+ * TID is obtained from the OS.
+ * @return 1 when caller's thread can access DAP, 0 otherwise.
+ */
+uint8_t dap_lock_verify_tid_self(void)
+{
+	uint8_t ready = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	ready = (dap_lock_verify_tid(os_tsk_self()));
+	os_mut_release(&_dap_lock_mutex);
+	return ready;
+}
+
+/**
+ * Mark DAP lock for a given Operation under caller's thread.
+ * Verification is first performed if lock can take place.
+ * @operation is the operation code to assign to DAP.
+ * @return 1 when operation is/can be assigned, 0 otherwise.
+ */
+uint8_t dap_lock_operation(dap_lock_operation_t operation)
+{
+	uint8_t locked = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	if (dap_lock_verify_operation(operation))
+	{
+		_dap_lock_operation = operation;
+		locked = 1;
+	}
+	util_assert(locked);
+	os_mut_release(&_dap_lock_mutex);
+	return locked;
+}
+
+/**
+ * Verify DAP against existing/possible operation assignment.
+ * @operation is the operation code to verify on DAP.
+ * @return 1 when operation is/can be assigned, 0 otherwise.
+ */
+uint8_t dap_lock_verify_operation(dap_lock_operation_t operation)
+{
+	uint8_t ready = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	// Check if operation already ongoing or port free.
+	ready = (operation == _dap_lock_operation ? 1 : 0);
+	ready |= ( DAP_LOCK_OPERATION_NONE == _dap_lock_operation ? 1 : 0);
+	// Also verify if TID can use the port.
+	ready &= dap_lock_verify_tid_self();
+	os_mut_release(&_dap_lock_mutex);
+	return ready;
+}
+
+/**
+ * Mark DAP as free to use, if called from thread that locked the port.
+ * @return 1 when DAP gets unlocked for use by anyone, 0 otherwise.
+ */
+uint8_t dap_unlock(void)
+{
+	uint8_t unlocked = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	if (dap_lock_verify_tid_self())
+	{
+		dap_unlock_force();
+		unlocked = 1;
+	}
+	os_mut_release(&_dap_lock_mutex);
+	util_assert(unlocked);
+	return unlocked;
+}
+
+/**
+ * Clear all DAP Locks with no verification.
+ */
+uint8_t dap_unlock_force(void)
+{
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	_dap_lock_tid = 0;
+	_dap_lock_operation = DAP_LOCK_OPERATION_NONE;
+	os_mut_release(&_dap_lock_mutex);
+	return 1;
+}
+
+/**
+ * Check and mark finished Operation on DAP.
+ * @operation is the finished Operation code.
+ * @return 1 when DAP gets unlocked, 0 otherwise.
+ */
+uint8_t dap_unlock_operation(dap_lock_operation_t operation)
+{
+	uint8_t unlocked = 0;
+	os_mut_wait(&_dap_lock_mutex, 0xFFFF);
+	if (dap_lock_verify_operation(operation))
+	{
+		unlocked = dap_unlock();
+	}
+	os_mut_release(&_dap_lock_mutex);
+	return unlocked;
+}
+
+//
+// Below are CMSIS-DAP handler wrappers specific to DAPLink.
+//
+uint8_t DAP_Lock_Verify (void *param)
+{
+	return dap_lock_verify_tid_self();
+}
+
+uint8_t DAP_Lock (void *param)
+{
+	return dap_lock_operation(DAP_LOCK_OPERATION_HID_DEBUG);
+}
+
+uint8_t DAP_Unlock (void *param)
+{
+	return dap_unlock_operation(DAP_LOCK_OPERATION_HID_DEBUG);
+}

--- a/source/daplink/interface/dap_lock.h
+++ b/source/daplink/interface/dap_lock.h
@@ -1,0 +1,54 @@
+/**
+ * @file    swd_host.h
+ * @brief   Host driver for accessing the DAP
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DAPLOCK_H
+#define DAPLOCK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum dap_lock_operation_t {
+	DAP_LOCK_OPERATION_NONE = 0,
+	DAP_LOCK_OPERATION_HIC_INIT,
+	DAP_LOCK_OPERATION_CDC_BREAK,
+	DAP_LOCK_OPERATION_HID_DEBUG,
+	DAP_LOCK_OPERATION_UMS_FLASH,
+} dap_lock_operation_t;
+
+uint8_t dap_lock_mutex_init(void);
+uint8_t dap_lock_tid(OS_TID tid);
+uint8_t dap_lock_tid_self(void);
+uint8_t dap_lock_verify_tid(OS_TID tid);
+uint8_t dap_lock_verify_tid_self(void);
+uint8_t dap_lock_operation(dap_lock_operation_t operation);
+uint8_t dap_lock_verify_operation(dap_lock_operation_t operation);
+uint8_t dap_unlock(void);
+uint8_t dap_unlock_force(void);
+uint8_t dap_unlock_operation(dap_lock_operation_t operation);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+#endif

--- a/source/daplink/interface/main.c
+++ b/source/daplink/interface/main.c
@@ -213,6 +213,9 @@ __task void main_task(void)
     uint8_t thread_started = 0;
     // button state
     main_reset_state_t main_reset_button_state = MAIN_RESET_RELEASED;
+    // Initialize DAP locks.
+    util_assert(dap_lock_mutex_init());
+	  util_assert(dap_lock_operation(DAP_LOCK_OPERATION_HIC_INIT));
     // Initialize settings - required for asserts to work
     config_init();
     // Update bootloader if it is out of date
@@ -225,7 +228,7 @@ __task void main_task(void)
     gpio_set_hid_led(GPIO_LED_OFF);
     gpio_set_cdc_led(GPIO_LED_OFF);
     gpio_set_msc_led(GPIO_LED_OFF);
-    // Initialize the DAP
+		// Initialize the DAP
     DAP_Setup();
     // do some init with the target before USB and files are configured
     prerun_board_config();
@@ -238,6 +241,8 @@ __task void main_task(void)
     usbd_connect(0);
     usb_state = USB_CONNECTING;
     usb_state_count = USB_CONNECT_DELAY;
+    // Unlock SWD Port after possible initial use.
+    util_assert(dap_unlock());
     // Start timer tasks
     os_tsk_create_user(timer_task_30mS, TIMER_TASK_30_PRIORITY, (void *)stk_timer_30_task, TIMER_TASK_30_STACK);
 

--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -107,6 +107,12 @@ static uint8_t swd_transfer_retry(uint32_t req, uint32_t *data)
 
 uint8_t swd_init(void)
 {
+	// Lock SWD Port for current TID, if possible.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
     //TODO - DAP_Setup puts GPIO pins in a hi-z state which can
     //       cause problems on re-init.  This needs to be investigated
     //       and fixed.
@@ -117,13 +123,26 @@ uint8_t swd_init(void)
 
 uint8_t swd_off(void)
 {
-    PORT_OFF();
+	// Unlock SWD Port by current TID, if possible.
+    if (!dap_lock_verify_tid_self())
+    {
+		util_assert(0);
+		return 0;
+    }
+	PORT_OFF();
     return 1;
 }
 
 // Read debug port register.
 uint8_t swd_read_dp(uint8_t adr, uint32_t *val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t tmp_in;
     uint8_t tmp_out[4];
     uint8_t ack;
@@ -145,6 +164,13 @@ uint8_t swd_read_dp(uint8_t adr, uint32_t *val)
 // Write debug port register
 uint8_t swd_write_dp(uint8_t adr, uint32_t val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t req;
     uint8_t data[4];
     uint8_t ack;
@@ -171,6 +197,13 @@ uint8_t swd_write_dp(uint8_t adr, uint32_t val)
 // Read access port register.
 uint8_t swd_read_ap(uint32_t adr, uint32_t *val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in, ack;
     uint8_t tmp_out[4];
     uint32_t tmp;
@@ -200,6 +233,13 @@ uint8_t swd_read_ap(uint32_t adr, uint32_t *val)
 // Write access port register
 uint8_t swd_write_ap(uint32_t adr, uint32_t val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t data[4];
     uint8_t req, ack;
     uint32_t apsel = adr & 0xff000000;
@@ -239,6 +279,13 @@ uint8_t swd_write_ap(uint32_t adr, uint32_t val)
 // size is in bytes.
 static uint8_t swd_write_block(uint32_t address, uint8_t *data, uint32_t size)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in[4], req;
     uint32_t size_in_words;
     uint32_t i, ack;
@@ -283,6 +330,13 @@ static uint8_t swd_write_block(uint32_t address, uint8_t *data, uint32_t size)
 // size is in bytes.
 static uint8_t swd_read_block(uint32_t address, uint8_t *data, uint32_t size)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in[4], req, ack;
     uint32_t size_in_words;
     uint32_t i;
@@ -330,6 +384,13 @@ static uint8_t swd_read_block(uint32_t address, uint8_t *data, uint32_t size)
 // Read target memory.
 static uint8_t swd_read_data(uint32_t addr, uint32_t *val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in[4];
     uint8_t tmp_out[4];
     uint8_t req, ack;
@@ -367,6 +428,13 @@ static uint8_t swd_read_data(uint32_t addr, uint32_t *val)
 // Write target memory.
 static uint8_t swd_write_data(uint32_t address, uint32_t data)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in[4];
     uint8_t req, ack;
     // put addr in TAR register
@@ -394,6 +462,13 @@ static uint8_t swd_write_data(uint32_t address, uint32_t data)
 // Read 32-bit word from target memory.
 static uint8_t swd_read_word(uint32_t addr, uint32_t *val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     if (!swd_write_ap(AP_CSW, CSW_VALUE | CSW_SIZE32)) {
         return 0;
     }
@@ -408,6 +483,13 @@ static uint8_t swd_read_word(uint32_t addr, uint32_t *val)
 // Write 32-bit word to target memory.
 static uint8_t swd_write_word(uint32_t addr, uint32_t val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     if (!swd_write_ap(AP_CSW, CSW_VALUE | CSW_SIZE32)) {
         return 0;
     }
@@ -422,6 +504,13 @@ static uint8_t swd_write_word(uint32_t addr, uint32_t val)
 // Read 8-bit byte from target memory.
 static uint8_t swd_read_byte(uint32_t addr, uint8_t *val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t tmp;
 
     if (!swd_write_ap(AP_CSW, CSW_VALUE | CSW_SIZE8)) {
@@ -439,6 +528,13 @@ static uint8_t swd_read_byte(uint32_t addr, uint8_t *val)
 // Write 8-bit byte to target memory.
 static uint8_t swd_write_byte(uint32_t addr, uint8_t val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t tmp;
 
     if (!swd_write_ap(AP_CSW, CSW_VALUE | CSW_SIZE8)) {
@@ -458,6 +554,13 @@ static uint8_t swd_write_byte(uint32_t addr, uint8_t val)
 // size is in bytes.
 uint8_t swd_read_memory(uint32_t address, uint8_t *data, uint32_t size)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t n;
 
     // Read bytes until word aligned
@@ -507,6 +610,13 @@ uint8_t swd_read_memory(uint32_t address, uint8_t *data, uint32_t size)
 // size is in bytes.
 uint8_t swd_write_memory(uint32_t address, uint8_t *data, uint32_t size)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t n = 0;
 
     // Write bytes until word aligned
@@ -555,6 +665,13 @@ uint8_t swd_write_memory(uint32_t address, uint8_t *data, uint32_t size)
 // Execute system call.
 static uint8_t swd_write_debug_state(DEBUG_STATE *state)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t i, status;
 
     if (!swd_write_dp(DP_SELECT, 0)) {
@@ -603,6 +720,13 @@ static uint8_t swd_write_debug_state(DEBUG_STATE *state)
 
 static uint8_t swd_read_core_register(uint32_t n, uint32_t *val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     int i = 0, timeout = 100;
 
     if (!swd_write_word(DCRSR, n)) {
@@ -633,6 +757,13 @@ static uint8_t swd_read_core_register(uint32_t n, uint32_t *val)
 
 static uint8_t swd_write_core_register(uint32_t n, uint32_t val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     int i = 0, timeout = 100;
 
     if (!swd_write_word(DCRDR, val)) {
@@ -659,6 +790,13 @@ static uint8_t swd_write_core_register(uint32_t n, uint32_t val)
 
 static uint8_t swd_wait_until_halted(void)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     // Wait for target to stop
     uint32_t val, i, timeout = MAX_TIMEOUT;
 
@@ -677,6 +815,13 @@ static uint8_t swd_wait_until_halted(void)
 
 uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     DEBUG_STATE state = {{0}, 0};
     // Call flash algorithm function on target and wait for result.
     state.r[0]     = arg1;                   // R0: Argument 1
@@ -712,6 +857,13 @@ uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t e
 // SWD Reset
 static uint8_t swd_reset(void)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in[8];
     uint8_t i = 0;
 
@@ -726,6 +878,13 @@ static uint8_t swd_reset(void)
 // SWD Switch
 static uint8_t swd_switch(uint16_t val)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in[2];
     tmp_in[0] = val & 0xff;
     tmp_in[1] = (val >> 8) & 0xff;
@@ -736,6 +895,13 @@ static uint8_t swd_switch(uint16_t val)
 // SWD Read ID
 static uint8_t swd_read_idcode(uint32_t *id)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint8_t tmp_in[1];
     uint8_t tmp_out[4];
     tmp_in[0] = 0x00;
@@ -752,6 +918,13 @@ static uint8_t swd_read_idcode(uint32_t *id)
 
 static uint8_t JTAG2SWD()
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t tmp = 0;
 
     if (!swd_reset()) {
@@ -775,6 +948,13 @@ static uint8_t JTAG2SWD()
 
 uint8_t swd_init_debug(void)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t tmp = 0;
     int i = 0;
     int timeout = 100;
@@ -837,11 +1017,25 @@ uint8_t swd_init_debug(void)
 
 __attribute__((weak)) void swd_set_target_reset(uint8_t asserted)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return;
+	}
+
     (asserted) ? PIN_nRESET_OUT(0) : PIN_nRESET_OUT(1);
 }
 
 uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t val;
     swd_init();
 
@@ -939,6 +1133,13 @@ uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
 
 uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state)
 {
+	// Verify DAP Lock against our TID.
+	if (!dap_lock_verify_tid_self())
+	{
+		util_assert(0);
+		return 0;
+	}
+
     uint32_t val;
     swd_init();
 

--- a/source/daplink/interface/swd_host.h
+++ b/source/daplink/interface/swd_host.h
@@ -22,8 +22,12 @@
 #ifndef SWDHOST_CM_H
 #define SWDHOST_CM_H
 
+#include "util.h"
+#include "tasks.h"
+#include "RTL.h"
 #include "flash_blob.h"
 #include "target_reset.h"
+#include "dap_lock.h"
 #ifdef TARGET_MCU_CORTEX_A
 #include "debug_ca.h"
 #else

--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -54,6 +54,13 @@ const flash_intf_t *const flash_intf_target = &flash_intf;
 
 static error_t target_flash_init()
 {
+		// Verify the Lock of the DAP.
+		if (!dap_lock_operation(DAP_LOCK_OPERATION_UMS_FLASH))
+		{
+			util_assert(0);
+			return ERROR_BUSY;
+		}
+
     const program_target_t *const flash = target_device.flash_algo;
 
     if (0 == target_set_state(RESET_PROGRAM)) {
@@ -74,6 +81,13 @@ static error_t target_flash_init()
 
 static error_t target_flash_uninit(void)
 {
+		// Verify the Unlock of the DAP.
+		if (!dap_unlock_operation(DAP_LOCK_OPERATION_UMS_FLASH))
+		{
+			util_assert(0);
+			return ERROR_BUSY;
+		}
+		
     // Resume the target if configured to do so
     if (config_get_auto_rst()) {
         target_set_state(RESET_RUN);

--- a/source/usb/cdc/usbd_core_cdc.c
+++ b/source/usb/cdc/usbd_core_cdc.c
@@ -24,6 +24,7 @@
 #include "RTL.h"
 #include "rl_usb.h"
 #include "usb_for_lib.h"
+#include "swd_host.h"
 
 
 /*
@@ -93,9 +94,18 @@ __weak BOOL USBD_EndPoint0_Setup_CDC_ReqToIF(void)
                 break;
 
             case CDC_SEND_BREAK:
+								if (!dap_lock_operation(DAP_LOCK_OPERATION_CDC_BREAK))
+								{
+									util_assert(0);
+									return(__FALSE);
+								}
                 if (USBD_CDC_ACM_SendBreak(USBD_SetupPacket.wValue)) {
                     USBD_StatusInStage();                              /* send Acknowledge */
-                    return (__TRUE);
+										if (!dap_unlock_operation(DAP_LOCK_OPERATION_CDC_BREAK)) {
+											util_assert(0);
+											return(__FALSE);
+										}
+										return (__TRUE);
                 }
 
                 break;


### PR DESCRIPTION
This solves concurrent access to Target's DAP over SWD (possibly also JTAG) from functions like HID Debug / CDC Reset / UMS Flashing.. with a minimal possible set of code and changes I could work out. Minor impact on CMSIS-DAP is presented with an example of application, when accepted can be extended and merged into upstream project..

Locking DAP prevents concurrent thread access to SWD/JTAG DAP operations. Lock may be assigned to Task (prevents concurrency) and to mark Operation. Task Lock is tied to OS and has precedence over user set Operation Lock. All underlying DAP/SWD/JTAG operations should be protected internally with provided lock verify mechanisms (TID based) that tells if DAP is available. By setting Operation Lock user also locks DAP for a given TID. No other TID can access DAP in that time, nor other Operation Lock can be set or clear, until ongoing Operation is unlocked from an originating owner thread/task. Unlocking the Operation makes DAP again available for use by anyone. Functions return 1 for OK/GO/READY, 0 for ERROR/BUSY/FAIL. User needs to initialize mutex by hand before any function can be called.

To demonstrate that lock is working, when accessing DAP that is busy you should get an assert from dap_lock.c or FAIL.TXT error with "Requested Resource Busy" (i.e. when reset or flashing occurs during pyOCD session).. this may be removed if not really necessary to inform user that way but comes handy for solution assessment..

Feedback testing and comments are welcome :-)

Signed-off-by: CeDeROM Tomasz CEDRO <tomek@cedro.info>