### PR TITLE
Cortex-M target reset unify

### DIFF
--- a/source/daplink/interface/swd_host.h
+++ b/source/daplink/interface/swd_host.h
@@ -37,6 +37,7 @@ extern "C" {
 uint8_t swd_init(void);
 uint8_t swd_off(void);
 uint8_t swd_init_debug(void);
+uint8_t swd_debug_deinit(void);
 uint8_t swd_read_dp(uint8_t adr, uint32_t *val);
 uint8_t swd_write_dp(uint8_t adr, uint32_t val);
 uint8_t swd_read_ap(uint32_t adr, uint32_t *val);
@@ -44,9 +45,21 @@ uint8_t swd_write_ap(uint32_t adr, uint32_t val);
 uint8_t swd_read_memory(uint32_t address, uint8_t *data, uint32_t size);
 uint8_t swd_write_memory(uint32_t address, uint8_t *data, uint32_t size);
 uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4);
-void swd_set_target_reset(uint8_t asserted);
-uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state);
-uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state);
+uint8_t swd_set_target_reset(uint8_t asserted);
+
+static uint8_t target_debug_enable(void);
+static uint8_t target_debug_halt(void);
+static uint8_t target_debug_halt_on_reset_enable(void);
+static uint8_t target_debug_halt_on_reset_disable(void);
+static uint8_t target_debug_halt_check(void);
+static uint8_t target_reset_sw(void);
+static uint8_t target_reset_hw(void);
+static uint8_t target_reset_hw_assert(uint8_t asserted);
+
+uint8_t target_quirk_reset_pre_program(void *param);
+uint8_t target_quirk_reset_post_program(void *param);
+uint8_t target_quirk_reset_pre_run(void *param);
+uint8_t target_quirk_reset_post_run(void *param);
 
 #ifdef __cplusplus
 }

--- a/source/daplink/interface/swd_host_ca.c
+++ b/source/daplink/interface/swd_host_ca.c
@@ -3,7 +3,7 @@
  * @brief   Implementation of swd_host.h
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2018, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -777,9 +777,10 @@ uint8_t swd_uninit_debug(void)
     return 1;
 }
 
-__attribute__((weak)) void swd_set_target_reset(uint8_t asserted)
+__attribute__((weak)) uint8_t swd_set_target_reset(uint8_t asserted)
 {
     (asserted) ? PIN_nRESET_OUT(0) : PIN_nRESET_OUT(1);
+    return 1;
 }
 
 uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
@@ -865,6 +866,7 @@ uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
     return 1;
 }
 
+// NOTE: This function does not work on Reneas R7S Cortex-A Target.
 uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state)
 {
     uint32_t val;
@@ -949,6 +951,19 @@ uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state)
     }
 
     return 1;
+}
+
+// TODO: Align this code with Cortex-M when deidcated Target code is ready.
+uint8_t target_set_state(TARGET_RESET_STATE state)
+{
+    uint8_t res;
+    // This kind of fallback causes UMS flashing to fail on GR-PEACH!
+    // Reset works with HW/SW but RESET_HALT works only for HW.
+    //res = swd_set_target_state_sw(state);
+    //if (!res) {
+        res = swd_set_target_state_hw(state);
+    //}
+    return res;
 }
 
 #endif

--- a/source/hic_hal/target_config.h
+++ b/source/hic_hal/target_config.h
@@ -40,6 +40,15 @@ extern "C" {
 // This can vary from target to target and should be in the structure or flash blob
 #define TARGET_AUTO_INCREMENT_PAGE_SIZE    (1024)
 
+/* TARGET RESET RELATED DEFINES */
+#define TARGET_DELAY_RESET  1       // How long do we wait after reset.
+#define TARGET_DELAY_RETRY  100     // How long do we wait with retries.
+enum TARGET_RESET_TYPES {           // Enumerate available reset types.
+    TARGET_RESET_NONE=0,            // No reset is also an option.
+    TARGET_RESET_HARDWARE=1,        // Hardware reset using GPIO.
+    TARGET_RESET_SOFTWARE=2         // Software reset using AIRCR.
+};
+
 /**
  @struct target_cfg_t
  @brief  The firmware configuration struct has unique about the chip its running on.

--- a/source/hic_hal/target_reset.h
+++ b/source/hic_hal/target_reset.h
@@ -30,11 +30,11 @@ extern "C" {
 #endif
 
 typedef enum {
-    RESET_HOLD,              // Hold target in reset
+    RESET_HOLD,              // Hold target under reset asserted. TODO: Reset-Halt?
     RESET_PROGRAM,           // Reset target and setup for flash programming.
     RESET_RUN,               // Reset target and run normally
     NO_DEBUG,                // Disable debug on running target
-    DEBUG                    // Enable debug on running target
+    DEBUG,                   // Enable debug on running target
 } TARGET_RESET_STATE;
 
 void target_before_init_debug(void);

--- a/source/target/freescale/target_reset_Kseries.c
+++ b/source/target/freescale/target_reset_Kseries.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the Kinetis K series
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -30,7 +30,6 @@
 
 void target_before_init_debug(void)
 {
-    swd_set_target_reset(1);
 }
 
 void prerun_target_config(void)
@@ -55,6 +54,12 @@ void board_init(void)
 {
 }
 
+/**
+ * Unlock Sequence clears out the Security Bits and Flash Memory.
+ * NOTE: This leaves Hardware Reset line asserted on exit until halt!
+ * NOTE: During the unlock sequence the hardware reset must be asserted to
+ * ensure device code cannot execute / interfere with the unlocking procedure.
+ */
 uint8_t target_unlock_sequence(void)
 {
     uint32_t val;
@@ -150,7 +155,3 @@ uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)
     return 0;
 }
 
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_hw(state);
-}

--- a/source/target/freescale/target_reset_Lseries.c
+++ b/source/target/freescale/target_reset_Lseries.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the Kinetis L series
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -136,7 +136,3 @@ uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)
     return 0;
 }
 
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_hw(state);
-}

--- a/source/target/nordic/target_reset.c
+++ b/source/target/nordic/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the nrf51
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -38,12 +38,8 @@ uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)
     return 0;
 }
 
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_sw(state);
-}
-
-void swd_set_target_reset(uint8_t asserted)
+// TODO: REMOVE THAT FUNCTION AFTER GLOBAL WAS INTRODUCED UNWEAK, VERIFY!
+void nrf_swd_set_target_reset(uint8_t asserted)
 {
     if (asserted) {
         swd_init_debug();

--- a/source/target/nordic/target_reset_nrf5x_sam3u2c.c
+++ b/source/target/nordic/target_reset_nrf5x_sam3u2c.c
@@ -24,27 +24,26 @@
 #include "DAP_config.h"
 #include "info.h"
 
+// For nRF chips CxxxPWRUPREQ is required, which is part of swd_init_debug().
 void target_before_init_debug(void)
 {
     return;
 }
 
+// TODO: Memory unlock routines can be added here for locked chips.
 uint8_t target_unlock_sequence(void)
 {
     return 1;
 }
 
+// TODO: Memory lock routines can be added here to lock the chip.
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)
 {
     return 0;
 }
 
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_sw(state);
-}
-
-void swd_set_target_reset(uint8_t asserted)
+// TODO: Take the debug disable quirk from here..
+void nrf_swd_set_target_reset(uint8_t asserted)
 {
     const char *board_id;
     board_id = info_get_board_id();

--- a/source/target/nxp/lpc4088/target_reset.c
+++ b/source/target/nxp/lpc4088/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the lpc4088
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -59,22 +59,22 @@ uint8_t target_unlock_sequence(void)
     return 1;
 }
 
-uint8_t target_set_state(TARGET_RESET_STATE state)
+uint8_t target_quirk_reset_pre_program(void *param)
 {
-    //return swd_set_target_state_hw(state);
-    uint8_t res;
-    if (state == RESET_PROGRAM)
-    {
-        gpio_set_isp_pin(0);
-        res = swd_set_target_state_hw(state);
-        gpio_set_isp_pin(1);
-    }
-    else
-    {
-        gpio_set_isp_pin(1);
-        res = swd_set_target_state_hw(state);
-    }
-    return res;
+    gpio_set_isp_pin(0);
+    return 1;
+}
+
+uint8_t target_quirk_reset_post_program(void *param)
+{
+    gpio_set_isp_pin(1);
+    return 1;
+}
+
+uint8_t target_quirk_reset_pre_run(void *param)
+{
+    gpio_set_isp_pin(1);
+    return 1;
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)

--- a/source/target/nxp/target_reset.c
+++ b/source/target/nxp/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the lpc812
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -30,11 +30,6 @@ void target_before_init_debug(void)
 uint8_t target_unlock_sequence(void)
 {
     return 1;
-}
-
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_hw(state);
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)

--- a/source/target/onsemi/ncs36510/target_reset.c
+++ b/source/target/onsemi/ncs36510/target_reset.c
@@ -1,5 +1,5 @@
 /* CMSIS-DAP Interface Firmware
- * Copyright (c) 2009-2013 ARM Limited
+ * Copyright (c) 2009-2017 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,6 @@ void target_before_init_debug(void) {
 
 uint8_t target_unlock_sequence(void) {
     return 1;
-}
-
-uint8_t target_set_state(TARGET_RESET_STATE state) {
-	/* sw reset preferred because hardware (pin) reset also resets debug logic */
-  return swd_set_target_state_sw(state); 
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size) {

--- a/source/target/renesas/target_reset.c
+++ b/source/target/renesas/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the rza1h
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -30,11 +30,6 @@ void target_before_init_debug(void)
 uint8_t target_unlock_sequence(void)
 {
     return 1;
-}
-
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_hw(state);
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)

--- a/source/target/siliconlabs/target_reset.c
+++ b/source/target/siliconlabs/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the efm32gg
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -30,11 +30,6 @@ void target_before_init_debug(void)
 uint8_t target_unlock_sequence(void)
 {
     return 1;
-}
-
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_sw(state);
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)

--- a/source/target/st/nz32_sc151/target_reset.c
+++ b/source/target/st/nz32_sc151/target_reset.c
@@ -32,11 +32,6 @@ uint8_t target_unlock_sequence(void)
     return 1;
 }
 
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_hw(state);
-}
-
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)
 {
     return 0;

--- a/source/target/st/target_reset.c
+++ b/source/target/st/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the stm32f407
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -37,7 +37,3 @@ uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)
     return 0;
 }
 
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_hw(state);
-}

--- a/source/target/st/xDot-L151/target_reset.c
+++ b/source/target/st/xDot-L151/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the stm32l151
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -30,11 +30,6 @@ void target_before_init_debug(void)
 uint8_t target_unlock_sequence(void)
 {
     return 1;
-}
-
-uint8_t target_set_state(TARGET_RESET_STATE state)
-{
-    return swd_set_target_state_hw(state);
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)

--- a/source/target/toshiba/target_reset.c
+++ b/source/target/toshiba/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the lpc812
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -23,10 +23,6 @@
 #include "target_reset.h"
 #include "swd_host.h"
 
-__attribute__((weak)) void target_set_state_by_board(TARGET_RESET_STATE state)
-{
-}
-
 void target_before_init_debug(void) {
     swd_set_target_reset(1);
     os_dly_wait(2);
@@ -37,11 +33,6 @@ void target_before_init_debug(void) {
 
 uint8_t target_unlock_sequence(void) {
     return 1;
-}
-
-uint8_t target_set_state(TARGET_RESET_STATE state) {
-    target_set_state_by_board(state);
-    return swd_set_target_state_sw(state);
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)

--- a/source/target/wiznet/target_reset.c
+++ b/source/target/wiznet/target_reset.c
@@ -3,7 +3,7 @@
  * @brief   Target reset for the W7500 
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -23,54 +23,12 @@
 #include "target_reset.h"
 #include "swd_host.h"
 
-__attribute__((weak)) void target_set_state_by_board(TARGET_RESET_STATE state)
-{
-    if( state == RESET_PROGRAM )
-    {
-        do
-        {
-            swd_set_target_reset(1);
-            os_dly_wait(2);
-
-            swd_set_target_reset(0);
-            os_dly_wait(2);
-        } while(!swd_init_debug());
-    }
-}
-
 void target_before_init_debug(void) {
-    //swd_set_target_state_hw(RESET_HOLD);
     return;
 }
 
 uint8_t target_unlock_sequence(void) {
     return 1;
-}
-
-uint8_t target_set_state(TARGET_RESET_STATE state) {
-    uint8_t status;
-    
-    target_set_state_by_board(state);
-    
-    if( state == RESET_RUN )
-    {
-        do
-        {
-            swd_set_target_reset(1);
-            os_dly_wait(2);
-            swd_set_target_reset(0);
-            os_dly_wait(2);
-        } while(!swd_init_debug());
-
-        swd_off();
-        status = 1;
-    }
-    else
-    {
-        status = swd_set_target_state_sw(state);
-    }
-    
-    return status;
 }
 
 uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)


### PR DESCRIPTION
This PR brings the unification to target reset routines trying the software reset first and then hardware reset if the first fails.

Both `swd_set_target_state_hw()` and `swd_set_target_state_sw()` are replaced with `target_set_state()` which also removes set state from target implementations unless reset really requires some unique reset quirk. New functions will be placed in dedicated `target.{c,h}` file also separate from `swd_host.{c,h}`.

Still testing, please merge only after label is removed and code is confirmed after in depth testing..