### PR TITLE
Improve handling of HID set and get report

### DIFF
--- a/source/daplink/cmsis-dap/usbd_user_hid.c
+++ b/source/daplink/cmsis-dap/usbd_user_hid.c
@@ -38,41 +38,37 @@
 #error "USB HID Input Report Size must match DAP Packet Size"
 #endif
 
-#define FREE_SEM_INIT_COUNT          (DAP_PACKET_COUNT)
-#define PROC_SEM_INIT_COUNT          0
-#define SEND_SEM_INIT_COUNT          0
+#define FREE_COUNT_INIT          (DAP_PACKET_COUNT)
+#define SEND_COUNT_INIT          0
 
-static uint8_t temp_buf                      [DAP_PACKET_SIZE];
 static uint8_t USB_Request [DAP_PACKET_COUNT][DAP_PACKET_SIZE];  // Request  Buffer
 
-static OS_SEM free_sem;
-static OS_SEM proc_sem;
-static OS_SEM send_sem;
+static uint32_t free_count;
+static uint32_t send_count;
 
-static OS_MUT hid_mutex;
-
-// Only used by HID out thread
+// Only used on USB thread
 static uint32_t recv_idx;
-
-// Only used by hid_process
-static uint32_t proc_idx;
-
-// Used by hid_process and HID out thread
-// so must be synchronized to HID lock
 static uint32_t send_idx;
 static volatile uint8_t  USB_ResponseIdle;
+
+void hid_send_packet()
+{
+    if (send_count) {
+        send_count--;
+        usbd_hid_get_report_trigger(0, USB_Request[send_idx], DAP_PACKET_SIZE);
+        send_idx = (send_idx + 1) % DAP_PACKET_COUNT;
+        free_count++;
+    }
+}
 
 // USB HID Callback: when system initializes
 void usbd_hid_init(void)
 {
     recv_idx = 0;
-    proc_idx = 0;
     send_idx = 0;
     USB_ResponseIdle = 1;
-    os_sem_init(&free_sem, FREE_SEM_INIT_COUNT);
-    os_sem_init(&proc_sem, PROC_SEM_INIT_COUNT);
-    os_sem_init(&send_sem, SEND_SEM_INIT_COUNT);
-    os_mut_init(&hid_mutex);
+    free_count = FREE_COUNT_INIT;
+    send_count = SEND_COUNT_INIT;
 }
 
 // USB HID Callback: when data needs to be prepared for the host
@@ -81,24 +77,20 @@ int usbd_hid_get_report(U8 rtype, U8 rid, U8 *buf, U8 req)
     switch (rtype) {
         case HID_REPORT_INPUT:
             switch (req) {
-                case USBD_HID_REQ_EP_CTRL:
                 case USBD_HID_REQ_PERIOD_UPDATE:
                     break;
 
+                case USBD_HID_REQ_EP_CTRL:
                 case USBD_HID_REQ_EP_INT:
-                    os_mut_wait(&hid_mutex, 0xFFFF);
-
-                    if (os_sem_wait(&send_sem, 0) == OS_R_OK) {
+                    if (send_count > 0) {
+                        send_count--;
                         memcpy(buf, USB_Request[send_idx], DAP_PACKET_SIZE);
                         send_idx = (send_idx + 1) % DAP_PACKET_COUNT;
-                        os_sem_send(&free_sem);
-                        os_mut_release(&hid_mutex);
+                        free_count++;
                         return (DAP_PACKET_SIZE);
-                    } else {
+                    } else if (req == USBD_HID_REQ_EP_INT) {
                         USB_ResponseIdle = 1;
                     }
-
-                    os_mut_release(&hid_mutex);
                     break;
             }
 
@@ -127,13 +119,21 @@ void usbd_hid_set_report(U8 rtype, U8 rid, U8 *buf, int len, U8 req)
 
             // Store data into request packet buffer
             // If there are no free buffers discard the data
-            if (os_sem_wait(&free_sem, 0) == OS_R_OK) {
+            if (free_count > 0) {
+                free_count--;
                 memcpy(USB_Request[recv_idx], buf, len);
+                DAP_ExecuteCommand(buf, USB_Request[recv_idx]);
                 recv_idx = (recv_idx + 1) % DAP_PACKET_COUNT;
-                os_sem_send(&proc_sem);
+                send_count++;
+                if (USB_ResponseIdle) {
+                    hid_send_packet();
+                    USB_ResponseIdle = 0;
+                }
             } else {
                 util_assert(0);
             }
+
+            main_blink_hid_led(MAIN_LED_OFF);
 
             break;
 
@@ -142,41 +142,4 @@ void usbd_hid_set_report(U8 rtype, U8 rid, U8 *buf, int len, U8 req)
     }
 }
 
-void hid_send_packet(void)
-{
-    OS_RESULT ret;
-    os_mut_wait(&hid_mutex, 0xFFFF);
 
-    ret = os_sem_wait(&send_sem, 0);
-    // There must be data avaiable to send when hid_send_packet is called
-    util_assert(OS_R_OK == ret);
-
-    usbd_hid_get_report_trigger(0, USB_Request[send_idx], DAP_PACKET_SIZE);
-    send_idx = (send_idx + 1) % DAP_PACKET_COUNT;
-    os_sem_send(&free_sem);
-
-    os_mut_release(&hid_mutex);
-}
-
-// CMSIS-DAP task
-__task void hid_process(void *argv)
-{
-    while (1) {
-        // Process DAP Command
-        os_sem_wait(&proc_sem, 0xFFFF);
-        DAP_ExecuteCommand(USB_Request[proc_idx], temp_buf);
-        memcpy(USB_Request[proc_idx], temp_buf, DAP_PACKET_SIZE);
-        proc_idx = (proc_idx + 1) % DAP_PACKET_COUNT;
-        os_sem_send(&send_sem);
-
-        // Send input report if USB is idle
-        os_mut_wait(&hid_mutex, 0xFFFF);
-        if (USB_ResponseIdle) {
-            main_hid_send_event();
-            USB_ResponseIdle = 0;
-        }
-        os_mut_release(&hid_mutex);
-
-        main_blink_hid_led(MAIN_LED_OFF);
-    }
-}


### PR DESCRIPTION
Synchronously handle HID set report so that HID get report is always able to send the result of HID set report. This also simplifies the code and saves rom since the dedicated HID thread is no longer needed.

I tested performance to make sure there were no regressions:

pyOCD programming before this PR:
INFO:root:Programmed 819200 bytes (200 pages) at 45.05 kB/s
INFO:root:Programmed 819200 bytes (200 pages) at 44.99 kB/s
INFO:root:Programmed 819200 bytes (200 pages) at 46.38 kB/s


pyOCD programming with this pr:
INFO:root:Programmed 819200 bytes (200 pages) at 44.70 kB/s
INFO:root:Programmed 819200 bytes (200 pages) at 46.45 kB/s
INFO:root:Programmed 819200 bytes (200 pages) at 46.11 kB/s