### PR TITLE
Support devices with sectors less than 256 bytes

### DIFF
--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -172,7 +172,9 @@ static error_t target_flash_erase_chip(void)
 static uint32_t target_flash_program_page_min_size(uint32_t addr)
 {
     uint32_t size = 256;
-    util_assert(target_device.sector_size >= size);
+    if (size > target_device.sector_size) {
+        size = target_device.sector_size;
+    }
     return size;
 }
 


### PR DESCRIPTION
If a device's sector is smaller than 256 bytes then set the minimum programming size to the sector size rather than asserting.