### PR TITLE
Add support for the USI WM-BN-BM-22

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -365,3 +365,7 @@ projects:
         - *module_if
         - *module_hic_lpc11u35
         - records/board/mtb_laird_bl652.yaml
+    lpc11u35_mtb_usi_wm_bn_bm_22_if:
+        - *module_if
+        - *module_hic_lpc11u35
+        - records/board/mtb_usi_wm_bn_bm_22.yaml

--- a/records/board/mtb_usi_wm_bn_bm_22.yaml
+++ b/records/board/mtb_usi_wm_bn_bm_22.yaml
@@ -1,0 +1,11 @@
+common:
+    macros:
+        - IO_CONFIG_OVERRIDE
+    includes:
+        - source/board/override_mtb
+    sources:
+        board:
+            - source/board/mtb_usi_wm_bn_bm_22.c
+        target:
+            - source/target/st/stm32f412rg/target.c
+            - source/target/st/target_reset.c

--- a/source/board/mtb_usi_wm_bn_bm_22.c
+++ b/source/board/mtb_usi_wm_bn_bm_22.c
@@ -1,0 +1,24 @@
+/**
+ * @file    96b_nitrogen.c
+ * @brief   board ID for the Seeed Studio 96Boards Nitrogen board
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_config.h"
+
+const char *board_id = "0462";

--- a/source/target/st/stm32f412rg/flash_blob.c
+++ b/source/target/st/stm32f412rg/flash_blob.c
@@ -1,0 +1,72 @@
+/* Flash OS Routines (Automagically Generated)
+ * Copyright (c) 2009-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ #include "flash_blob.h"
+
+static const uint32_t _flash_prog_blob[] = {
+    0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,
+    0x03004601, 0x28200e00, 0x0940d302, 0xe0051d00, 0xd3022810, 0x1cc00900, 0x0880e000, 0xd50102c9,
+    0x43082110, 0x48424770, 0x60414940, 0x60414941, 0x60012100, 0x22f068c1, 0x60c14311, 0x06806940,
+    0x483ed406, 0x6001493c, 0x60412106, 0x6081493c, 0x47702000, 0x69014836, 0x43110542, 0x20006101,
+    0xb5104770, 0x69014832, 0x43212404, 0x69016101, 0x431103a2, 0x49336101, 0xe0004a30, 0x68c36011,
+    0xd4fb03db, 0x43a16901, 0x20006101, 0xb530bd10, 0xffb6f7ff, 0x68ca4926, 0x431a23f0, 0x240260ca,
+    0x690a610c, 0x0e0006c0, 0x610a4302, 0x03e26908, 0x61084310, 0x4a214823, 0x6010e000, 0x03ed68cd,
+    0x6908d4fb, 0x610843a0, 0x060068c8, 0xd0030f00, 0x431868c8, 0x200160c8, 0xb570bd30, 0x1cc94d14,
+    0x68eb0889, 0x26f00089, 0x60eb4333, 0x612b2300, 0xe0174b15, 0x431c692c, 0x6814612c, 0x68ec6004,
+    0xd4fc03e4, 0x0864692c, 0x612c0064, 0x062468ec, 0xd0040f24, 0x433068e8, 0x200160e8, 0x1d00bd70,
+    0x1f091d12, 0xd1e52900, 0xbd702000, 0x45670123, 0x40023c00, 0xcdef89ab, 0x00005555, 0x40003000,
+    0x00000fff, 0x0000aaaa, 0x00000201, 0x00000000
+};
+
+// Start address of flash
+static const uint32_t flash_start = 0x08000000;
+// Size of flash
+static const uint32_t flash_size = 0x00080000;
+
+/**
+* List of start and size for each size of flash sector - even indexes are start, odd are size
+* The size will apply to all sectors between the listed address and the next address
+* in the list.
+* The last pair in the list will have sectors starting at that address and ending
+* at address flash_start + flash_size.
+*/
+static const uint32_t sectors_info[] = {
+    0x08000000, 0x00004000,
+    0x08010000, 0x00010000,
+    0x08020000, 0x00020000,
+};
+
+static const program_target_t flash = {
+    0x20000047, // Init
+    0x20000075, // UnInit
+    0x20000083, // EraseChip
+    0x200000af, // EraseSector
+    0x200000fb, // ProgramPage
+
+    // BKPT : start of blob + 1
+    // RSB  : blob start + header + rw data offset
+    // RSP  : stack pointer
+    {
+        0x20000001,
+        0x2000016c,
+        0x20000800
+    },
+
+    0x20000000 + 0x00000A00,  // mem buffer location
+    0x20000000,               // location to write prog_blob in target RAM
+    sizeof(_flash_prog_blob),   // prog_blob size
+    _flash_prog_blob,           // address of prog_blob
+    0x00000400       // ram_to_flash_bytes_to_be_written
+};

--- a/source/target/st/stm32f412rg/target.c
+++ b/source/target/st/stm32f412rg/target.c
@@ -1,0 +1,36 @@
+/**
+ * @file    target.c
+ * @brief   Target information for the stm32f412re
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2017-2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_config.h"
+
+// The file flash_blob.c must only be included in target.c
+#include "flash_blob.c"
+
+// target information
+target_cfg_t target_device = {
+    .sector_size        = 0x4000,
+    .sector_cnt         = (0x100000 / 0x4000),
+    .flash_start        = 0x08000000,
+    .flash_end          = 0x08100000,
+    .ram_start          = 0x20000000,
+    .ram_end            = 0x20040000,
+    .flash_algo         = (program_target_t *) &flash
+};

--- a/test/info.py
+++ b/test/info.py
@@ -92,6 +92,7 @@ PROJECT_RELEASE_INFO = {
     ('lpc11u35_mtb_wise1530_if',                    False,      0x0000,     "bin"       ),
     ('lpc11u35_mtb_wise1570_if',                    False,      0x0000,     "bin"       ),
     ('lpc11u35_mtb_laird_bl652_if',                 False,      0x0000,     "bin"       ),
+    ('lpc11u35_mtb_usi_wm_bn_bm_22_if',             False,      0x0000,     "bin"       ),
 }
 
 # All supported configurations
@@ -128,6 +129,7 @@ SUPPORTED_CONFIGURATIONS = [
     (   0x459,      'lpc11u35_mtb_wise1530_if',                 None,               None                                    ), # TODO - set target when mbed-os supports this
     (   0x460,      'lpc11u35_mtb_wise1570_if',                 None,               None                                    ), # TODO - set target when mbed-os supports this
     (   0x0461,     'lpc11u35_mtb_laird_bl652_if',              None,               None                                    ), # TODO - set target when mbed-os supports this
+    (   0x0462,     'lpc11u35_mtb_usi_wm_bn_bm_22_if',          None,               None                                    ), # TODO - set target when mbed-os supports this
     (   0x8080,     'lpc11u35_ff1705_l151_if',                  None,               'L-TEK-FF1705'                          ),
     (   0x8081,     'lpc11u35_ff_lpc546xx_if',                  None,               'L-TEK-FF-LPC546XX'                     ),
     (   0x824,      'lpc11u35_lpc824xpresso_if',                None,               'LPCXpresso824-MAX'                     ),


### PR DESCRIPTION
Add the files necessary for the USI WM-BN-BM-22. Flash algo was taken from stm32f412re but the flash is sized for +1mb.