### PR TITLE
Avoid calling swd_init() when invoking the RUN state

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -843,7 +843,11 @@ __attribute__((weak)) void swd_set_target_reset(uint8_t asserted)
 uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
 {
     uint32_t val;
-    swd_init();
+
+    /* Calling swd_init prior to enterring RUN state causes operations to fail. */
+    if (state != RUN) {
+        swd_init();
+    }
 
     switch (state) {
         case RESET_HOLD:
@@ -959,7 +963,11 @@ uint8_t swd_set_target_state_hw(TARGET_RESET_STATE state)
 uint8_t swd_set_target_state_sw(TARGET_RESET_STATE state)
 {
     uint32_t val;
-    swd_init();
+
+    /* Calling swd_init prior to enterring RUN state causes operations to fail. */
+    if (state != RUN) {
+        swd_init();
+    }
 
     switch (state) {
         case RESET_HOLD:


### PR DESCRIPTION
Failures were seen when swd_init() was called in the RUN state.
This needs to be investigated further. Issue#416 has been created
to track this.

Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>