### PR TITLE
Add support for NRF52840-DK board

### DIFF
--- a/source/board/mkit_dk_dongle_nrf5x.c
+++ b/source/board/mkit_dk_dongle_nrf5x.c
@@ -21,6 +21,7 @@
  
 #include "sam3u2c.h"
 #include "target_config.h"
+#include "util.h"
 
 const char *board_id = "";
 
@@ -29,9 +30,12 @@ const char *board_id_nrf51_mkit = "1070";
 const char *board_id_nrf51_dk = "1100";
 const char *board_id_nrf51_dongle = "1120";
 const char *board_id_nrf52_dk = "1101";
+const char *board_id_nrf52840_dk = "1102";
 
 
 extern target_cfg_t target_device_nrf52;
+extern target_cfg_t target_device_nrf52840;
+
 static void set_target_device(uint32_t device)
 {
     if (device == 0) {
@@ -40,41 +44,72 @@ static void set_target_device(uint32_t device)
     else if (device == 1) {
         target_device = target_device_nrf52;
     }
+    else if (device == 2) {
+        target_device = target_device_nrf52840;
+    }
 }
+
 
 void prerun_board_config(void)
 {
     // Work around for setting the correct board id based on GPIOs
     uint8_t bit1;
     uint8_t bit2;
+    uint8_t bit3;
     
     PIOB->PIO_PER = (1 << 1); // Enable PIO pin PB1
     PIOB->PIO_PER = (1 << 2); // Enable PIO pin PB2
+    PIOB->PIO_PER = (1 << 3); // Enable PIO pin PB3
     PIOB->PIO_ODR = (1 << 1); // Disabe output
     PIOB->PIO_ODR = (1 << 2); // Disabe output
+    PIOB->PIO_ODR = (1 << 3); // Disabe output
     PIOB->PIO_PUER = (1 << 1); // Enable pull-up 
     PIOB->PIO_PUER = (1 << 2); // Enable pull-up
+    PIOB->PIO_PUER = (1 << 3); // Enable pull-up
     
     bit1 = (PIOB->PIO_PDSR >> 1) & 1; // Read PB1
     bit2 = (PIOB->PIO_PDSR >> 2) & 1; // Read PB2
-    
-    if (!bit2 && bit1) {
-        board_id = board_id_nrf51_dk;  // 1100
-        set_target_device(0);
-    }
-    else if (!bit2 && !bit1) {
-        board_id = board_id_nrf51_dongle;  // 1120
-        set_target_device(0);
-    }
-    else if (bit2 && !bit1) {
-        board_id = board_id_nrf52_dk;  // 1101
-        set_target_device(1);
-    }
-    else { //mkit
+    bit3 = (PIOB->PIO_PDSR >> 3) & 1; // Read PB3
+
+    /* pins translate to board-ids as follow
+     *
+     *  PB3|PB2|PB1|BOARD ID| BOARD
+     *  ----------------------------------
+     *   0 | 0 | 0 |  1120  | nRF51-Dongle
+     *   0 | 0 | 1 |  1100  | nRF51-DK
+     *   0 | 1 | 0 |  1101  | nRF52-DK
+     *   0 | 1 | 1 |  1102  | nRF52840-DK
+     *   1 | 1 | 1 |  1070  | older nRF51 (mkit)
+     *   1 | 0 | 0 |    undefined
+     *   1 | 0 | 1 |    undefined
+     *   1 | 1 | 0 |    undefined
+     */
+
+
+    if (bit3) {
         board_id = board_id_nrf51_mkit;  // 1070
         set_target_device(0);
+        //Note only a setting of 111 is defined
+        util_assert(bit2 && bit1);
+    } else {
+        if (!bit2 && bit1) {
+            board_id = board_id_nrf51_dk;  // 1100
+            set_target_device(0);
+        }
+        else if (!bit2 && !bit1) {
+            board_id = board_id_nrf51_dongle;  // 1120
+            set_target_device(0);
+        }
+        else if (bit2 && !bit1) {
+            board_id = board_id_nrf52_dk;  // 1101
+            set_target_device(1);
+        } else { //(bit2 && bit1)
+            board_id = board_id_nrf52840_dk;  // 1102
+            set_target_device(2);
+        }
     }
     
     PIOB->PIO_PUDR = (1 << 1); // Disable pull-up 
     PIOB->PIO_PUDR = (1 << 2); // Disable pull-up
+    PIOB->PIO_PUDR = (1 << 3); // Disable pull-up
 }

--- a/source/target/nordic/nrf5x/target.c
+++ b/source/target/nordic/nrf5x/target.c
@@ -46,3 +46,14 @@ target_cfg_t target_device_nrf52 = {
     .flash_algo     = (program_target_t *) &flash_nrf52,
     .erase_reset    = 1,
 };
+
+target_cfg_t target_device_nrf52840 = {
+    .sector_size    = 4096,
+    .sector_cnt     = (KB(1024) / 4096),
+    .flash_start    = 0,
+    .flash_end      = KB(1024),
+    .ram_start      = 0x20000000,
+    .ram_end        = 0x20008000,
+    .flash_algo     = (program_target_t *) &flash_nrf52,
+    .erase_reset    = 1,
+};

--- a/source/target/nordic/target_reset_nrf5x_sam3u2c.c
+++ b/source/target/nordic/target_reset_nrf5x_sam3u2c.c
@@ -50,19 +50,25 @@ void swd_set_target_reset(uint8_t asserted)
     board_id = info_get_board_id();
     uint32_t ap_index_return;
     uint8_t nrf52_dk_is_used;
+    uint8_t nrf52840_dk_is_used;
     uint8_t ublox_evk_nina_b1_used;
 
-    nrf52_dk_is_used =      (   board_id[0] == '1' 
+    nrf52_dk_is_used =      (   board_id[0] == '1'
                                 && board_id[1] == '1'
                                 && board_id[2] == '0'
                                 && board_id[3] == '1') ? 1 : 0;  // ID 1101 is the nrf52-dk
-								
-    ublox_evk_nina_b1_used = (  board_id[0] == '1' 
+
+    nrf52840_dk_is_used =   (   board_id[0] == '1'
+                                && board_id[1] == '1'
+                                && board_id[2] == '0'
+                                && board_id[3] == '2') ? 1 : 0;  // ID 1102 is the nrf52840-dk
+
+    ublox_evk_nina_b1_used = (  board_id[0] == '1'
                                 && board_id[1] == '2'
                                 && board_id[2] == '3'
                                 && board_id[3] == '7') ? 1 : 0;  // ID 1237 is the UBLOX_EVK_NINA_B1 which is based on NRF52
 
-    if (nrf52_dk_is_used || ublox_evk_nina_b1_used) {
+    if (nrf52_dk_is_used || nrf52840_dk_is_used || ublox_evk_nina_b1_used) {
         if (asserted) {
             swd_init_debug();
             


### PR DESCRIPTION
Based on pins PB1, PB2, PB3, set board id to 1102 for NRF52840-DK.

Signed-off-by: Kyle Stein <kyle.stein@arm.com>