### PR TITLE
Add WebUSB support using CMSIS-DAP interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Arm Mbed DAPLink is an open-source software project that enables programming and
 * MSC - drag-n-drop programming flash memory
 * CDC - virtual com port for log, trace and terminal emulation
 * HID - CMSIS-DAP compliant debug channel
+* WEBUSB HID - CMSIS-DAP compliant debug channel
 
 More features are planned and will show up gradually over time. The project is constantly under heavy development by Arm, its partners, numerous hardware vendors and the open-source community around the world. DAPLink has superseded the mbed CMSIS-DAP interface firmware project. You are free to use and contribute. Enjoy!
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -25,6 +25,8 @@ module:
         - records/usb/usb-hid.yaml
         - records/usb/usb-msc.yaml
         - records/usb/usb-cdc.yaml
+        - records/usb/usb-webusb.yaml
+        - records/usb/usb-winusb.yaml
         - records/daplink/cmsis-dap.yaml
         - records/daplink/drag-n-drop.yaml
         - records/daplink/usb2uart.yaml

--- a/records/usb/usb-webusb.yaml
+++ b/records/usb/usb-webusb.yaml
@@ -1,0 +1,7 @@
+common:
+    macros:
+        - WEBUSB_INTERFACE
+        - WEBUSB_HID_ENDPOINT
+    sources:
+        usb:
+            - source/usb/webusb

--- a/records/usb/usb-winusb.yaml
+++ b/records/usb/usb-winusb.yaml
@@ -1,0 +1,6 @@
+common:
+    macros:
+        - WINUSB_INTERFACE
+    sources:
+        usb:
+            - source/usb/winusb

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -287,6 +287,9 @@ static uint32_t read_file_details_txt(uint32_t sector_offset, uint8_t *data, uin
 #ifdef HID_ENDPOINT
     pos += util_write_string(buf + pos, ", HID");
 #endif
+#if (USBD_WEBUSB_ENABLE)
+    pos += util_write_string(buf + pos, ", WebUSB");
+#endif
     pos += util_write_string(buf + pos, "\r\n");
 
     // CRC of the bootloader (if there is one)

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -287,7 +287,7 @@ static uint32_t read_file_details_txt(uint32_t sector_offset, uint8_t *data, uin
 #ifdef HID_ENDPOINT
     pos += util_write_string(buf + pos, ", HID");
 #endif
-#if (USBD_WEBUSB_ENABLE)
+#if (WEBUSB_HID_ENDPOINT)
     pos += util_write_string(buf + pos, ", WebUSB");
 #endif
     pos += util_write_string(buf + pos, "\r\n");

--- a/source/daplink/macro.h
+++ b/source/daplink/macro.h
@@ -40,6 +40,12 @@ extern "C" {
 
 #define ROUND_DOWN(value, boundary)     ((value) - ((value) % (boundary)))
 
+#define STRINGIFY_LITERAL(x) #x
+
+#define STRINGIFY_MACRO(x) STRINGIFY_LITERAL(x)
+
+#define CONCAT_MACRO_TO_STRING(str,x) (str STRINGIFY_MACRO(x))
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/hic_hal/atmel/sam3u2c/usb_config.c
+++ b/source/hic_hal/atmel/sam3u2c/usb_config.c
@@ -381,9 +381,9 @@
 #define USBD_WEBUSB_ENABLE          0
 #endif
 #define USBD_WEBUSB_VENDOR_CODE     0x21
-#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_BASE_LANDING_URL "os.mbed.com/webusb/landing-page/?vid="
 #define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
-#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_ORIGIN_URL      "os.mbed.com/"
 #define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 
 //     Microsoft OS Descriptors 2.0 (WinUSB) support

--- a/source/hic_hal/freescale/k20dx/usb_config.c
+++ b/source/hic_hal/freescale/k20dx/usb_config.c
@@ -378,9 +378,9 @@
 #define USBD_WEBUSB_ENABLE          0
 #endif
 #define USBD_WEBUSB_VENDOR_CODE     0x21
-#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_BASE_LANDING_URL "os.mbed.com/webusb/landing-page/?vid="
 #define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
-#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_ORIGIN_URL      "os.mbed.com/"
 #define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 
 //     Microsoft OS Descriptors 2.0 (WinUSB) support

--- a/source/hic_hal/freescale/k20dx/usb_config.c
+++ b/source/hic_hal/freescale/k20dx/usb_config.c
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+#include "macro.h"
+
 // <e> USB Device
 //   <i> Enable the USB Device functionality
 #define USBD_ENABLE                 1
@@ -29,7 +31,11 @@
 //   <o0.0> High-speed
 //     <i> Enable high-speed functionality (if device supports it)
 #define USBD_HS_ENABLE              0
-
+#if (defined(WEBUSB_INTERFACE) || defined(WINUSB_INTERFACE))
+#define USBD_BOS_ENABLE             1
+#else
+#define USBD_BOS_ENABLE             0
+#endif
 //   <h> Device Settings
 //     <i> These settings affect Device Descriptor
 //     <o0> Power
@@ -130,9 +136,28 @@
 #else
 #define HID_ENDPOINT 1
 #endif
+
+#ifndef WEBUSB_HID_ENDPOINT
+#define WEBUSB_HID_ENDPOINT 0
+#else
+#define WEBUSB_HID_ENDPOINT 1
+
+#if !HID_ENDPOINT
+#error "HID Endpoint must be enabled if WEBUSB_HID_ENDPOINT is"
+#endif
+#endif
+
 #define USBD_HID_ENABLE             HID_ENDPOINT
-#define USBD_HID_EP_INTIN           1
-#define USBD_HID_EP_INTOUT          1
+#define USBD_HID_WEBUSB_ENABLE      WEBUSB_HID_ENDPOINT
+#define USBD_HID_EP_INTIN           5
+#define USBD_HID_EP_INTOUT          5
+
+#if WEBUSB_HID_ENDPOINT
+// Pick a unique endpoint for the WEBUSB HID IF.
+#define USBD_HID_WEBUSB_EP_INTIN    1
+#define USBD_HID_WEBUSB_EP_INTOUT   1
+#endif
+
 #define USBD_HID_EP_INTIN_STACK     0
 #define USBD_HID_WMAXPACKETSIZE     64
 #define USBD_HID_BINTERVAL          1
@@ -140,6 +165,7 @@
 #define USBD_HID_HS_WMAXPACKETSIZE  64
 #define USBD_HID_HS_BINTERVAL       6
 #define USBD_HID_STRDESC            L"CMSIS-DAP"
+#define USBD_HID_WEBUSB_STRDESC     L"WebUSB: CMSIS-DAP"
 #define USBD_HID_INREPORT_NUM       1
 #define USBD_HID_OUTREPORT_NUM      1
 #define USBD_HID_INREPORT_MAX_SZ    64
@@ -345,15 +371,34 @@
 //     </e>
 #define USBD_CLS_ENABLE             0
 
+//     WebUSB support
+#ifdef WEBUSB_INTERFACE
+#define USBD_WEBUSB_ENABLE          1
+#else
+#define USBD_WEBUSB_ENABLE          0
+#endif
+#define USBD_WEBUSB_VENDOR_CODE     0x21
+#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
+#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
+
+//     Microsoft OS Descriptors 2.0 (WinUSB) support
+#ifdef WINUSB_INTERFACE
+#define USBD_WINUSB_ENABLE          1
+#else
+#define USBD_WINUSB_ENABLE          0
+#endif
+#define USBD_WINUSB_VENDOR_CODE     0x20
+#define USBD_WINUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 //   </e>
 // </e>
 
 
 /* USB Device Calculations ---------------------------------------------------*/
 
-#define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
-#define MAX(x, y)                (((x) < (y)) ? (y) : (x))
+#define USBD_IF_NUM                (USBD_HID_WEBUSB_ENABLE+USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE|USBD_CLS_ENABLE|USBD_HID_WEBUSB_ENABLE))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))
 #define USBD_EP_NUM_CALC2           MAX((USBD_ADC_ENABLE    *(USBD_ADC_EP_ISOOUT    )), (USBD_CDC_ACM_ENABLE*(USBD_CDC_ACM_EP_INTIN)))
@@ -361,7 +406,7 @@
 #define USBD_EP_NUM_CALC4           MAX(USBD_EP_NUM_CALC0, USBD_EP_NUM_CALC1)
 #define USBD_EP_NUM_CALC5           MAX(USBD_EP_NUM_CALC2, USBD_EP_NUM_CALC3)
 #define USBD_EP_NUM_CALC6           MAX(USBD_EP_NUM_CALC4, USBD_EP_NUM_CALC5)
-#define USBD_EP_NUM                (USBD_EP_NUM_CALC6)
+#define USBD_EP_NUM                 MAX(USBD_EP_NUM_CALC6, USBD_HID_EP_INTIN*USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_MSC_ENABLE)
@@ -428,7 +473,8 @@
 #define USBD_MSC_IF_NUM            (USBD_ADC_ENABLE*2+0)
 #define USBD_CDC_ACM_CIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+0)
 #define USBD_CDC_ACM_DIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+1)
-#define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+0)
+#define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2)
+#define USBD_HID_WEBUSB_IF_NUM      (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
 
 #define USBD_ADC_CIF_STR_NUM       (3+USBD_STRDESC_SER_ENABLE+0)
 #define USBD_ADC_SIF1_STR_NUM      (3+USBD_STRDESC_SER_ENABLE+1)
@@ -436,7 +482,8 @@
 #define USBD_CDC_ACM_CIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+0)
 #define USBD_CDC_ACM_DIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+1)
 #define USBD_HID_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2)
-#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_HID_WEBUSB_IF_STR_NUM  (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE+USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_HID_HS_ENABLE)

--- a/source/hic_hal/freescale/kl26z/usb_config.c
+++ b/source/hic_hal/freescale/kl26z/usb_config.c
@@ -379,9 +379,9 @@
 #define USBD_WEBUSB_ENABLE          0
 #endif
 #define USBD_WEBUSB_VENDOR_CODE     0x21
-#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_BASE_LANDING_URL "os.mbed.com/webusb/landing-page/?vid="
 #define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
-#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_ORIGIN_URL      "os.mbed.com/"
 #define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 
 //     Microsoft OS Descriptors 2.0 (WinUSB) support

--- a/source/hic_hal/freescale/kl26z/usb_config.c
+++ b/source/hic_hal/freescale/kl26z/usb_config.c
@@ -19,6 +19,7 @@
  * limitations under the License.
  */
 
+#include "macro.h"
 
 // <e> USB Device
 //   <i> Enable the USB Device functionality
@@ -30,7 +31,11 @@
 //   <o0.0> High-speed
 //     <i> Enable high-speed functionality (if device supports it)
 #define USBD_HS_ENABLE              0
-
+#if (defined(WEBUSB_INTERFACE) || defined(WINUSB_INTERFACE))
+#define USBD_BOS_ENABLE             1
+#else
+#define USBD_BOS_ENABLE             0
+#endif
 //   <h> Device Settings
 //     <i> These settings affect Device Descriptor
 //     <o0> Power
@@ -131,9 +136,29 @@
 #else
 #define HID_ENDPOINT 1
 #endif
+
+#ifndef WEBUSB_HID_ENDPOINT
+#define WEBUSB_HID_ENDPOINT 0
+#else
+#define WEBUSB_HID_ENDPOINT 1
+
+#if !HID_ENDPOINT
+#error "HID Endpoint must be enabled if WEBUSB_HID_ENDPOINT is"
+#endif
+#endif
+
 #define USBD_HID_ENABLE             HID_ENDPOINT
-#define USBD_HID_EP_INTIN           1
-#define USBD_HID_EP_INTOUT          1
+#define USBD_HID_WEBUSB_ENABLE      WEBUSB_HID_ENDPOINT
+#define USBD_HID_EP_INTIN           5
+#define USBD_HID_EP_INTOUT          5
+
+#if WEBUSB_HID_ENDPOINT
+// Pick a unique endpoint for the WEBUSB HID IF.
+#define USBD_HID_WEBUSB_EP_INTIN    1
+#define USBD_HID_WEBUSB_EP_INTOUT   1
+#endif
+
+#define USBD_HID_ENABLE             HID_ENDPOINT
 #define USBD_HID_EP_INTIN_STACK     0
 #define USBD_HID_WMAXPACKETSIZE     64
 #define USBD_HID_BINTERVAL          1
@@ -141,6 +166,7 @@
 #define USBD_HID_HS_WMAXPACKETSIZE  64
 #define USBD_HID_HS_BINTERVAL       6
 #define USBD_HID_STRDESC            L"CMSIS-DAP"
+#define USBD_HID_WEBUSB_STRDESC     L"WebUSB: CMSIS-DAP"
 #define USBD_HID_INREPORT_NUM       1
 #define USBD_HID_OUTREPORT_NUM      1
 #define USBD_HID_INREPORT_MAX_SZ    64
@@ -346,15 +372,34 @@
 //     </e>
 #define USBD_CLS_ENABLE             0
 
+//     WebUSB support
+#ifdef WEBUSB_INTERFACE
+#define USBD_WEBUSB_ENABLE          1
+#else
+#define USBD_WEBUSB_ENABLE          0
+#endif
+#define USBD_WEBUSB_VENDOR_CODE     0x21
+#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
+#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
+
+//     Microsoft OS Descriptors 2.0 (WinUSB) support
+#ifdef WINUSB_INTERFACE
+#define USBD_WINUSB_ENABLE          1
+#else
+#define USBD_WINUSB_ENABLE          0
+#endif
+#define USBD_WINUSB_VENDOR_CODE     0x20
+#define USBD_WINUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 //   </e>
 // </e>
 
 
 /* USB Device Calculations ---------------------------------------------------*/
 
-#define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
-#define MAX(x, y)                (((x) < (y)) ? (y) : (x))
+#define USBD_IF_NUM                (USBD_HID_WEBUSB_ENABLE+USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE|USBD_CLS_ENABLE|USBD_HID_WEBUSB_ENABLE))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))
 #define USBD_EP_NUM_CALC2           MAX((USBD_ADC_ENABLE    *(USBD_ADC_EP_ISOOUT    )), (USBD_CDC_ACM_ENABLE*(USBD_CDC_ACM_EP_INTIN)))
@@ -362,7 +407,7 @@
 #define USBD_EP_NUM_CALC4           MAX(USBD_EP_NUM_CALC0, USBD_EP_NUM_CALC1)
 #define USBD_EP_NUM_CALC5           MAX(USBD_EP_NUM_CALC2, USBD_EP_NUM_CALC3)
 #define USBD_EP_NUM_CALC6           MAX(USBD_EP_NUM_CALC4, USBD_EP_NUM_CALC5)
-#define USBD_EP_NUM                (USBD_EP_NUM_CALC6)
+#define USBD_EP_NUM                	MAX(USBD_EP_NUM_CALC6, USBD_HID_EP_INTIN*USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_MSC_ENABLE)
@@ -429,7 +474,8 @@
 #define USBD_MSC_IF_NUM            (USBD_ADC_ENABLE*2+0)
 #define USBD_CDC_ACM_CIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+0)
 #define USBD_CDC_ACM_DIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+1)
-#define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+0)
+#define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2)
+#define USBD_HID_WEBUSB_IF_NUM     (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
 
 #define USBD_ADC_CIF_STR_NUM       (3+USBD_STRDESC_SER_ENABLE+0)
 #define USBD_ADC_SIF1_STR_NUM      (3+USBD_STRDESC_SER_ENABLE+1)
@@ -437,7 +483,8 @@
 #define USBD_CDC_ACM_CIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+0)
 #define USBD_CDC_ACM_DIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+1)
 #define USBD_HID_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2)
-#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_HID_WEBUSB_IF_STR_NUM  (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE+USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_HID_HS_ENABLE)

--- a/source/hic_hal/nxp/lpc11u35/usb_config.c
+++ b/source/hic_hal/nxp/lpc11u35/usb_config.c
@@ -379,9 +379,9 @@
 #define USBD_WEBUSB_ENABLE          0
 #endif
 #define USBD_WEBUSB_VENDOR_CODE     0x21
-#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_BASE_LANDING_URL "os.mbed.com/webusb/landing-page/?vid="
 #define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
-#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_ORIGIN_URL      "os.mbed.com/"
 #define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 
 //     Microsoft OS Descriptors 2.0 (WinUSB) support

--- a/source/hic_hal/nxp/lpc11u35/usb_config.c
+++ b/source/hic_hal/nxp/lpc11u35/usb_config.c
@@ -19,13 +19,19 @@
  * limitations under the License.
  */
 
+#include "macro.h"
+
 // <e> USB Device
 //   <i> Enable the USB Device functionality
 #define USBD_ENABLE                 1
 #define USBD_RTX_CORE_STACK         0
 #define USBD_RTX_DEVICE_STACK       0
 #define USBD_RTX_ENDPOINT0_STACK    0
-
+#if (defined(WEBUSB_INTERFACE) || defined(WINUSB_INTERFACE))
+#define USBD_BOS_ENABLE             1
+#else
+#define USBD_BOS_ENABLE             0
+#endif
 //   <o0.0> High-speed
 //     <i> Enable high-speed functionality (if device supports it)
 #define USBD_HS_ENABLE              0
@@ -130,9 +136,29 @@
 #else
 #define HID_ENDPOINT 1
 #endif
+
+#ifndef WEBUSB_HID_ENDPOINT
+#define WEBUSB_HID_ENDPOINT 0
+#else
+#define WEBUSB_HID_ENDPOINT 1
+
+#if !HID_ENDPOINT
+#error "HID Endpoint must be enabled if WEBUSB_HID_ENDPOINT is"
+#endif
+#endif
+
 #define USBD_HID_ENABLE             HID_ENDPOINT
-#define USBD_HID_EP_INTIN           1
-#define USBD_HID_EP_INTOUT          1
+#define USBD_HID_WEBUSB_ENABLE      WEBUSB_HID_ENDPOINT
+#define USBD_HID_EP_INTIN           5
+#define USBD_HID_EP_INTOUT          5
+
+#if WEBUSB_HID_ENDPOINT
+// Pick a unique endpoint for the WEBUSB HID IF.
+#define USBD_HID_WEBUSB_EP_INTIN    1
+#define USBD_HID_WEBUSB_EP_INTOUT   1
+#endif
+
+#define USBD_HID_ENABLE             HID_ENDPOINT
 #define USBD_HID_EP_INTIN_STACK     0
 #define USBD_HID_WMAXPACKETSIZE     64
 #define USBD_HID_BINTERVAL          1
@@ -140,6 +166,7 @@
 #define USBD_HID_HS_WMAXPACKETSIZE  64
 #define USBD_HID_HS_BINTERVAL       6
 #define USBD_HID_STRDESC            L"CMSIS-DAP"
+#define USBD_HID_WEBUSB_STRDESC     L"WebUSB: CMSIS-DAP"
 #define USBD_HID_INREPORT_NUM       1
 #define USBD_HID_OUTREPORT_NUM      1
 #define USBD_HID_INREPORT_MAX_SZ    64
@@ -345,15 +372,34 @@
 //     </e>
 #define USBD_CLS_ENABLE             0
 
+//     WebUSB support
+#ifdef WEBUSB_INTERFACE
+#define USBD_WEBUSB_ENABLE          1
+#else
+#define USBD_WEBUSB_ENABLE          0
+#endif
+#define USBD_WEBUSB_VENDOR_CODE     0x21
+#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
+#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
+
+//     Microsoft OS Descriptors 2.0 (WinUSB) support
+#ifdef WINUSB_INTERFACE
+#define USBD_WINUSB_ENABLE          1
+#else
+#define USBD_WINUSB_ENABLE          0
+#endif
+#define USBD_WINUSB_VENDOR_CODE     0x20
+#define USBD_WINUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 //   </e>
 // </e>
 
 
 /* USB Device Calculations ---------------------------------------------------*/
 
-#define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
-#define MAX(x, y)                (((x) < (y)) ? (y) : (x))
+#define USBD_IF_NUM                (USBD_HID_WEBUSB_ENABLE+USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE|USBD_CLS_ENABLE|USBD_HID_WEBUSB_ENABLE))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))
 #define USBD_EP_NUM_CALC2           MAX((USBD_ADC_ENABLE    *(USBD_ADC_EP_ISOOUT    )), (USBD_CDC_ACM_ENABLE*(USBD_CDC_ACM_EP_INTIN)))
@@ -361,7 +407,7 @@
 #define USBD_EP_NUM_CALC4           MAX(USBD_EP_NUM_CALC0, USBD_EP_NUM_CALC1)
 #define USBD_EP_NUM_CALC5           MAX(USBD_EP_NUM_CALC2, USBD_EP_NUM_CALC3)
 #define USBD_EP_NUM_CALC6           MAX(USBD_EP_NUM_CALC4, USBD_EP_NUM_CALC5)
-#define USBD_EP_NUM                (USBD_EP_NUM_CALC6)
+#define USBD_EP_NUM                 MAX(USBD_EP_NUM_CALC6, USBD_HID_EP_INTIN*USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_MSC_ENABLE)
@@ -428,7 +474,8 @@
 #define USBD_MSC_IF_NUM            (USBD_ADC_ENABLE*2+0)
 #define USBD_CDC_ACM_CIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+0)
 #define USBD_CDC_ACM_DIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+1)
-#define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+0)
+#define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2)
+#define USBD_HID_WEBUSB_IF_NUM      (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
 
 #define USBD_ADC_CIF_STR_NUM       (3+USBD_STRDESC_SER_ENABLE+0)
 #define USBD_ADC_SIF1_STR_NUM      (3+USBD_STRDESC_SER_ENABLE+1)
@@ -436,7 +483,9 @@
 #define USBD_CDC_ACM_CIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+0)
 #define USBD_CDC_ACM_DIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+1)
 #define USBD_HID_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2)
-#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_HID_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2)
+#define USBD_HID_WEBUSB_IF_STR_NUM  (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE+USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_HID_HS_ENABLE)

--- a/source/hic_hal/nxp/lpc4322/usb_config.c
+++ b/source/hic_hal/nxp/lpc4322/usb_config.c
@@ -379,9 +379,9 @@
 #define USBD_WEBUSB_ENABLE          0
 #endif
 #define USBD_WEBUSB_VENDOR_CODE     0x21
-#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_BASE_LANDING_URL "os.mbed.com/webusb/landing-page/?vid="
 #define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
-#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_ORIGIN_URL      "os.mbed.com/"
 #define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 
 //     Microsoft OS Descriptors 2.0 (WinUSB) support

--- a/source/hic_hal/nxp/lpc4322/usb_config.c
+++ b/source/hic_hal/nxp/lpc4322/usb_config.c
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+#include "macro.h"
+
 // <e> USB Device
 //   <i> Enable the USB Device functionality
 #define USBD_ENABLE                 1
@@ -29,7 +31,11 @@
 //   <o0.0> High-speed
 //     <i> Enable high-speed functionality (if device supports it)
 #define USBD_HS_ENABLE              0
-
+#if (defined(WEBUSB_INTERFACE) || defined(WINUSB_INTERFACE))
+#define USBD_BOS_ENABLE             1
+#else
+#define USBD_BOS_ENABLE             0
+#endif
 //   <h> Device Settings
 //     <i> These settings affect Device Descriptor
 //     <o0> Power
@@ -130,9 +136,29 @@
 #else
 #define HID_ENDPOINT 1
 #endif
+
+#ifndef WEBUSB_HID_ENDPOINT
+#define WEBUSB_HID_ENDPOINT 0
+#else
+#define WEBUSB_HID_ENDPOINT 1
+
+#if !HID_ENDPOINT
+#error "HID Endpoint must be enabled if WEBUSB_HID_ENDPOINT is"
+#endif
+#endif
+
 #define USBD_HID_ENABLE             HID_ENDPOINT
-#define USBD_HID_EP_INTIN           1
-#define USBD_HID_EP_INTOUT          1
+#define USBD_HID_WEBUSB_ENABLE      WEBUSB_HID_ENDPOINT
+#define USBD_HID_EP_INTIN           5
+#define USBD_HID_EP_INTOUT          5
+
+#if WEBUSB_HID_ENDPOINT
+// Pick a unique endpoint for the WEBUSB HID IF.
+#define USBD_HID_WEBUSB_EP_INTIN    1
+#define USBD_HID_WEBUSB_EP_INTOUT   1
+#endif
+
+#define USBD_HID_ENABLE             HID_ENDPOINT
 #define USBD_HID_EP_INTIN_STACK     0
 #define USBD_HID_WMAXPACKETSIZE     64
 #define USBD_HID_BINTERVAL          1
@@ -140,6 +166,7 @@
 #define USBD_HID_HS_WMAXPACKETSIZE  64
 #define USBD_HID_HS_BINTERVAL       6
 #define USBD_HID_STRDESC            L"CMSIS-DAP"
+#define USBD_HID_WEBUSB_STRDESC     L"WebUSB: CMSIS-DAP"
 #define USBD_HID_INREPORT_NUM       1
 #define USBD_HID_OUTREPORT_NUM      1
 #define USBD_HID_INREPORT_MAX_SZ    64
@@ -345,15 +372,34 @@
 //     </e>
 #define USBD_CLS_ENABLE             0
 
+//     WebUSB support
+#ifdef WEBUSB_INTERFACE
+#define USBD_WEBUSB_ENABLE          1
+#else
+#define USBD_WEBUSB_ENABLE          0
+#endif
+#define USBD_WEBUSB_VENDOR_CODE     0x21
+#define USBD_WEBUSB_BASE_LANDING_URL "armmbed.github.io/dapjs-web-demo/?vid="
+#define USBD_WEBUSB_LANDING_URL     CONCAT_MACRO_TO_STRING(USBD_WEBUSB_BASE_LANDING_URL, USBD_DEVDESC_IDVENDOR)
+#define USBD_WEBUSB_ORIGIN_URL      "armmbed.github.io/"
+#define USBD_WEBUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
+
+//     Microsoft OS Descriptors 2.0 (WinUSB) support
+#ifdef WINUSB_INTERFACE
+#define USBD_WINUSB_ENABLE          1
+#else
+#define USBD_WINUSB_ENABLE          0
+#endif
+#define USBD_WINUSB_VENDOR_CODE     0x20
+#define USBD_WINUSB_IF_NUM          USBD_HID_WEBUSB_IF_NUM
 //   </e>
 // </e>
 
 
 /* USB Device Calculations ---------------------------------------------------*/
 
-#define USBD_IF_NUM                (USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
-#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE))
-#define MAX(x, y)                (((x) < (y)) ? (y) : (x))
+#define USBD_IF_NUM                (USBD_HID_WEBUSB_ENABLE+USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
+#define USBD_MULTI_IF              (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE|USBD_CLS_ENABLE|USBD_HID_WEBUSB_ENABLE))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))
 #define USBD_EP_NUM_CALC2           MAX((USBD_ADC_ENABLE    *(USBD_ADC_EP_ISOOUT    )), (USBD_CDC_ACM_ENABLE*(USBD_CDC_ACM_EP_INTIN)))
@@ -361,7 +407,7 @@
 #define USBD_EP_NUM_CALC4           MAX(USBD_EP_NUM_CALC0, USBD_EP_NUM_CALC1)
 #define USBD_EP_NUM_CALC5           MAX(USBD_EP_NUM_CALC2, USBD_EP_NUM_CALC3)
 #define USBD_EP_NUM_CALC6           MAX(USBD_EP_NUM_CALC4, USBD_EP_NUM_CALC5)
-#define USBD_EP_NUM                (USBD_EP_NUM_CALC6)
+#define USBD_EP_NUM                 MAX(USBD_EP_NUM_CALC6, USBD_HID_EP_INTIN*USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_MSC_ENABLE)
@@ -429,6 +475,8 @@
 #define USBD_CDC_ACM_CIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+0)
 #define USBD_CDC_ACM_DIF_NUM       (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+1)
 #define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+0)
+#define USBD_HID_IF_NUM            (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2)
+#define USBD_HID_WEBUSB_IF_NUM      (USBD_ADC_ENABLE*2+USBD_MSC_ENABLE*1+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
 
 #define USBD_ADC_CIF_STR_NUM       (3+USBD_STRDESC_SER_ENABLE+0)
 #define USBD_ADC_SIF1_STR_NUM      (3+USBD_STRDESC_SER_ENABLE+1)
@@ -436,7 +484,8 @@
 #define USBD_CDC_ACM_CIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+0)
 #define USBD_CDC_ACM_DIF_STR_NUM   (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+1)
 #define USBD_HID_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2)
-#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_HID_WEBUSB_IF_STR_NUM  (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE)
+#define USBD_MSC_IF_STR_NUM        (3+USBD_STRDESC_SER_ENABLE+USBD_ADC_ENABLE*3+USBD_CDC_ACM_ENABLE*2+USBD_HID_ENABLE+USBD_HID_WEBUSB_ENABLE)
 
 #if    (USBD_HID_ENABLE)
 #if    (USBD_HID_HS_ENABLE)

--- a/source/hic_hal/target_config.h
+++ b/source/hic_hal/target_config.h
@@ -57,6 +57,7 @@ typedef struct target_cfg {
 
 extern target_cfg_t target_device;
 
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/usb/hid/usbd_core_hid.c
+++ b/source/usb/hid/usbd_core_hid.c
@@ -36,7 +36,8 @@ __weak BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
 {
     switch (USBD_SetupPacket.wValueH) {
         case HID_HID_DESCRIPTOR_TYPE:
-            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num) {
+            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num &&
+                USBD_SetupPacket.wIndexL != usbd_hid_webusb_if_num) {
                 return (__FALSE);  /* Only Single HID Interface is supported */
             }
 
@@ -55,7 +56,8 @@ __weak BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
             break;
 
         case HID_REPORT_DESCRIPTOR_TYPE:
-            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num) {
+            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num &&
+                USBD_SetupPacket.wIndexL != usbd_hid_webusb_if_num) {
                 return (__FALSE);  /* Only Single HID Interface is supported */
             }
 
@@ -82,7 +84,8 @@ __weak BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
 
 __weak BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
 {
-    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num) {         /* IF number correct? */
+    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num ||
+        USBD_SetupPacket.wIndexL == usbd_hid_webusb_if_num) {         /* IF number correct? */
         switch (USBD_SetupPacket.bRequest) {
             case HID_REQUEST_GET_REPORT:
                 if (USBD_HID_GetReport()) {
@@ -155,7 +158,8 @@ __weak BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
 
 __weak BOOL USBD_EndPoint0_Out_HID_ReqToIF(void)
 {
-    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num) {   /* IF number correct? */
+    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num ||
+        USBD_SetupPacket.wIndexL == usbd_hid_webusb_if_num) {   /* IF number correct? */
         switch (USBD_SetupPacket.bRequest) {
             case HID_REQUEST_SET_REPORT:
                 if (USBD_HID_SetReport()) {

--- a/source/usb/usb_def.h
+++ b/source/usb/usb_def.h
@@ -104,6 +104,8 @@ typedef __packed struct _USB_SETUP_PACKET {
 #define USB_OTG_DESCRIPTOR_TYPE                     9
 #define USB_DEBUG_DESCRIPTOR_TYPE                  10
 #define USB_INTERFACE_ASSOCIATION_DESCRIPTOR_TYPE  11
+#define USB_BINARY_OBJECT_STORE_DESCRIPTOR_TYPE    15
+#define USB_DEVICE_CAPABILITY_DESCRIPTOR_TYPE      16
 
 /* USB Device Classes */
 #define USB_DEVICE_CLASS_RESERVED              0x00
@@ -117,6 +119,7 @@ typedef __packed struct _USB_SETUP_PACKET {
 #define USB_DEVICE_CLASS_STORAGE               0x08
 #define USB_DEVICE_CLASS_HUB                   0x09
 #define USB_DEVICE_CLASS_MISCELLANEOUS         0xEF
+#define USB_DEVICE_CLASS_APPLICATION_SPECIFIC  0xFE
 #define USB_DEVICE_CLASS_VENDOR_SPECIFIC       0xFF
 
 /* bmAttributes in Configuration Descriptor */
@@ -149,6 +152,20 @@ typedef __packed struct _USB_SETUP_PACKET {
 #define USB_ENDPOINT_USAGE_FEEDBACK            0x10
 #define USB_ENDPOINT_USAGE_IMPLICIT_FEEDBACK   0x20
 #define USB_ENDPOINT_USAGE_RESERVED            0x30
+
+/* bDevCapabilityType in Device Capability Descriptor */
+#define USB_DEVICE_CAPABILITY_WIRELESS_USB                  1
+#define USB_DEVICE_CAPABILITY_USB_2_0_EXTENSION             2
+#define USB_DEVICE_CAPABILITY_SUPERSPEED_USB                3
+#define USB_DEVICE_CAPABILITY_CONTAINER_ID                  4
+#define USB_DEVICE_CAPABILITY_PLATFORM                      5
+#define USB_DEVICE_CAPABILITY_POWER_DELIVERY_CAPABILITY     6
+#define USB_DEVICE_CAPABILITY_BATTERY_INFO_CAPABILITY       7
+#define USB_DEVICE_CAPABILITY_PD_CONSUMER_PORT_CAPABILITY   8
+#define USB_DEVICE_CAPABILITY_PD_PROVIDER_PORT_CAPABILITY   9
+#define USB_DEVICE_CAPABILITY_SUPERSPEED_PLUS               10
+#define USB_DEVICE_CAPABILITY_PRECISION_TIME_MEASUREMENT    11
+#define USB_DEVICE_CAPABILITY_WIRELESS_USB_EXT              12
 
 /* USB Standard Device Descriptor */
 typedef __packed struct _USB_DEVICE_DESCRIPTOR {
@@ -241,5 +258,19 @@ typedef __packed struct _USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
     U8  iFunction;
 } USB_INTERFACE_ASSOCIATION_DESCRIPTOR;
 
+/* USB Binary Object Store Descriptor */
+typedef __packed struct _USB_BINARY_OBJECT_STORE_DESCRIPTOR {
+    U8  bLength;
+    U8  bDescriptorType;
+    U16 wTotalLength;
+    U8  bNumDeviceCaps;
+} USB_BINARY_OBJECT_STORE_DESCRIPTOR;
+
+/* USB Device Capability Descriptor */
+typedef __packed struct _USB_DEVICE_CAPABILITY_DESCRIPTOR {
+    U8  bLength;
+    U8  bDescriptorType;
+    U8  bDevCapabilityType;
+} USB_DEVICE_CAPABILITY_DESCRIPTOR;
 
 #endif  /* __USB_DEF_H__ */

--- a/source/usb/usb_lib.c
+++ b/source/usb/usb_lib.c
@@ -43,6 +43,7 @@ U8 USBD_AltSetting[USBD_IF_NUM];
 U8 USBD_EP0Buf[USBD_MAX_PACKET0];
 const U8 usbd_power = USBD_POWER;
 const U8 usbd_hs_enable = USBD_HS_ENABLE;
+const U8 usbd_bos_enable = USBD_BOS_ENABLE;
 const U16 usbd_if_num = USBD_IF_NUM;
 const U8 usbd_ep_num = USBD_EP_NUM;
 const U8 usbd_max_packet0 = USBD_MAX_PACKET0;
@@ -65,8 +66,11 @@ const U8 usbd_max_packet0 = USBD_MAX_PACKET0;
 
 #if    (USBD_HID_ENABLE)
 const U8 usbd_hid_if_num = USBD_HID_IF_NUM;
+const U8 usbd_hid_webusb_if_num = USBD_HID_WEBUSB_IF_NUM;
 const U8 usbd_hid_ep_intin = USBD_HID_EP_INTIN;
+const U8 usbd_hid_webusb_ep_intin = USBD_HID_WEBUSB_EP_INTIN;
 const U8 usbd_hid_ep_intout = USBD_HID_EP_INTOUT;
+const U8 usbd_hid_webusb_ep_intout = USBD_HID_WEBUSB_EP_INTOUT;
 const U16 usbd_hid_interval[2]  = {USBD_HID_INTERVAL, USBD_HID_HS_INTERVAL};
 const U16 usbd_hid_maxpacketsize[2] = {USBD_HID_WMAXPACKETSIZE, USBD_HID_HS_WMAXPACKETSIZE};
 const U8 usbd_hid_inreport_num = USBD_HID_INREPORT_NUM;
@@ -126,6 +130,18 @@ const U16 usbd_cdc_acm_maxpacketsize1[2] = {USBD_CDC_ACM_WMAXPACKETSIZE1, USBD_C
 U8 USBD_CDC_ACM_SendBuf[USBD_CDC_ACM_SENDBUF_SIZE];
 U8 USBD_CDC_ACM_ReceiveBuf[USBD_CDC_ACM_RECEIVEBUF_SIZE];
 U8 USBD_CDC_ACM_NotifyBuf[10];
+#endif
+
+#if    (USBD_WEBUSB_ENABLE)
+const U8 usbd_webusb_vendor_code = USBD_WEBUSB_VENDOR_CODE;
+#else
+const U8 usbd_webusb_vendor_code;
+#endif
+
+#if    (USBD_WINUSB_ENABLE)
+const U8 usbd_winusb_vendor_code = USBD_WINUSB_VENDOR_CODE;
+#else
+const U8 usbd_winusb_vendor_code;
 #endif
 
 /*------------------------------------------------------------------------------
@@ -414,6 +430,283 @@ BOOL USBD_EndPoint0_Out_HID_ReqToIF(void)
     return (__FALSE);
 }
 #endif  /* (USBD_HID_ENABLE) */
+
+#if    (USBD_HID_WEBUSB_ENABLE)
+#ifdef __RTX
+#if   ((USBD_HID_WEBUSB_EP_INTOUT != 0) && (USBD_HID_WEBUSB_EP_INTIN != USBD_HID_WEBUSB_EP_INTOUT))
+#if    (USBD_HID_WEBUSB_EP_INTIN == 1)
+#define USBD_RTX_EndPoint1             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 2)
+#define USBD_RTX_EndPoint2             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 3)
+#define USBD_RTX_EndPoint3             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 4)
+#define USBD_RTX_EndPoint4             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 5)
+#define USBD_RTX_EndPoint5             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 6)
+#define USBD_RTX_EndPoint6             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 7)
+#define USBD_RTX_EndPoint7             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 8)
+#define USBD_RTX_EndPoint8             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 9)
+#define USBD_RTX_EndPoint9             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 10)
+#define USBD_RTX_EndPoint10            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 11)
+#define USBD_RTX_EndPoint11            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 12)
+#define USBD_RTX_EndPoint12            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 13)
+#define USBD_RTX_EndPoint13            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 14)
+#define USBD_RTX_EndPoint14            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 15)
+#define USBD_RTX_EndPoint15            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#endif
+
+#if    (USBD_HID_WEBUSB_EP_INTOUT == 1)
+#define USBD_RTX_EndPoint1             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 2)
+#define USBD_RTX_EndPoint2             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 3)
+#define USBD_RTX_EndPoint3             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 4)
+#define USBD_RTX_EndPoint4             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 5)
+#define USBD_RTX_EndPoint5             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 6)
+#define USBD_RTX_EndPoint6             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 7)
+#define USBD_RTX_EndPoint7             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 8)
+#define USBD_RTX_EndPoint8             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 9)
+#define USBD_RTX_EndPoint9             USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 10)
+#define USBD_RTX_EndPoint10            USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 11)
+#define USBD_RTX_EndPoint11            USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 12)
+#define USBD_RTX_EndPoint12            USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 13)
+#define USBD_RTX_EndPoint13            USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 14)
+#define USBD_RTX_EndPoint14            USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 15)
+#define USBD_RTX_EndPoint15            USBD_RTX_HID_WEBUSB_EP_INTOUT_Event
+#endif
+#elif    (USBD_HID_WEBUSB_EP_INTOUT != 0)
+#if    (USBD_HID_WEBUSB_EP_INTIN == 1)
+#define USBD_RTX_EndPoint1             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 2)
+#define USBD_RTX_EndPoint2             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 3)
+#define USBD_RTX_EndPoint3             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 4)
+#define USBD_RTX_EndPoint4             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 5)
+#define USBD_RTX_EndPoint5             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 6)
+#define USBD_RTX_EndPoint6             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 7)
+#define USBD_RTX_EndPoint7             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 8)
+#define USBD_RTX_EndPoint8             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 9)
+#define USBD_RTX_EndPoint9             USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 10)
+#define USBD_RTX_EndPoint10            USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 11)
+#define USBD_RTX_EndPoint11            USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 12)
+#define USBD_RTX_EndPoint12            USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 13)
+#define USBD_RTX_EndPoint13            USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 14)
+#define USBD_RTX_EndPoint14            USBD_RTX_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 15)
+#define USBD_RTX_EndPoint15            USBD_RTX_HID_WEBUSB_EP_INT_Event
+#endif
+#else
+#if    (USBD_HID_WEBUSB_EP_INTIN == 1)
+#define USBD_RTX_EndPoint1             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 2)
+#define USBD_RTX_EndPoint2             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 3)
+#define USBD_RTX_EndPoint3             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 4)
+#define USBD_RTX_EndPoint4             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 5)
+#define USBD_RTX_EndPoint5             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 6)
+#define USBD_RTX_EndPoint6             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 7)
+#define USBD_RTX_EndPoint7             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 8)
+#define USBD_RTX_EndPoint8             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 9)
+#define USBD_RTX_EndPoint9             USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 10)
+#define USBD_RTX_EndPoint10            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 11)
+#define USBD_RTX_EndPoint11            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 12)
+#define USBD_RTX_EndPoint12            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 13)
+#define USBD_RTX_EndPoint13            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 14)
+#define USBD_RTX_EndPoint14            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 15)
+#define USBD_RTX_EndPoint15            USBD_RTX_HID_WEBUSB_EP_INTIN_Event
+#endif
+#endif
+#else
+#if   ((USBD_HID_WEBUSB_EP_INTOUT != 0) && (USBD_HID_WEBUSB_EP_INTIN != USBD_HID_WEBUSB_EP_INTOUT))
+#if    (USBD_HID_WEBUSB_EP_INTIN == 1)
+#define USBD_EndPoint1                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 2)
+#define USBD_EndPoint2                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 3)
+#define USBD_EndPoint3                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 4)
+#define USBD_EndPoint4                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 5)
+#define USBD_EndPoint5                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 6)
+#define USBD_EndPoint6                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 7)
+#define USBD_EndPoint7                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 8)
+#define USBD_EndPoint8                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 9)
+#define USBD_EndPoint9                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 10)
+#define USBD_EndPoint10                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 11)
+#define USBD_EndPoint11                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 12)
+#define USBD_EndPoint12                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 13)
+#define USBD_EndPoint13                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 14)
+#define USBD_EndPoint14                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 15)
+#define USBD_EndPoint15                USBD_HID_WEBUSB_EP_INTIN_Event
+#endif
+
+#if    (USBD_HID_WEBUSB_EP_INTOUT == 1)
+#define USBD_EndPoint1                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 2)
+#define USBD_EndPoint2                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 3)
+#define USBD_EndPoint3                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 4)
+#define USBD_EndPoint4                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 5)
+#define USBD_EndPoint5                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 6)
+#define USBD_EndPoint6                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 7)
+#define USBD_EndPoint7                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 8)
+#define USBD_EndPoint8                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 9)
+#define USBD_EndPoint9                 USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 10)
+#define USBD_EndPoint10                USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 11)
+#define USBD_EndPoint11                USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 12)
+#define USBD_EndPoint12                USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 13)
+#define USBD_EndPoint13                USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 14)
+#define USBD_EndPoint14                USBD_HID_WEBUSB_EP_INTOUT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTOUT == 15)
+#define USBD_EndPoint15                USBD_HID_WEBUSB_EP_INTOUT_Event
+#endif
+#elif    (USBD_HID_WEBUSB_EP_INTOUT != 0)
+#if    (USBD_HID_WEBUSB_EP_INTIN == 1)
+#define USBD_EndPoint1                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 2)
+#define USBD_EndPoint2                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 3)
+#define USBD_EndPoint3                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 4)
+#define USBD_EndPoint4                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 5)
+#define USBD_EndPoint5                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 6)
+#define USBD_EndPoint6                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 7)
+#define USBD_EndPoint7                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 8)
+#define USBD_EndPoint8                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 9)
+#define USBD_EndPoint9                 USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 10)
+#define USBD_EndPoint10                USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 11)
+#define USBD_EndPoint11                USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 12)
+#define USBD_EndPoint12                USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 13)
+#define USBD_EndPoint13                USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 14)
+#define USBD_EndPoint14                USBD_HID_WEBUSB_EP_INT_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 15)
+#define USBD_EndPoint15                USBD_HID_WEBUSB_EP_INT_Event
+#endif
+#else
+#if    (USBD_HID_WEBUSB_EP_INTIN == 1)
+#define USBD_EndPoint1                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 2)
+#define USBD_EndPoint2                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 3)
+#define USBD_EndPoint3                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 4)
+#define USBD_EndPoint4                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 5)
+#define USBD_EndPoint5                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 6)
+#define USBD_EndPoint6                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 7)
+#define USBD_EndPoint7                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 8)
+#define USBD_EndPoint8                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 9)
+#define USBD_EndPoint9                 USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 10)
+#define USBD_EndPoint10                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 11)
+#define USBD_EndPoint11                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 12)
+#define USBD_EndPoint12                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 13)
+#define USBD_EndPoint13                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 14)
+#define USBD_EndPoint14                USBD_HID_WEBUSB_EP_INTIN_Event
+#elif  (USBD_HID_WEBUSB_EP_INTIN == 15)
+#define USBD_EndPoint15                USBD_HID_WEBUSB_EP_INTIN_Event
+#endif
+#endif
+#endif
+#else
+BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
+{
+    return (__FALSE);
+}
+BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
+{
+    return (__FALSE);
+}
+BOOL USBD_EndPoint0_Out_HID_ReqToIF(void)
+{
+    return (__FALSE);
+}
+#endif  /* (USBD_HID_WEBUSB_ENABLE) */
 
 #if    (USBD_MSC_ENABLE)
 #ifdef __RTX
@@ -1507,6 +1800,7 @@ void USBD_RTX_TaskInit(void)
 #define USBD_WTOTALLENGTH                 (USB_CONFIGUARTION_DESC_SIZE +                 \
                                            USBD_CDC_ACM_DESC_LEN * USBD_CDC_ACM_ENABLE + \
                                            USBD_HID_DESC_LEN     * USBD_HID_ENABLE     + \
+                                           (USB_INTERFACE_DESC_SIZE + (USB_ENDPOINT_DESC_SIZE*(1+(USBD_HID_EP_INTOUT != 0)))) * USBD_HID_WEBUSB_ENABLE + \
                                            USBD_MSC_DESC_LEN     * USBD_MSC_ENABLE)
 
 /*------------------------------------------------------------------------------
@@ -1567,7 +1861,9 @@ __weak \
 const U8 USBD_DeviceDescriptor[] = {
     USB_DEVICE_DESC_SIZE,                 /* bLength */
     USB_DEVICE_DESCRIPTOR_TYPE,           /* bDescriptorType */
-#if ((USBD_HS_ENABLE) || (USBD_MULTI_IF))
+#if (USBD_BOS_ENABLE)
+    WBVAL(0x0210), /* 2.10 */             /* bcdUSB */
+#elif ((USBD_HS_ENABLE) || (USBD_MULTI_IF))
     WBVAL(0x0200), /* 2.00 */             /* bcdUSB */
 #else
     WBVAL(0x0110), /* 1.10 */             /* bcdUSB */
@@ -1601,7 +1897,11 @@ __weak \
 const U8 USBD_DeviceQualifier[] = {
     USB_DEVICE_QUALI_SIZE,                /* bLength */
     USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
+#if (USBD_BOS_ENABLE)
+    WBVAL(0x0210), /* 2.10 */             /* bcdUSB */
+#else
     WBVAL(0x0200), /* 2.00 */             /* bcdUSB */
+#endif
     0x00,                                 /* bDeviceClass */
     0x00,                                 /* bDeviceSubClass */
     0x00,                                 /* bDeviceProtocol */
@@ -1615,7 +1915,11 @@ __weak \
 const U8 USBD_DeviceQualifier_HS[] = {
     USB_DEVICE_QUALI_SIZE,                /* bLength */
     USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
+#if (USBD_BOS_ENABLE)
+    WBVAL(0x0210), /* 2.10 */             /* bcdUSB */
+#else
     WBVAL(0x0200), /* 2.00 */             /* bcdUSB */
+#endif
     0x00,                                 /* bDeviceClass */
     0x00,                                 /* bDeviceSubClass */
     0x00,                                 /* bDeviceProtocol */
@@ -1631,6 +1935,107 @@ const U8 USBD_DeviceQualifier[]    = { 0 };
 /* USB Device Qualifier Descriptor for High Speed */
 __weak \
 const U8 USBD_DeviceQualifier_HS[] = { 0 };
+#endif
+
+#if (USBD_WINUSB_ENABLE)
+
+#define USBD_WINUSB_DESC_SET_LEN           170
+#define FUNCTION_SUBSET_LEN                160
+#define DEVICE_INTERFACE_GUIDS_FEATURE_LEN 132
+
+const U8 USBD_WinUSBDescriptorSetDescriptor[] = {
+    WBVAL(WINUSB_DESCRIPTOR_SET_HEADER_SIZE), /* wLength */
+    WBVAL(WINUSB_SET_HEADER_DESCRIPTOR_TYPE), /* wDescriptorType */
+    0x00, 0x00, 0x03, 0x06, /* >= Win 8.1 */  /* dwWindowsVersion*/
+    WBVAL(USBD_WINUSB_DESC_SET_LEN),          /* wDescriptorSetTotalLength */
+    WBVAL(WINUSB_FUNCTION_SUBSET_HEADER_SIZE),/* wLength */
+    WBVAL(WINUSB_SUBSET_HEADER_FUNCTION_TYPE),/* wDescriptorType */
+    USBD_WINUSB_IF_NUM,                       /* bFirstInterface */
+    0,                                        /* bReserved */
+    WBVAL(FUNCTION_SUBSET_LEN),               /* wSubsetLength */
+    WBVAL(WINUSB_FEATURE_COMPATIBLE_ID_SIZE), /* wLength */
+    WBVAL(WINUSB_FEATURE_COMPATIBLE_ID_TYPE), /* wDescriptorType */
+    'W', 'I', 'N', 'U', 'S', 'B', 0, 0,       /* CompatibleId*/
+    0, 0, 0, 0, 0, 0, 0, 0,                   /* SubCompatibleId*/
+    WBVAL(DEVICE_INTERFACE_GUIDS_FEATURE_LEN),/* wLength */
+    WBVAL(WINUSB_FEATURE_REG_PROPERTY_TYPE),  /* wDescriptorType */
+    WBVAL(WINUSB_PROP_DATA_TYPE_REG_MULTI_SZ), /* wPropertyDataType */
+    WBVAL(42), /* wPropertyNameLength */
+    'D',0,'e',0,'v',0,'i',0,'c',0,'e',0,
+    'I',0,'n',0,'t',0,'e',0,'r',0,'f',0,'a',0,'c',0,'e',0,
+    'G',0,'U',0,'I',0,'D',0,'s',0,0,0,
+    WBVAL(80), /* wPropertyDataLength */
+    '{',0,
+    '9',0,'2',0,'C',0,'E',0,'6',0,'4',0,'6',0,'2',0,'-',0,
+    '9',0,'C',0,'7',0,'7',0,'-',0,
+    '4',0,'6',0,'F',0,'E',0,'-',0,
+    '9',0,'3',0,'3',0,'B',0,'-',
+    0,'3',0,'1',0,'C',0,'B',0,'9',0,'C',0,'5',0,'A',0,'A',0,'3',0,'B',0,'9',0,
+    '}',0,0,0,0,0
+};
+
+#else
+
+const U8 USBD_WinUSBDescriptorSetDescriptor[] = { 0 };
+
+BOOL USBD_EndPoint0_Setup_WinUSB_ReqToDevice(void)
+{
+    return (__FALSE);
+}
+
+#endif
+
+#if (USBD_BOS_ENABLE)
+
+#define USBD_NUM_DEV_CAPABILITIES         (USBD_WEBUSB_ENABLE + USBD_WINUSB_ENABLE)
+
+#define USBD_WEBUSB_DESC_LEN              (sizeof(WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR))
+
+#define USBD_WINUSB_DESC_LEN              (sizeof(WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR))
+
+#define USBD_BOS_WTOTALLENGTH             (USB_BOS_DESC_SIZE +                         \
+                                           USBD_WEBUSB_DESC_LEN * USBD_WEBUSB_ENABLE + \
+                                           USBD_WINUSB_DESC_LEN * USBD_WINUSB_ENABLE)
+
+__weak \
+const U8 USBD_BinaryObjectStoreDescriptor[] = {
+	USB_BOS_DESC_SIZE,                      /* bLength */
+	USB_BINARY_OBJECT_STORE_DESCRIPTOR_TYPE,/* bDescriptorType */
+	WBVAL(USBD_BOS_WTOTALLENGTH),           /* wTotalLength */
+	USBD_NUM_DEV_CAPABILITIES,              /* bNumDeviceCaps */
+#if (USBD_WEBUSB_ENABLE)
+	USBD_WEBUSB_DESC_LEN,                   /* bLength */
+	USB_DEVICE_CAPABILITY_DESCRIPTOR_TYPE,  /* bDescriptorType */
+	USB_DEVICE_CAPABILITY_PLATFORM,         /* bDevCapabilityType */
+	0x00,                                   /* bReserved */
+	0x38, 0xB6, 0x08, 0x34,                 /* PlatformCapabilityUUID */
+	0xA9, 0x09, 0xA0, 0x47,
+	0x8B, 0xFD, 0xA0, 0x76,
+	0x88, 0x15, 0xB6, 0x65,
+	WBVAL(0x0100), /* 1.00 */               /* bcdVersion */
+	USBD_WEBUSB_VENDOR_CODE,                /* bVendorCode */
+	1,                                      /* iLandingPage */
+#endif
+#if (USBD_WINUSB_ENABLE)
+	USBD_WINUSB_DESC_LEN,                   /* bLength */
+	USB_DEVICE_CAPABILITY_DESCRIPTOR_TYPE,  /* bDescriptorType */
+	USB_DEVICE_CAPABILITY_PLATFORM,         /* bDevCapabilityType */
+	0x00,                                   /* bReserved */
+	0xDF, 0x60, 0xDD, 0xD8,                 /* PlatformCapabilityUUID */
+	0x89, 0x45, 0xC7, 0x4C,
+	0x9C, 0xD2, 0x65, 0x9D,
+	0x9E, 0x64, 0x8A, 0x9F,
+	0x00, 0x00, 0x03, 0x06, /* >= Win 8.1 *//* dwWindowsVersion*/
+	WBVAL(USBD_WINUSB_DESC_SET_LEN),        /* wDescriptorSetTotalLength */
+	USBD_WINUSB_VENDOR_CODE,                /* bVendorCode */
+	0,                                      /* bAltEnumCode */
+#endif
+};
+
+#else
+__weak \
+const U8 USBD_BinaryObjectStoreDescriptor[] = { 0 };
+
 #endif
 
 #define HID_DESC                                                                                            \
@@ -1654,6 +2059,18 @@ const U8 USBD_DeviceQualifier_HS[] = { 0 };
   HID_REPORT_DESCRIPTOR_TYPE,           /* bDescriptorType */                                               \
   WBVAL(USB_HID_REPORT_DESC_SIZE),      /* wDescriptorLength */
 
+#define HID_WEBUSB_DESC                                                                                            \
+  /* Interface, Alternate Setting 0, VENDOR_SPECIFIC Class */                                                           \
+  USB_INTERFACE_DESC_SIZE,              /* bLength */                                                       \
+  USB_INTERFACE_DESCRIPTOR_TYPE,        /* bDescriptorType */                                               \
+  USBD_HID_WEBUSB_IF_NUM,                /* bInterfaceNumber */                                              \
+  0x00,                                 /* bAlternateSetting */                                             \
+  0x01+(USBD_HID_WEBUSB_EP_INTOUT != 0),       /* bNumEndpoints */                                                 \
+  USB_DEVICE_CLASS_VENDOR_SPECIFIC,     /* bInterfaceClass */                                               \
+  USB_DEVICE_CLASS_HUMAN_INTERFACE,     /* bInterfaceSubClass */                                            \
+  HID_PROTOCOL_NONE,                    /* bInterfaceProtocol */                                            \
+  USBD_HID_WEBUSB_IF_STR_NUM,                  /* iInterface */                                                    \
+
 #define HID_EP                          /* HID Endpoint for Low-speed/Full-speed */                         \
 /* Endpoint, HID Interrupt In */                                                                            \
   USB_ENDPOINT_DESC_SIZE,               /* bLength */                                                       \
@@ -1676,6 +2093,32 @@ const U8 USBD_DeviceQualifier_HS[] = { 0 };
   USB_ENDPOINT_DESC_SIZE,               /* bLength */                                                       \
   USB_ENDPOINT_DESCRIPTOR_TYPE,         /* bDescriptorType */                                               \
   USB_ENDPOINT_OUT(USBD_HID_EP_INTOUT), /* bEndpointAddress */                                              \
+  USB_ENDPOINT_TYPE_INTERRUPT,          /* bmAttributes */                                                  \
+  WBVAL(USBD_HID_WMAXPACKETSIZE),       /* wMaxPacketSize */                                                \
+  USBD_HID_BINTERVAL,                   /* bInterval */
+	
+#define HID_WEBUSB_EP                          /* HID Endpoint for Low-speed/Full-speed */                         \
+/* Endpoint, HID Interrupt In */                                                                            \
+  USB_ENDPOINT_DESC_SIZE,               /* bLength */                                                       \
+  USB_ENDPOINT_DESCRIPTOR_TYPE,         /* bDescriptorType */                                               \
+  USB_ENDPOINT_IN(USBD_HID_WEBUSB_EP_INTIN),   /* bEndpointAddress */                                              \
+  USB_ENDPOINT_TYPE_INTERRUPT,          /* bmAttributes */                                                  \
+  WBVAL(USBD_HID_WMAXPACKETSIZE),       /* wMaxPacketSize */                                                \
+  USBD_HID_BINTERVAL,                   /* bInterval */
+
+#define HID_WEBUSB_EP_INOUT                    /* HID Endpoint for Low-speed/Full-speed */                         \
+/* Endpoint, HID Interrupt In */                                                                            \
+  USB_ENDPOINT_DESC_SIZE,               /* bLength */                                                       \
+  USB_ENDPOINT_DESCRIPTOR_TYPE,         /* bDescriptorType */                                               \
+  USB_ENDPOINT_IN(USBD_HID_WEBUSB_EP_INTIN),   /* bEndpointAddress */                                              \
+  USB_ENDPOINT_TYPE_INTERRUPT,          /* bmAttributes */                                                  \
+  WBVAL(USBD_HID_WMAXPACKETSIZE),       /* wMaxPacketSize */                                                \
+  USBD_HID_BINTERVAL,                   /* bInterval */                                                     \
+                                                                                                            \
+/* Endpoint, HID Interrupt Out */                                                                           \
+  USB_ENDPOINT_DESC_SIZE,               /* bLength */                                                       \
+  USB_ENDPOINT_DESCRIPTOR_TYPE,         /* bDescriptorType */                                               \
+  USB_ENDPOINT_OUT(USBD_HID_WEBUSB_EP_INTOUT), /* bEndpointAddress */                                              \
   USB_ENDPOINT_TYPE_INTERRUPT,          /* bmAttributes */                                                  \
   WBVAL(USBD_HID_WMAXPACKETSIZE),       /* wMaxPacketSize */                                                \
   USBD_HID_BINTERVAL,                   /* bInterval */
@@ -2037,15 +2480,6 @@ const U8 USBD_ConfigDescriptor[] = {
     MSC_EP
 #endif
 
-#if (USBD_HID_ENABLE)
-    HID_DESC
-#if (USBD_HID_EP_INTOUT != 0)
-    HID_EP_INOUT
-#else
-    HID_EP
-#endif
-#endif
-
 #if (USBD_CDC_ACM_ENABLE)
 #if (USBD_MULTI_IF)
     CDC_ACM_DESC_IAD(USBD_CDC_ACM_CIF_NUM, 2)
@@ -2055,6 +2489,25 @@ const U8 USBD_ConfigDescriptor[] = {
     CDC_ACM_DESC_IF1
     CDC_ACM_EP_IF1
 #endif
+
+#if (USBD_HID_ENABLE)
+    HID_DESC
+#if (USBD_HID_EP_INTOUT != 0)
+    HID_EP_INOUT
+#else
+    HID_EP
+#endif
+#endif
+
+#if (USBD_HID_WEBUSB_ENABLE)
+    HID_WEBUSB_DESC
+#if (USBD_HID_EP_INTOUT != 0)
+    HID_WEBUSB_EP_INOUT
+#else
+    HID_WEBUSB_EP
+#endif
+#endif
+
 
     /* Terminator */                                                                                            \
     0                                     /* bLength */                                                       \
@@ -2106,6 +2559,15 @@ const U8 USBD_ConfigDescriptor_HS[] = {
 #endif
 #endif
 
+#if (USBD_HID_WEBUSB_ENABLE)
+HID_WEBUSB_DESC
+ #if (USBD_HID_EP_INTOUT != 0)
+ HID_WEBUSB_EP_INOUT_HS
+ #else
+ HID_WEBUSB_EP_HS
+ #endif
+#endif
+
 #if (USBD_CDC_ACM_ENABLE)
 #if (USBD_MULTI_IF)
     CDC_ACM_DESC_IAD(USBD_CDC_ACM_CIF_NUM, 2)
@@ -2115,6 +2577,7 @@ const U8 USBD_ConfigDescriptor_HS[] = {
     CDC_ACM_DESC_IF1
     CDC_ACM_EP_IF1_HS
 #endif
+
 
     /* Terminator */                                                                                            \
     0                                     /* bLength */                                                       \
@@ -2162,10 +2625,20 @@ const U8 USBD_OtherSpeedConfigDescriptor[] = {
 #endif
 #endif
 
+#if (USBD_HID_WEBUSB_ENABLE)
+HID_WEBUSB_DESC
+ #if (USBD_HID_EP_INTOUT != 0)
+ HID_WEBUSB_EP_INOUT_HS
+ #else
+ HID_WEBUSB_EP_HS
+ #endif
+#endif
+
 #if (USBD_MSC_ENABLE)
     MSC_DESC
     MSC_EP_HS
 #endif
+
 
     /* Terminator */
     0                                     /* bLength */
@@ -2213,6 +2686,15 @@ const U8 USBD_OtherSpeedConfigDescriptor_HS[] = {
 #endif
 #endif
 
+#if (USBD_HID_WEBUSB_ENABLE)
+HID_WEBUSB_DESC
+ #if (USBD_HID_EP_INTOUT != 0)
+HID_WEBUSB_EP_INOUT
+ #else
+HID_WEBUSB_EP
+ #endif
+#endif
+
 #if (USBD_MSC_ENABLE)
     MSC_DESC
     MSC_EP
@@ -2258,6 +2740,9 @@ const struct {
 #if (USBD_HID_ENABLE)
     USBD_STR_DEF(HID_STRDESC);
 #endif
+#if (USBD_HID_WEBUSB_ENABLE)
+		USBD_STR_DEF(HID_WEBUSB_STRDESC);
+#endif
 #if (USBD_MSC_ENABLE)
     USBD_STR_DEF(MSC_STRDESC);
 #endif
@@ -2281,10 +2766,86 @@ const struct {
 #if (USBD_HID_ENABLE)
     USBD_STR_VAL(HID_STRDESC),
 #endif
+#if (USBD_HID_WEBUSB_ENABLE)
+		USBD_STR_VAL(HID_WEBUSB_STRDESC),
+#endif
 #if (USBD_MSC_ENABLE)
     USBD_STR_VAL(MSC_STRDESC),
 #endif
 };
+
+#if (USBD_WEBUSB_ENABLE)
+
+#define WEBUSB_NUM_FUNCTIONS              (1)
+
+#define WEBUSB_WTOTALLENGTH               (WEBUSB_DESCRIPTOR_SET_HEADER_SIZE +      \
+                                           WEBUSB_CONFIGURATION_SUBSET_HEADER_SIZE +\
+                                           (WEBUSB_NUM_FUNCTIONS * (WEBUSB_FUNCTION_SUBSET_HEADER_SIZE + 1)))
+
+__weak \
+const U8 USBD_WebUSBAllowedOriginsHeader[] = {
+    WEBUSB_DESCRIPTOR_SET_HEADER_SIZE,      /* bLength */
+	WEBUSB_DESCRIPTOR_SET_HEADER_TYPE,      /* bDescriptorType */
+	WBVAL(WEBUSB_WTOTALLENGTH),             /* wTotalLength */
+    0x01,                                   /* bNumConfigurations */
+    WEBUSB_CONFIGURATION_SUBSET_HEADER_SIZE,/* bLength */
+    WEBUSB_CONFIGURATION_SUBSET_HEADER_TYPE,/* bDescriptorType */
+    0x01,                                   /* bConfigurationValue */
+    WEBUSB_NUM_FUNCTIONS,                   /* bNumFunctions */
+#if (1)
+    (WEBUSB_FUNCTION_SUBSET_HEADER_SIZE+1), /* bLength */
+    WEBUSB_FUNCTION_SUBSET_HEADER_TYPE,     /* bDescriptorType */
+    USBD_WEBUSB_IF_NUM,                     /* bFirstInterfaceNumber */
+    0x01,                                   /* iOrigin */
+#endif
+};
+
+/* WebUSB Create URL Descriptor */
+#define WEBUSB_URL_DEF(n)       \
+  struct {                      \
+    U8  bLength;                \
+    U8  bDescriptorType;        \
+    U8  bScheme;                \
+    U8  URL[sizeof(USBD_##n)-1];\
+  } url##n
+
+#define WEBUSB_HTTP_URL_VAL(n)  \
+{                               \
+    (sizeof(USBD_##n) - 1) + 3, \
+    WEBUSB_URL_TYPE,            \
+    WEBUSB_URL_SCHEME_HTTP,     \
+    USBD_##n                    \
+}
+
+#define WEBUSB_HTTPS_URL_VAL(n) \
+{                               \
+    (sizeof(USBD_##n) - 1) + 3, \
+    WEBUSB_URL_TYPE,            \
+    WEBUSB_URL_SCHEME_HTTPS,    \
+    USBD_##n                    \
+}
+
+__weak \
+const struct {
+    WEBUSB_URL_DEF(WEBUSB_LANDING_URL);
+    WEBUSB_URL_DEF(WEBUSB_ORIGIN_URL);
+} USBD_WebUSBURLDescriptor
+= {
+    WEBUSB_HTTPS_URL_VAL(WEBUSB_LANDING_URL),
+    WEBUSB_HTTPS_URL_VAL(WEBUSB_ORIGIN_URL),
+};
+
+#else
+
+const U8 USBD_WebUSBAllowedOriginsHeader[] = { 0 };
+const U8 USBD_WebUSBURLDescriptor[] = { 0 };
+
+BOOL USBD_EndPoint0_Setup_WebUSB_ReqToDevice(void)
+{
+    return (__FALSE);
+}
+
+#endif
 
 #endif
 

--- a/source/usb/usb_lib.c
+++ b/source/usb/usb_lib.c
@@ -2806,12 +2806,12 @@ const U8 USBD_WebUSBAllowedOriginsHeader[] = {
     U8  bLength;                \
     U8  bDescriptorType;        \
     U8  bScheme;                \
-    U8  URL[sizeof(USBD_##n)-1];\
+    U8  URL[sizeof(USBD_##n)+8];\
   } url##n
 
 #define WEBUSB_HTTP_URL_VAL(n)  \
 {                               \
-    (sizeof(USBD_##n) - 1) + 3, \
+    (sizeof(USBD_##n) + 8) + 3, \
     WEBUSB_URL_TYPE,            \
     WEBUSB_URL_SCHEME_HTTP,     \
     USBD_##n                    \
@@ -2819,14 +2819,14 @@ const U8 USBD_WebUSBAllowedOriginsHeader[] = {
 
 #define WEBUSB_HTTPS_URL_VAL(n) \
 {                               \
-    (sizeof(USBD_##n) - 1) + 3, \
+    (sizeof(USBD_##n) + 8) + 3, \
     WEBUSB_URL_TYPE,            \
     WEBUSB_URL_SCHEME_HTTPS,    \
     USBD_##n                    \
 }
 
 __weak \
-const struct {
+struct {
     WEBUSB_URL_DEF(WEBUSB_LANDING_URL);
     WEBUSB_URL_DEF(WEBUSB_ORIGIN_URL);
 } USBD_WebUSBURLDescriptor
@@ -2838,7 +2838,7 @@ const struct {
 #else
 
 const U8 USBD_WebUSBAllowedOriginsHeader[] = { 0 };
-const U8 USBD_WebUSBURLDescriptor[] = { 0 };
+U8 USBD_WebUSBURLDescriptor[] = { 0 };
 
 BOOL USBD_EndPoint0_Setup_WebUSB_ReqToDevice(void)
 {

--- a/source/usb/usb_lib.h
+++ b/source/usb/usb_lib.h
@@ -29,6 +29,7 @@ extern U8 USBD_AltSetting[];
 extern U8 USBD_EP0Buf[];
 extern const U8 usbd_power;
 extern const U8 usbd_hs_enable;
+extern const U8 usbd_bos_enable;
 extern const U16 usbd_if_num;
 extern const U8 usbd_ep_num;
 extern const U8 usbd_max_packet0;
@@ -39,8 +40,11 @@ extern const U8 usbd_max_packet0;
  *----------------------------------------------------------------------------*/
 extern const U8 usbd_hid_enable;
 extern const U8 usbd_hid_if_num;
+extern const U8 usbd_hid_webusb_if_num;
 extern const U8 usbd_hid_ep_intin;
 extern const U8 usbd_hid_ep_intout;
+extern const U8 usbd_hid_webusb_ep_intin;
+extern const U8 usbd_hid_webusb_ep_intout;
 extern const U16 usbd_hid_interval     [2];
 extern const U16 usbd_hid_maxpacketsize[2];
 extern const U8 usbd_hid_inreport_num;
@@ -92,6 +96,10 @@ extern U8 USBD_CDC_ACM_SendBuf[];
 extern U8 USBD_CDC_ACM_ReceiveBuf[];
 extern U8 USBD_CDC_ACM_NotifyBuf[10];
 
+extern const U8 usbd_webusb_vendor_code;
+
+extern const U8 usbd_winusb_vendor_code;
+
 extern void usbd_os_evt_set(U16 event_flags, U32 task);
 extern U16 usbd_os_evt_get(void);
 extern U32 usbd_os_evt_wait_or(U16 wait_flags, U16 timeout);
@@ -114,6 +122,10 @@ extern const U8 USBD_OtherSpeedConfigDescriptor[];
 extern const U8 USBD_OtherSpeedConfigDescriptor_HS[];
 extern const U8 USBD_OtherSpeedConfigDescriptor[];
 extern const U8 USBD_OtherSpeedConfigDescriptor_HS[];
+extern const U8 USBD_BinaryObjectStoreDescriptor[];
 extern const U8 USBD_StringDescriptor[];
+extern const U8 USBD_WebUSBAllowedOriginsHeader[];
+extern const U8 USBD_WebUSBURLDescriptor[];
+extern const U8 USBD_WinUSBDescriptorSetDescriptor[];
 
 #endif  /* __USB_LIB_H__ */

--- a/source/usb/usb_webusb.h
+++ b/source/usb/usb_webusb.h
@@ -1,0 +1,71 @@
+/**
+ * @file    usb_webusb.h
+ * @brief   WebUSB driver header
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __USB_WEBUSB_H__
+#define __USB_WEBUSB_H__
+
+/* WebUSB Descriptor Types */
+#define WEBUSB_DESCRIPTOR_SET_HEADER_TYPE       0x00
+#define WEBUSB_CONFIGURATION_SUBSET_HEADER_TYPE 0x01
+#define WEBUSB_FUNCTION_SUBSET_HEADER_TYPE      0x02
+#define WEBUSB_URL_TYPE                         0x03
+
+/* WebUSB Platform Capability Descriptor */
+typedef __packed struct _WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
+    U8  bLength;
+    U8  bDescriptorType;
+    U8  bDevCapabilityType;
+    U8  bReserved;
+    U8  platformCapabilityUUID[16];
+    U16 bcdVersion;
+    U8  bVendorCode;
+    U8  iLandingPage;
+} WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR;
+
+typedef __packed struct _WEBUSB_ALLOWED_ORIGINS_HEADER_DESCRIPTOR {
+    U8  bLength;
+    U8  bDescriptorType;
+    U16 wTotalLength;
+    U8  bNumConfigurations;
+    U8  iOrigin[];
+} WEBUSB_ALLOWED_ORIGINS_HEADER_DESCRIPTOR;
+
+typedef __packed struct _WEBUSB_URL_DESCRIPTOR {
+    U8  bLength;
+    U8  bDescriptorType;
+    U8  bScheme;
+    char URL[];
+} WEBUSB_URL_DESCRIPTOR;
+
+/* WebUSB Request Codes */
+#define WEBUSB_REQUEST_GET_ALLOWED_ORIGINS      0x01
+#define WEBUSB_REQUEST_GET_URL                  0x02
+
+/* bScheme in URL descriptor */
+#define WEBUSB_URL_SCHEME_HTTP                  0x00
+#define WEBUSB_URL_SCHEME_HTTPS                 0x01
+
+/* WebUSB Descriptor sizes */
+#define WEBUSB_DESCRIPTOR_SET_HEADER_SIZE       5
+#define WEBUSB_CONFIGURATION_SUBSET_HEADER_SIZE 4
+#define WEBUSB_FUNCTION_SUBSET_HEADER_SIZE      3
+
+#endif  /* __USB_WEBUSB_H__ */

--- a/source/usb/usb_winusb.h
+++ b/source/usb/usb_winusb.h
@@ -1,0 +1,68 @@
+/**
+ * @file    usb_winusb.h
+ * @brief   WinUSB driver header
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __USB_WINUSB_H__
+#define __USB_WINUSB_H__
+
+/* WinUSB Microsoft OS 2.0 Descriptor Types */
+#define WINUSB_SET_HEADER_DESCRIPTOR_TYPE           0x00
+#define WINUSB_SUBSET_HEADER_CONFIGURATION_TYPE     0x01
+#define WINUSB_SUBSET_HEADER_FUNCTION_TYPE          0x02
+#define WINUSB_FEATURE_COMPATIBLE_ID_TYPE           0x03
+#define WINUSB_FEATURE_REG_PROPERTY_TYPE            0x04
+#define WINUSB_FEATURE_MIN_RESUME_TIME_TYPE         0x05
+#define WINUSB_FEATURE_MODEL_ID_TYPE                0x06
+#define WINUSB_FEATURE_CCGP_DEVICE_TYPE             0x07
+
+
+#define WINUSB_PROP_DATA_TYPE_REG_SZ                0x01
+#define WINUSB_PROP_DATA_TYPE_REG_MULTI_SZ          0x07
+
+/* WinUSB Microsoft OS 2.0 descriptor Platform Capability Descriptor */
+typedef __packed struct _WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
+    U8  bLength;
+    U8  bDescriptorType;
+    U8  bDevCapabilityType;
+    U8  bReserved;
+    U8  platformCapabilityUUID[16];
+    U32 dwWindowsVersion;
+    U16 wDescriptorSetTotalLength;
+    U8  bVendorCode;
+    U8  bAltEnumCode;
+} WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR;
+
+/* WinUSB Microsoft OS 2.0 descriptor set header */
+typedef __packed struct _WINUSB_DESCRIPTOR_SET_HEADER {
+    U16 wLength;
+    U16 wDescriptorType;
+    U32 dwWindowsVersion;
+    U16 wTotalLength;
+} WINUSB_DESCRIPTOR_SET_HEADER;
+
+/* WinUSB Microsoft OS 2.0 descriptor request codes */
+#define WINUSB_REQUEST_GET_DESCRIPTOR_SET          0x07
+#define WINUSB_REQUEST_SET_ALT_ENUM                0x08
+
+/* WinUSB Microsoft OS 2.0 descriptor sizes */
+#define WINUSB_DESCRIPTOR_SET_HEADER_SIZE          10
+#define WINUSB_FUNCTION_SUBSET_HEADER_SIZE         8
+#define WINUSB_FEATURE_COMPATIBLE_ID_SIZE          20
+#endif // __USB_WINUSB_H__

--- a/source/usb/usbd_core_webusb.h
+++ b/source/usb/usbd_core_webusb.h
@@ -1,6 +1,6 @@
 /**
- * @file    usb.h
- * @brief   USB Header
+ * @file    usbd_core_webusb.h
+ * @brief   USB Device Core WebUSB header
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -19,31 +19,12 @@
  * limitations under the License.
  */
 
-#ifndef __USB_H__
-#define __USB_H__
-
-/* General USB header files                                                   */
-#include "usb_def.h"
-#include "usb_cdc.h"
-#include "usb_hid.h"
-#include "usb_msc.h"
-#include "usb_webusb.h"
-#include "usb_winusb.h"
+#ifndef __USBD_CORE_WEBUSB_H__
+#define __USBD_CORE_WEBUSB_H__
 
 
-/* USB Device header files                                                    */
-#include "usbd_core.h"
-#include "usbd_core_cdc.h"
-#include "usbd_core_hid.h"
-#include "usbd_core_msc.h"
-#include "usbd_core_webusb.h"
-#include "usbd_core_winusb.h"
+/*--------------------------- Core overridable vendor specific functions ------*/
 
-#include "usbd_desc.h"
-#include "usbd_event.h"
-#include "usbd_cdc_acm.h"
-#include "usbd_hid.h"
-#include "usbd_msc.h"
-#include "usbd_hw.h"
+extern BOOL USBD_EndPoint0_Setup_WebUSB_ReqToDevice(void);
 
-#endif  /* __USB_H__ */
+#endif  /* __USBD_CORE_WEBUSB_H__ */

--- a/source/usb/usbd_core_winusb.h
+++ b/source/usb/usbd_core_winusb.h
@@ -1,6 +1,6 @@
 /**
- * @file    usb.h
- * @brief   USB Header
+ * @file    usbd_core_winusb.h
+ * @brief   USB Device Core WinUSB header
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -19,31 +19,12 @@
  * limitations under the License.
  */
 
-#ifndef __USB_H__
-#define __USB_H__
-
-/* General USB header files                                                   */
-#include "usb_def.h"
-#include "usb_cdc.h"
-#include "usb_hid.h"
-#include "usb_msc.h"
-#include "usb_webusb.h"
-#include "usb_winusb.h"
+#ifndef __USBD_CORE_WINUSB_H__
+#define __USBD_CORE_WINUSB_H__
 
 
-/* USB Device header files                                                    */
-#include "usbd_core.h"
-#include "usbd_core_cdc.h"
-#include "usbd_core_hid.h"
-#include "usbd_core_msc.h"
-#include "usbd_core_webusb.h"
-#include "usbd_core_winusb.h"
+/*--------------------------- Core overridable vendor specific functions ------*/
 
-#include "usbd_desc.h"
-#include "usbd_event.h"
-#include "usbd_cdc_acm.h"
-#include "usbd_hid.h"
-#include "usbd_msc.h"
-#include "usbd_hw.h"
+extern BOOL USBD_EndPoint0_Setup_WinUSB_ReqToDevice(void);
 
-#endif  /* __USB_H__ */
+#endif  /* __USBD_CORE_WINUSB_H__ */

--- a/source/usb/usbd_desc.h
+++ b/source/usb/usbd_desc.h
@@ -30,6 +30,7 @@
 #define USB_INTERFACE_ASSOC_DESC_SIZE     (sizeof(USB_INTERFACE_ASSOCIATION_DESCRIPTOR))
 #define USB_INTERFACE_DESC_SIZE           (sizeof(USB_INTERFACE_DESCRIPTOR))
 #define USB_ENDPOINT_DESC_SIZE            (sizeof(USB_ENDPOINT_DESCRIPTOR))
+#define USB_BOS_DESC_SIZE                 (sizeof(USB_BINARY_OBJECT_STORE_DESCRIPTOR))
 #define USB_HID_DESC_SIZE                 (sizeof(HID_DESCRIPTOR))
 #define USB_HID_REPORT_DESC_SIZE          (sizeof(USBD_HID_ReportDescriptor))
 

--- a/source/usb/usbd_hid.h
+++ b/source/usb/usbd_hid.h
@@ -42,6 +42,10 @@ extern void USBD_HID_EP_INTIN_Event(U32 event);
 extern void USBD_HID_EP_INTOUT_Event(U32 event);
 extern void USBD_HID_EP_INT_Event(U32 event);
 
+extern void USBD_HID_WEBUSB_EP_INTIN_Event(U32 event);
+extern void USBD_HID_WEBUSB_EP_INTOUT_Event(U32 event);
+extern void USBD_HID_WEBUSB_EP_INT_Event(U32 event);
+
 extern __task void USBD_RTX_HID_EP_INTIN_Event(void);
 extern __task void USBD_RTX_HID_EP_INTOUT_Event(void);
 extern __task void USBD_RTX_HID_EP_INT_Event(void);

--- a/source/usb/webusb/usbd_core_webusb.c
+++ b/source/usb/webusb/usbd_core_webusb.c
@@ -1,0 +1,92 @@
+/**
+ * @file    usbd_core_webusb.c
+ * @brief   WebUSB Device driver
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "string.h"
+
+#include "RTL.h"
+#include "rl_usb.h"
+#include "usb_for_lib.h"
+
+/*
+ *  USB Device Endpoint 0 Event Callback - WebUSB specific handling (Setup Request To Device)
+ *    Parameters:      none
+ *    Return Value:    TRUE - Setup vendor request ok, FALSE - Setup vendor request not supported
+ */
+
+__weak BOOL USBD_EndPoint0_Setup_WebUSB_ReqToDevice(void)
+{
+    U8  *pD;
+    U32 len, n;
+
+    BOOL success = (__FALSE);
+    if (USBD_SetupPacket.bRequest == usbd_webusb_vendor_code) {			/* vendor code correct? */
+        switch (USBD_SetupPacket.wIndex) {
+            case WEBUSB_REQUEST_GET_ALLOWED_ORIGINS:
+                pD = (U8 *)USBD_WebUSBAllowedOriginsHeader;
+                USBD_EP0Data.pData = pD;
+                len = ((WEBUSB_ALLOWED_ORIGINS_HEADER_DESCRIPTOR *)pD)->wTotalLength;
+                success = (__TRUE);
+                break;
+
+            case WEBUSB_REQUEST_GET_URL:
+                pD = (U8 *)USBD_WebUSBURLDescriptor;
+                if (USBD_SetupPacket.wValueL == 0) {
+                    success = (__FALSE);
+                    break;
+                }
+
+                for (n = 0; n + 1 < USBD_SetupPacket.wValueL; n++) {
+                    if (((WEBUSB_URL_DESCRIPTOR *)pD)->bLength != 0) {
+                        pD += ((WEBUSB_URL_DESCRIPTOR *)pD)->bLength;
+                    }
+                }
+
+                if (((WEBUSB_URL_DESCRIPTOR *)pD)->bLength == 0) {
+                    success = (__FALSE);
+                    break;
+                }
+
+                USBD_EP0Data.pData = pD;
+                len = ((WEBUSB_URL_DESCRIPTOR *)pD)->bLength;
+
+                success = (__TRUE);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    if (success) {
+        if (len < USBD_SetupPacket.wLength) {
+            USBD_EP0Data.Count = len;
+            if (!(len & (usbd_max_packet0 - 1))) {
+                USBD_ZLP = 1;
+            }
+        } else {
+            USBD_EP0Data.Count = USBD_SetupPacket.wLength;
+        }
+
+        USBD_DataInStage();
+    }
+
+    return success;
+}

--- a/source/usb/webusb/usbd_core_webusb.c
+++ b/source/usb/webusb/usbd_core_webusb.c
@@ -24,6 +24,7 @@
 #include "RTL.h"
 #include "rl_usb.h"
 #include "usb_for_lib.h"
+#include "info.h"
 
 /*
  *  USB Device Endpoint 0 Event Callback - WebUSB specific handling (Setup Request To Device)
@@ -63,7 +64,8 @@ __weak BOOL USBD_EndPoint0_Setup_WebUSB_ReqToDevice(void)
                     success = (__FALSE);
                     break;
                 }
-
+                strcat(((WEBUSB_URL_DESCRIPTOR *)pD)->URL, "&bid=");
+                strcat(((WEBUSB_URL_DESCRIPTOR *)pD)->URL, info_get_board_id());
                 USBD_EP0Data.pData = pD;
                 len = ((WEBUSB_URL_DESCRIPTOR *)pD)->bLength;
 

--- a/source/usb/winusb/usbd_core_winusb.c
+++ b/source/usb/winusb/usbd_core_winusb.c
@@ -1,0 +1,68 @@
+/**
+ * @file    usbd_core_winusb.c
+ * @brief   WinUSB Device driver
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "string.h"
+
+#include "RTL.h"
+#include "rl_usb.h"
+#include "usb_for_lib.h"
+
+/*
+ *  USB Device Endpoint 0 Event Callback - WinUSB specific handling (Setup Request To Device)
+ *    Parameters:      none
+ *    Return Value:    TRUE - Setup vendor request ok, FALSE - Setup vendor request not supported
+ */
+
+__weak BOOL USBD_EndPoint0_Setup_WinUSB_ReqToDevice(void)
+{
+    U8  *pD;
+    U32 len;
+
+    BOOL success = (__FALSE);
+    if (USBD_SetupPacket.bRequest == usbd_winusb_vendor_code) {			/* vendor code correct? */
+        switch (USBD_SetupPacket.wIndex) {
+            case WINUSB_REQUEST_GET_DESCRIPTOR_SET:
+                pD = (U8 *)USBD_WinUSBDescriptorSetDescriptor;
+                USBD_EP0Data.pData = pD;
+                len = ((WINUSB_DESCRIPTOR_SET_HEADER *)pD)->wTotalLength;
+                success = (__TRUE);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    if (success) {
+        if (len < USBD_SetupPacket.wLength) {
+            USBD_EP0Data.Count = len;
+            if (!(len & (usbd_max_packet0 - 1))) {
+                USBD_ZLP = 1;
+            }
+        } else {
+            USBD_EP0Data.Count = USBD_SetupPacket.wLength;
+        }
+
+        USBD_DataInStage();
+    }
+
+    return success;
+}


### PR DESCRIPTION
Add Microsoft OS 2.0 Descriptor support

Requirement: Google Chrome 61+
Tested with FRDM-K64F and Microbit on:

- Windows: 8.1, 10
- Mac OS 10.10, 10.12, 10.13
- Ubuntu 16.04

Known issues:
- Landing page is disabled temporary on Windows, more information here: https://github.com/WICG/webusb#implementation-status
- on Linux udev rule is required for WebUSB to work. More information here in `Tips` section: https://developers.google.com/web/updates/2016/03/access-usb-devices-on-the-web

Missing:
- Landing page needs to be modified to use new redirection service on os.mbed.com (https://os.mbed.com/webusb?vid={vendor_id}&board_id={board_id}. Not live yet.

@c1728p9 @cederom @sg- @thegecko @flit