### PR TITLE
CI Fixes

### DIFF
--- a/test/daplink_board.py
+++ b/test/daplink_board.py
@@ -218,7 +218,7 @@ class DaplinkBoard(object):
         self._assert = None
         self._check_fs_on_remount = False
         self._manage_assert = False
-        self._update_board_info()
+        self.update_board_info()
 
     def __str__(self):
         return "Name=%s Unique ID=%s" % (self.name, self.get_unique_id())
@@ -491,13 +491,13 @@ class DaplinkBoard(object):
         test_info.info("unmount took %s s" % (stop - start))
         start = time.time()
         while True:
-            if self._update_board_info(False):
+            if self.update_board_info(False):
                 if os.path.isdir(self.mount_point):
                     # Information returned by mbed-ls could be old.
                     # Only break from the loop if the second call to
                     # mbed-ls returns the same mount point.
                     tmp_mount = self.mount_point
-                    if self._update_board_info(False):
+                    if self.update_board_info(False):
                         if tmp_mount == self.mount_point:
                             break
             if elapsed > wait_time:
@@ -525,7 +525,7 @@ class DaplinkBoard(object):
                                       (self._assert.line, self._assert.file))
                 self.clear_assert()
 
-    def _update_board_info(self, exptn_on_fail=True):
+    def update_board_info(self, exptn_on_fail=True):
         """Update board info
 
         Update all board information variables that could

--- a/test/msd_test.py
+++ b/test/msd_test.py
@@ -158,6 +158,8 @@ class MassStorageTester(object):
                 self._run(test_info)
             except IOError:
                 time.sleep(self.DELAY_BEFORE_RETRY_S)
+                # Update board info since a remount could have occurred
+                self.board.update_board_info()
                 continue
             self.parent_test.attach_subtest(test_info)
             break

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -37,12 +37,14 @@ class TestInfo(object):
         FAILURE: "Failure: %s",
     }
 
-    def __init__(self, name):
+    def __init__(self, name, init_print=True):
         self._all = []
         self.failures = 0
         self.warnings = 0
         self.infos = 0
         self.name = name
+        if init_print:
+            self._print_msg("SubTest: " + name)
 
     def failure(self, msg):
         assert isinstance(msg, six.string_types)
@@ -159,7 +161,7 @@ class TestInfo(object):
     def _add_entry(self, entry_type, msg):
         if entry_type is self.SUBTEST:
             assert isinstance(msg, TestInfo)
-            self._print_msg("SubTest: " + msg.get_name())
+            # Test name printed in constructor
         else:
             assert isinstance(msg, six.string_types)
             self._print_msg(msg)
@@ -173,7 +175,7 @@ class TestInfo(object):
 class TestInfoStub(TestInfo):
 
     def __init__(self):
-        super(TestInfoStub, self).__init__('stub test')
+        super(TestInfoStub, self).__init__('stub test', False)
 
     def create_subtest(self, name):
         assert isinstance(name, six.string_types)


### PR DESCRIPTION
Handle transient errors more robustly by update board info when retrying a test. Also fix a bug causing test output to show up in the wrong order.