### PR TITLE
Simplify reset button handling

### DIFF
--- a/source/daplink/bootloader/main.c
+++ b/source/daplink/bootloader/main.c
@@ -236,7 +236,7 @@ int main(void)
 
     // check for invalid app image or rst button press. Should be checksum or CRC but NVIC validation is better than nothing.
     // If the interface has set the hold in bootloader setting don't jump to app
-    if (gpio_get_sw_reset() && validate_bin_nvic((uint8_t *)target_device.flash_start) && !config_ram_get_initial_hold_in_bl()) {
+    if (!gpio_get_reset_btn() && validate_bin_nvic((uint8_t *)target_device.flash_start) && !config_ram_get_initial_hold_in_bl()) {
         // change to the new vector table
         SCB->VTOR = target_device.flash_start;
         // modify stack pointer and start app

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -121,7 +121,7 @@ void vfs_user_file_change_handler(const vfs_filename_t filename, vfs_file_change
 {
     // Allow settings to be changed if automation mode is
     // enabled or if the user is holding the reset button
-    bool btn_pressed = !gpio_get_sw_reset();
+    bool btn_pressed = gpio_get_reset_btn();
 
     if (!btn_pressed && !config_get_automation_allowed()) {
         return;

--- a/source/daplink/interface/main.h
+++ b/source/daplink/interface/main.h
@@ -45,12 +45,6 @@ typedef enum main_usb_connect {
     USB_DISCONNECTING
 } main_usb_connect_t;
 
-typedef enum main_reset_state {
-    MAIN_RESET_PRESSED = 0,
-    MAIN_RESET_RELEASED,
-    MAIN_RESET_TARGET
-} main_reset_state_t;
-
 void main_reset_target(uint8_t send_unique_id);
 void main_usb_set_test_mode(bool enabled);
 void main_usb_configure_event(void);

--- a/source/hic_hal/atmel/sam3u2c/gpio.c
+++ b/source/hic_hal/atmel/sam3u2c/gpio.c
@@ -102,9 +102,14 @@ void PIOA_IRQHandler(void)
     }
 }
 
-uint8_t gpio_get_sw_reset()
+uint8_t gpio_get_reset_btn_no_fwrd(void)
 {
-    return (PIN_RESET_IN_FWRD_PORT->PIO_PDSR & PIN_RESET_IN_FWRD) != 0;
+    return 0;
+}
+
+uint8_t gpio_get_reset_btn_fwrd()
+{
+    return (PIN_RESET_IN_FWRD_PORT->PIO_PDSR & PIN_RESET_IN_FWRD) == 0;
 }
 
 void gpio_set_board_power(bool powerEnabled)

--- a/source/hic_hal/freescale/k20dx/gpio.c
+++ b/source/hic_hal/freescale/k20dx/gpio.c
@@ -104,18 +104,13 @@ void gpio_set_msc_led(gpio_led_state_t state)
     gpio_set_hid_led(state);
 }
 
-uint8_t gpio_get_sw_reset(void)
+uint8_t gpio_get_reset_btn_no_fwrd(void)
 {
-    return (PIN_nRESET_GPIO->PDIR & PIN_nRESET) ? 1 : 0;
+    return (PIN_nRESET_GPIO->PDIR & PIN_nRESET) ? 0 : 1;
+
 }
 
-uint8_t GPIOGetButtonState(void)
+uint8_t gpio_get_reset_btn_fwrd(void)
 {
     return 0;
-}
-
-void target_forward_reset(bool assert_reset)
-{
-    // Do nothing - reset button is already tied to the target
-    //              reset pin on k20dx interface hardware
 }

--- a/source/hic_hal/freescale/kl26z/gpio.c
+++ b/source/hic_hal/freescale/kl26z/gpio.c
@@ -78,9 +78,14 @@ void gpio_set_msc_led(gpio_led_state_t state)
     (GPIO_LED_ON == state) ? (PIN_MSC_LED_GPIO->PCOR = PIN_MSC_LED) : (PIN_MSC_LED_GPIO->PSOR = PIN_MSC_LED);
 }
 
-uint8_t gpio_get_sw_reset(void)
+uint8_t gpio_get_reset_btn_no_fwrd(void)
 {
-    return (PIN_SW_RESET_GPIO->PDIR & PIN_SW_RESET) ? 1 : 0;
+    return 0;
+}
+
+uint8_t gpio_get_reset_btn_fwrd(void)
+{
+    return (PIN_SW_RESET_GPIO->PDIR & PIN_SW_RESET) ? 0 : 1;
 }
 
 void gpio_set_board_power(bool powerEnabled)

--- a/source/hic_hal/gpio.h
+++ b/source/hic_hal/gpio.h
@@ -39,7 +39,13 @@ void gpio_set_board_power(bool powerEnabled);
 void gpio_set_hid_led(gpio_led_state_t state);
 void gpio_set_cdc_led(gpio_led_state_t state);
 void gpio_set_msc_led(gpio_led_state_t state);
-uint8_t gpio_get_sw_reset(void);
+uint8_t gpio_get_reset_btn_no_fwrd(void);
+uint8_t gpio_get_reset_btn_fwrd(void);
+
+static inline uint8_t gpio_get_reset_btn(void)
+{
+    return gpio_get_reset_btn_no_fwrd() || gpio_get_reset_btn_fwrd();
+}
 
 #ifdef __cplusplus
 }

--- a/source/hic_hal/nxp/lpc4322/gpio.c
+++ b/source/hic_hal/nxp/lpc4322/gpio.c
@@ -114,14 +114,14 @@ void gpio_set_isp_pin(uint8_t state)
     }
 }
 
-uint8_t gpio_get_sw_reset(void)
+uint8_t gpio_get_reset_btn_no_fwrd(void)
 {
-    return LPC_GPIO_PORT->W[PORT_nRESET * 32 + PIN_nRESET_IN_BIT] ? 1 : 0;
+    return LPC_GPIO_PORT->W[PORT_nRESET * 32 + PIN_nRESET_IN_BIT] ? 0 : 1;
 }
 
-void target_forward_reset(bool assert_reset)
+uint8_t gpio_get_reset_btn_fwrd(void)
 {
-    // Do nothing - reset is forwarded in gpio_get_sw_reset
+    return 0;
 }
 
 void gpio_set_board_power(bool powerEnabled)

--- a/source/hic_hal/target_reset.h
+++ b/source/hic_hal/target_reset.h
@@ -41,7 +41,6 @@ void target_before_init_debug(void);
 uint8_t target_unlock_sequence(void);
 uint8_t target_set_state(TARGET_RESET_STATE state);
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size);
-void target_forward_reset(bool assert_reset);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Rather than handling forwarded reset in on vendor specific code, instead handle this at a common layer. To do this, this patch adds the functions gpio_get_reset_btn_no_fwrd() and gpio_get_reset_btn_fwrd() which are far easier to implement.