### PR TITLE
Unrevert K64F sector erase change

### DIFF
--- a/source/board/frdmk64f.c
+++ b/source/board/frdmk64f.c
@@ -18,5 +18,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ 
+#include "stdbool.h"
+#include "flash_manager.h"
 
 const char *board_id = "0240";
+
+void prerun_board_config(void)
+{
+    flash_manager_set_page_erase(true);
+}

--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -141,7 +141,7 @@ static error_t target_flash_erase_sector(uint32_t addr)
     const program_target_t *const flash = target_device.flash_algo;
 
     // Check to make sure the address is on a sector boundary
-    if ((addr % target_device.sector_size) != 0) {
+    if ((addr % target_flash_erase_sector_size(addr)) != 0) {
         return ERROR_ERASE_SECTOR;
     }
 
@@ -172,13 +172,21 @@ static error_t target_flash_erase_chip(void)
 static uint32_t target_flash_program_page_min_size(uint32_t addr)
 {
     uint32_t size = 256;
-    if (size > target_device.sector_size) {
-        size = target_device.sector_size;
+    if (size > target_flash_erase_sector_size(addr)) {
+        size = target_flash_erase_sector_size(addr);
     }
     return size;
 }
 
 static uint32_t target_flash_erase_sector_size(uint32_t addr)
 {
+    if(target_device.sector_info_length > 0) { 
+        int sector_index = target_device.sector_info_length - 1;
+        for (; sector_index >= 0; sector_index--) {
+            if (addr >= target_device.sectors_info[sector_index].start) {
+                return target_device.sectors_info[sector_index].size;
+            }
+        }
+    }
     return target_device.sector_size;
 }

--- a/source/hic_hal/flash_blob.h
+++ b/source/hic_hal/flash_blob.h
@@ -48,6 +48,11 @@ typedef struct {
     const uint32_t  program_buffer_size;
 } program_target_t;
 
+typedef struct {
+    const uint32_t start;
+    const uint32_t size;
+} sector_info_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/hic_hal/target_config.h
+++ b/source/hic_hal/target_config.h
@@ -53,6 +53,8 @@ typedef struct target_cfg {
     uint32_t ram_end;               /*!< Highest contigous RAM address the application uses */
     program_target_t *flash_algo;   /*!< A pointer to the flash algorithm structure */
     uint8_t erase_reset;            /*!< Reset after performing an erase */
+    const sector_info_t* sectors_info; 
+    int sector_info_length;
 } target_cfg_t;
 
 extern target_cfg_t target_device;

--- a/source/target/freescale/k64f/flash_blob.c
+++ b/source/target/freescale/k64f/flash_blob.c
@@ -61,6 +61,10 @@ static const uint32_t K64F_FLM[] = {
     0x00400000, 0x00800000, 0x01000000, 0x01000000, 0x40020004, 0x00000000,
 };
 
+static const sector_info_t sectors_info[] = {
+    {0x00000000, 0x00001000},
+ };
+
 static const program_target_t flash = {
     0x20000021, // Init
     0x20000049, // UnInit

--- a/source/target/freescale/k64f/target.c
+++ b/source/target/freescale/k64f/target.c
@@ -3,7 +3,7 @@
  * @brief   Target information for the k64f
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright (c) 2017-2017, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -26,11 +26,11 @@
 
 // target information
 target_cfg_t target_device = {
-    .sector_size    = 4096,
-    .sector_cnt     = (MB(1) / 4096),
-    .flash_start    = 0,
-    .flash_end      = MB(1),
-    .ram_start      = 0x1FFF0000,
-    .ram_end        = 0x20030000,
-    .flash_algo     = (program_target_t *) &flash,
+    .flash_start        = 0x00000000,
+    .flash_end          = 0x00100000,
+    .ram_start          = 0x1fff0000,
+    .ram_end            = 0x20030000,
+    .flash_algo         = (program_target_t *) &flash,
+    .sectors_info       = sectors_info,
+    .sector_info_length = (sizeof(sectors_info))/(sizeof(sector_info_t))
 };


### PR DESCRIPTION
Cherry pick #374 to master to re-enable sector erase on the K64F. This was initially reverted in #386.