### PR TITLE
Fix reset-run before reset-flash.

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -859,11 +859,6 @@ uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
             break;
 
         case RESET_PROGRAM:
-            swd_set_target_reset(1);
-            os_dly_wait(2);
-            swd_set_target_reset(0);
-            os_dly_wait(2);
-
             if (!swd_init_debug()) {
                 return 0;
             }


### PR DESCRIPTION
Remove first hardware reset sequence that caused some issues on K64F while flashing new firmware while old was already starting up.

Signed-off-by: CeDeROM Tomasz CEDRO <tomek@cedro.info>