### PR TITLE
Allow target to be halted without being reset

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -925,6 +925,30 @@ uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
 
             break;
 
+        case HALT:
+            if (!swd_init_debug()) {
+                return 0;
+            }
+
+            // Enable debug and halt the core (DHCSR <- 0xA05F0003)
+            if (!swd_write_word(DBG_HCSR, DBGKEY | C_DEBUGEN | C_HALT)) {
+                return 0;
+            }
+
+            // Wait until core is halted
+            do {
+                if (!swd_read_word(DBG_HCSR, &val)) {
+                    return 0;
+                }
+            } while ((val & S_HALT) == 0);
+            break;
+
+        case RUN:
+            if (!swd_write_word(DBG_HCSR, DBGKEY)) {
+                return 0;
+            }
+            swd_off();
+
         default:
             return 0;
     }
@@ -1024,6 +1048,30 @@ uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state)
             }
 
             break;
+
+        case HALT:
+            if (!swd_init_debug()) {
+                return 0;
+            }
+
+            // Enable debug and halt the core (DHCSR <- 0xA05F0003)
+            if (!swd_write_word(DBG_HCSR, DBGKEY | C_DEBUGEN | C_HALT)) {
+                return 0;
+            }
+
+            // Wait until core is halted
+            do {
+                if (!swd_read_word(DBG_HCSR, &val)) {
+                    return 0;
+                }
+            } while ((val & S_HALT) == 0);
+            break;
+
+        case RUN:
+            if (!swd_write_word(DBG_HCSR, DBGKEY)) {
+                return 0;
+            }
+            swd_off();
 
         default:
             return 0;

--- a/source/daplink/interface/target_flash.c
+++ b/source/daplink/interface/target_flash.c
@@ -74,9 +74,12 @@ static error_t target_flash_init()
 
 static error_t target_flash_uninit(void)
 {
-    // Resume the target if configured to do so
     if (config_get_auto_rst()) {
+        // Resume the target if configured to do so
         target_set_state(RESET_RUN);
+    } else {
+        // Leave the target halted until a reset occurs
+        target_set_state(RESET_PROGRAM);
     }
 
     swd_off();

--- a/source/hic_hal/target_reset.h
+++ b/source/hic_hal/target_reset.h
@@ -34,7 +34,9 @@ typedef enum {
     RESET_PROGRAM,           // Reset target and setup for flash programming.
     RESET_RUN,               // Reset target and run normally
     NO_DEBUG,                // Disable debug on running target
-    DEBUG                    // Enable debug on running target
+    DEBUG,                   // Enable debug on running target
+    HALT,                    // Halt the target without resetting it
+    RUN                      // Resume the target without resetting it
 } TARGET_RESET_STATE;
 
 void target_before_init_debug(void);

--- a/source/target/freescale/target_reset_Kseries.c
+++ b/source/target/freescale/target_reset_Kseries.c
@@ -30,7 +30,7 @@
 
 void target_before_init_debug(void)
 {
-    swd_set_target_reset(1);
+    return;
 }
 
 void board_init(void)

--- a/source/target/freescale/target_reset_Lseries.c
+++ b/source/target/freescale/target_reset_Lseries.c
@@ -30,7 +30,7 @@
 
 void target_before_init_debug(void)
 {
-    swd_set_target_reset(1);
+    return;
 }
 
 void board_init(void)


### PR DESCRIPTION
Make changes to allow targets to be halted without a reset occurring:
- Reset after programming to update state
- Remove reset in Kinetis debug init
- Add options to HALT and RUN, 