### PR TITLE
Add error type to FAIL.txt

### DIFF
--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -314,13 +314,15 @@ static uint32_t read_file_details_txt(uint32_t sector_offset, uint8_t *data, uin
 }
 
 // Text representation of each error type, starting from the rightmost bit
-static const char* error_type_names[] = {
+static const char* const error_type_names[] = {
     "internal",
     "transient",
     "user",
     "target",
     "interface"
 };
+
+COMPILER_ASSERT(1 << ARRAY_SIZE(error_type_names) == ERROR_TYPE_MASK + 1);
 
 // File callback to be used with vfs_add_file to return file contents
 static uint32_t read_file_fail_txt(uint32_t sector_offset, uint8_t *data, uint32_t num_sectors)

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -56,7 +56,7 @@ static const char mbed_redirect_file[] =
     "</html>\r\n";
 
 static const char error_prefix[] = "error: ";
-static const char error_type_prefix[] = "error type: ";
+static const char error_type_prefix[] = "type: ";
 
 static const vfs_filename_t assert_file = "ASSERT  TXT";
 
@@ -330,7 +330,7 @@ static uint32_t read_file_fail_txt(uint32_t sector_offset, uint8_t *data, uint32
     uint32_t size = 0;
     char *buf = (char *)data;
     error_t status = vfs_mngr_get_transfer_status();
-    const char *contents = (const char *)error_get_string(status);
+    const char *contents = error_get_string(status);
     error_type_t type = error_get_type(status);
 
     if (sector_offset != 0) {

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -55,6 +55,9 @@ static const char mbed_redirect_file[] =
     "</body>\r\n"
     "</html>\r\n";
 
+static const char error_prefix[] = "error: ";
+static const char error_type_prefix[] = "error type: ";
+
 static const vfs_filename_t assert_file = "ASSERT  TXT";
 
 static uint8_t file_buffer[VFS_SECTOR_SIZE];
@@ -311,14 +314,27 @@ static uint32_t read_file_details_txt(uint32_t sector_offset, uint8_t *data, uin
 // File callback to be used with vfs_add_file to return file contents
 static uint32_t read_file_fail_txt(uint32_t sector_offset, uint8_t *data, uint32_t num_sectors)
 {
-    const char *contents = (const char *)error_get_string(vfs_mngr_get_transfer_status());
-    uint32_t size = strlen(contents);
+    uint32_t size = 0;
+    error_t status = vfs_mngr_get_transfer_status();
+    const char *contents = (const char *)error_get_string(status);
+    const char *type = (const char *)error_get_type(status);
 
     if (sector_offset != 0) {
         return 0;
     }
 
-    memcpy(data, contents, size);
+    memcpy(data + size, error_prefix, strlen(error_prefix));
+    size += strlen(error_prefix);
+    memcpy(data + size, contents, strlen(contents));
+    size += strlen(contents);
+    data[size] = '\r';
+    size++;
+    data[size] = '\n';
+    size++;
+    memcpy(data + size, error_type_prefix, strlen(error_type_prefix));
+    size += strlen(error_type_prefix);
+    memcpy(data + size, type, strlen(type));
+    size += strlen(type);
     data[size] = '\r';
     size++;
     data[size] = '\n';

--- a/source/daplink/error.c
+++ b/source/daplink/error.c
@@ -231,7 +231,7 @@ const char *error_get_string(error_t error)
 
 error_type_t error_get_type(error_t error)
 {
-    error_type_t type = 0;
+    error_type_t type = ERROR_TYPE_INTERNAL;
 
     if (error < ERROR_COUNT) {
         type = error_type[error];

--- a/source/daplink/error.c
+++ b/source/daplink/error.c
@@ -117,6 +117,100 @@ static const char *const error_message[] = {
     "The bootloader CRC did not pass.",
 
 };
+
+static const char *const error_type[] = {
+
+    /* These should always stay the same for each error type. */
+
+    // ERROR_SUCCESS
+    "",
+    // ERROR_FAILURE
+    "internal",
+    // ERROR_INTERNAL
+    "internal",
+
+    /* VFS user errors */
+
+    // ERROR_ERROR_DURING_TRANSFER
+    "transient",
+    // ERROR_TRANSFER_TIMEOUT
+    "user",
+    // ERROR_FILE_BOUNDS
+    "transient",
+    // ERROR_OOO_SECTOR
+    "transient",
+
+    /* Target flash errors */
+
+    // ERROR_RESET
+    "target",
+    // ERROR_ALGO_DL
+    "target",
+    // ERROR_ALGO_DATA_SEQ
+    "target",
+    // ERROR_INIT
+    "target",
+    // ERROR_SECURITY_BITS
+    "user",
+    // ERROR_UNLOCK
+    "target",
+    // ERROR_ERASE_SECTOR
+    "target",
+    // ERROR_ERASE_ALL
+    "target",
+    // ERROR_WRITE
+    "target",
+
+    /* File stream errors */
+
+    // ERROR_SUCCESS_DONE
+    "internal",
+    // ERROR_SUCCESS_DONE_OR_CONTINUE
+    "internal",
+    // ERROR_HEX_CKSUM
+    "user",
+    // ERROR_HEX_PARSER
+    "user",
+    // ERROR_HEX_PROGRAM
+    "user",
+    // ERROR_HEX_INVALID_ADDRESS
+    "user",
+    // ERROR_HEX_INVALID_APP_OFFSET
+    "user",
+
+    /* Flash decoder errors */
+
+    // ERROR_FD_BL_UPDT_ADDR_WRONG
+    "user",
+    // ERROR_FD_INTF_UPDT_ADDR_WRONG
+    "user",
+    // ERROR_FD_UNSUPPORTED_UPDATE
+    "user",
+
+    /* Flash IAP interface */
+
+    // ERROR_IAP_INIT
+    "interface",
+    // ERROR_IAP_UNINIT
+    "interface",
+    // ERROR_IAP_WRITE
+    "interface",
+    // ERROR_IAP_ERASE_SECTOR
+    "interface",
+    // ERROR_IAP_ERASE_ALL
+    "interface",
+    // ERROR_IAP_OUT_OF_BOUNDS
+    "interface",
+    // ERROR_IAP_UPDT_NOT_SUPPORTED
+    "interface",
+    // ERROR_IAP_UPDT_INCOMPLETE
+    "interface",
+    // ERROR_IAP_NO_INTERCEPT
+    "interface",
+    // ERROR_BL_UPDT_BAD_CRC
+    "interface",
+};
+
 COMPILER_ASSERT(ERROR_COUNT == ELEMENTS_IN_ARRAY(error_message));
 
 const char *error_get_string(error_t error)
@@ -133,4 +227,20 @@ const char *error_get_string(error_t error)
     }
 
     return msg;
+}
+
+const char *error_get_type(error_t error)
+{
+    const char *type = 0;
+
+    if (error < ERROR_COUNT) {
+        type = error_type[error];
+    }
+
+    if (0 == type) {
+        util_assert(0);
+        type = "";
+    }
+
+    return type;
 }

--- a/source/daplink/error.c
+++ b/source/daplink/error.c
@@ -118,97 +118,97 @@ static const char *const error_message[] = {
 
 };
 
-static const char *const error_type[] = {
+static error_type_t error_type[] = {
 
     /* These should always stay the same for each error type. */
 
     // ERROR_SUCCESS
-    "",
+    0,
     // ERROR_FAILURE
-    "internal",
+    ERROR_TYPE_INTERNAL,
     // ERROR_INTERNAL
-    "internal",
+    ERROR_TYPE_INTERNAL,
 
     /* VFS user errors */
 
     // ERROR_ERROR_DURING_TRANSFER
-    "transient",
+    ERROR_TYPE_TRANSIENT,
     // ERROR_TRANSFER_TIMEOUT
-    "user",
+    ERROR_TYPE_USER | ERROR_TYPE_TRANSIENT,
     // ERROR_FILE_BOUNDS
-    "transient",
+    ERROR_TYPE_TRANSIENT,
     // ERROR_OOO_SECTOR
-    "transient",
+    ERROR_TYPE_TRANSIENT,
 
     /* Target flash errors */
 
     // ERROR_RESET
-    "target",
+    ERROR_TYPE_TARGET,
     // ERROR_ALGO_DL
-    "target",
+    ERROR_TYPE_TARGET,
     // ERROR_ALGO_DATA_SEQ
-    "target",
+    ERROR_TYPE_TARGET,
     // ERROR_INIT
-    "target",
+    ERROR_TYPE_TARGET,
     // ERROR_SECURITY_BITS
-    "user",
+    ERROR_TYPE_USER,
     // ERROR_UNLOCK
-    "target",
+    ERROR_TYPE_TARGET,
     // ERROR_ERASE_SECTOR
-    "target",
+    ERROR_TYPE_TARGET,
     // ERROR_ERASE_ALL
-    "target",
+    ERROR_TYPE_TARGET,
     // ERROR_WRITE
-    "target",
+    ERROR_TYPE_TARGET,
 
     /* File stream errors */
 
     // ERROR_SUCCESS_DONE
-    "internal",
+    ERROR_TYPE_INTERNAL,
     // ERROR_SUCCESS_DONE_OR_CONTINUE
-    "internal",
+    ERROR_TYPE_INTERNAL,
     // ERROR_HEX_CKSUM
-    "user",
+    ERROR_TYPE_USER | ERROR_TYPE_TRANSIENT,
     // ERROR_HEX_PARSER
-    "user",
+    ERROR_TYPE_USER | ERROR_TYPE_TRANSIENT,
     // ERROR_HEX_PROGRAM
-    "user",
+    ERROR_TYPE_USER | ERROR_TYPE_TRANSIENT,
     // ERROR_HEX_INVALID_ADDRESS
-    "user",
+    ERROR_TYPE_USER,
     // ERROR_HEX_INVALID_APP_OFFSET
-    "user",
+    ERROR_TYPE_USER,
 
     /* Flash decoder errors */
 
     // ERROR_FD_BL_UPDT_ADDR_WRONG
-    "user",
+    ERROR_TYPE_USER,
     // ERROR_FD_INTF_UPDT_ADDR_WRONG
-    "user",
+    ERROR_TYPE_USER,
     // ERROR_FD_UNSUPPORTED_UPDATE
-    "user",
+    ERROR_TYPE_USER,
 
     /* Flash IAP interface */
 
     // ERROR_IAP_INIT
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_UNINIT
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_WRITE
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_ERASE_SECTOR
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_ERASE_ALL
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_OUT_OF_BOUNDS
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_UPDT_NOT_SUPPORTED
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_UPDT_INCOMPLETE
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_IAP_NO_INTERCEPT
-    "interface",
+    ERROR_TYPE_INTERFACE,
     // ERROR_BL_UPDT_BAD_CRC
-    "interface",
+    ERROR_TYPE_INTERFACE,
 };
 
 COMPILER_ASSERT(ERROR_COUNT == ELEMENTS_IN_ARRAY(error_message));
@@ -229,17 +229,12 @@ const char *error_get_string(error_t error)
     return msg;
 }
 
-const char *error_get_type(error_t error)
+error_type_t error_get_type(error_t error)
 {
-    const char *type = 0;
+    error_type_t type = 0;
 
     if (error < ERROR_COUNT) {
         type = error_type[error];
-    }
-
-    if (0 == type) {
-        util_assert(0);
-        type = "";
     }
 
     return type;

--- a/source/daplink/error.h
+++ b/source/daplink/error.h
@@ -90,7 +90,11 @@ typedef unsigned char error_type_t;
 #define ERROR_TYPE_USER 0x4
 #define ERROR_TYPE_TARGET 0x8
 #define ERROR_TYPE_INTERFACE 0x10
-// If you add another error type, update read_file_fail_txt()
+// If you add another error type:
+// 1. update error_type_names, used by read_file_fail_txt()
+// 2. update ERROR_TYPE_MASK
+// 3. make sure that error type bits still fit inside of error_type_t
+#define ERROR_TYPE_MASK 0x1F
 
 error_type_t error_get_type(error_t error);
 

--- a/source/daplink/error.h
+++ b/source/daplink/error.h
@@ -82,7 +82,17 @@ typedef enum {
 } error_t;
 
 const char *error_get_string(error_t error);
-const char *error_get_type(error_t error);
+
+typedef unsigned char error_type_t;
+
+#define ERROR_TYPE_INTERNAL 0x1
+#define ERROR_TYPE_TRANSIENT 0x2
+#define ERROR_TYPE_USER 0x4
+#define ERROR_TYPE_TARGET 0x8
+#define ERROR_TYPE_INTERFACE 0x10
+// If you add another error type, update read_file_fail_txt()
+
+error_type_t error_get_type(error_t error);
 
 #ifdef __cplusplus
 }

--- a/source/daplink/error.h
+++ b/source/daplink/error.h
@@ -26,7 +26,7 @@
 }
 #endif
 
-// Keep in sync with the list error_message
+// Keep in sync with the lists error_message and error_type
 typedef enum {
     /* Shared errors */
     ERROR_SUCCESS = 0,
@@ -82,6 +82,7 @@ typedef enum {
 } error_t;
 
 const char *error_get_string(error_t error);
+const char *error_get_type(error_t error);
 
 #ifdef __cplusplus
 }

--- a/test/daplink_board.py
+++ b/test/daplink_board.py
@@ -265,7 +265,7 @@ class DaplinkBoard(object):
             with open(fail_file, 'rb') as fail_file_handle:
                 msg = fail_file_handle.read()
                 lines = msg.splitlines()
-                if lines == 2:
+                if len(lines) == 2:
                     if lines[0].startswith('error: '):
                         error = lines[0][7:]
                     else:

--- a/test/daplink_board.py
+++ b/test/daplink_board.py
@@ -270,10 +270,10 @@ class DaplinkBoard(object):
                         error = lines[0][7:]
                     else:
                         raise Exception('Can not parse error line in FAIL.TXT')
-                    if lines[1].startswith('error type: '):
+                    if lines[1].startswith('type: '):
                         error_type = lines[1][12:]
                     else:
-                        raise Exception('Can not parse error type line in FAIL.TXT')
+                        raise Exception('Can not parse type line in FAIL.TXT')
                 else:
                     raise Exception('Wrong number of lines in FAIL.TXT, expected: 2')
         return error, error_type

--- a/test/daplink_board.py
+++ b/test/daplink_board.py
@@ -271,7 +271,7 @@ class DaplinkBoard(object):
                     else:
                         raise Exception('Can not parse error line in FAIL.TXT')
                     if lines[1].startswith('type: '):
-                        error_type = lines[1][12:]
+                        error_type = lines[1][6:]
                     else:
                         raise Exception('Can not parse type line in FAIL.TXT')
                 else:

--- a/test/daplink_board.py
+++ b/test/daplink_board.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
- 
+
 from __future__ import absolute_import
 
 import os
@@ -251,19 +251,32 @@ class DaplinkBoard(object):
         """Check if the board is connected"""
         return os.path.isdir(self.mount_point)
 
-    def get_failure_message(self):
-        """Get the failure message from fail.txt
+    def get_failure_message_and_type(self):
+        """Get the failure message and types from fail.txt
 
         return None if there there is no failure
         """
-        msg = None
+        error = None
+        error_type = None
         fail_file = self.get_file_path('FAIL.TXT')
         if not self.get_connected():
             raise Exception('Board not connected')
         if os.path.isfile(fail_file):
             with open(fail_file, 'rb') as fail_file_handle:
                 msg = fail_file_handle.read()
-        return msg
+                lines = msg.splitlines()
+                if lines == 2:
+                    if lines[0].startswith('error: '):
+                        error = lines[0][7:]
+                    else:
+                        raise Exception('Can not parse error line in FAIL.TXT')
+                    if lines[1].startswith('error type: '):
+                        error_type = lines[1][12:]
+                    else:
+                        raise Exception('Can not parse error type line in FAIL.TXT')
+                else:
+                    raise Exception('Wrong number of lines in FAIL.TXT, expected: 2')
+        return error, error_type
 
     def get_assert_info(self):
         """Return an AssertInfo if an assert occurred, else None"""

--- a/test/msd_test.py
+++ b/test/msd_test.py
@@ -247,7 +247,7 @@ class MassStorageTester(object):
             if msg == self._expected_failure_msg and error_type == self._expected_failure_type:
                 test_info.info(
                     'Failure as expected: "%s, %s"' %
-                    msg.strip(), error_type.strip())
+                    (msg.strip(), error_type.strip()))
             elif msg != self._expected_failure_msg:
                 test_info.failure('Failure but wrong string: "%s" vs "%s"' %
                                   (msg.strip(),

--- a/test/test_daplink.py
+++ b/test/test_daplink.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
- 
+
 from __future__ import absolute_import
 
 import os
@@ -279,7 +279,7 @@ def test_file_type(file_type, board_mode, board, parent_test,
     test.set_programming_data(local_data, file_name)
     test.set_expected_data(None)
     test.set_expected_failure_msg("In application programming failed because "
-                                  "the update sent was incomplete.\r\n")
+                                  "the update sent was incomplete.", "interface")
     test.set_expected_mode(board_mode)
     test.run()
     # If bootloader is missing then this should be indicated by a file
@@ -313,15 +313,15 @@ def test_file_type(file_type, board_mode, board, parent_test,
     if file_type != 'bin':
         mode_to_error = {
             board.MODE_IF: ('The starting address for the bootloader '
-                            'update is wrong.\r\n'),
+                            'update is wrong.'),
             board.MODE_BL: ('The starting address for the interface '
-                            'update is wrong.\r\n')
+                            'update is wrong.')
         }
         file_name = get_file_name()
         local_data = get_file_content(data_start + 0x400, raw_data)
         test = DLMassStorageTester(board, test_info, "Wrong Address",
                                    board_mode)
-        test.set_expected_failure_msg(mode_to_error[board_mode])
+        test.set_expected_failure_msg(mode_to_error[board_mode], 'user')
         test.set_programming_data(local_data, file_name)
         test.set_expected_data(raw_data)
         test.set_expected_mode(board_mode)
@@ -347,7 +347,7 @@ def test_file_type(file_type, board_mode, board, parent_test,
                                board_mode)
     test.set_programming_data(local_data, file_name)
     if board_mode == board.MODE_IF:
-        test.set_expected_failure_msg('The bootloader CRC did not pass.\r\n')
+        test.set_expected_failure_msg('The bootloader CRC did not pass.', 'interface')
         test.set_expected_data(None)
     elif board_mode == board.MODE_BL:
         # Interface images can be from other vendors and be missing
@@ -381,7 +381,7 @@ def test_file_type(file_type, board_mode, board, parent_test,
         test = DLMassStorageTester(board, test_info, 'Wrong data CRC',
                                    board_mode)
         test.set_programming_data(local_data, file_name)
-        test.set_expected_failure_msg('The bootloader CRC did not pass.\r\n')
+        test.set_expected_failure_msg('The bootloader CRC did not pass.', 'interface')
         test.set_expected_data(None)
         test.set_expected_mode(board.MODE_IF)
         test.run()


### PR DESCRIPTION
This patch adds error type information to FAIL.txt in case of failures to flash.

e.g.
currently in FAIL.txt
File sent out of order by PC. Target might be programmed correctly.
 
new FAIL.txt
error: File sent out of order by PC. Target might be programmed correctly.
error type: transient, user