### PR TITLE
Fix interfaces order.

### DIFF
--- a/source/usb/usb_lib.c
+++ b/source/usb/usb_lib.c
@@ -2175,15 +2175,6 @@ const U8 USBD_ConfigDescriptor[] = {
     MSC_EP
 #endif
 
-#if (USBD_HID_ENABLE)
-    HID_DESC
-#if (USBD_HID_EP_INTOUT != 0)
-    HID_EP_INOUT
-#else
-    HID_EP
-#endif
-#endif
-
 #if (USBD_CDC_ACM_ENABLE)
 #if (USBD_MULTI_IF)
     CDC_ACM_DESC_IAD(USBD_CDC_ACM_CIF_NUM, 2)
@@ -2192,6 +2183,15 @@ const U8 USBD_ConfigDescriptor[] = {
     CDC_ACM_EP_IF0
     CDC_ACM_DESC_IF1
     CDC_ACM_EP_IF1
+#endif
+
+#if (USBD_HID_ENABLE)
+    HID_DESC
+#if (USBD_HID_EP_INTOUT != 0)
+    HID_EP_INOUT
+#else
+    HID_EP
+#endif
 #endif
 
 #if (USBD_WEBUSB_ENABLE)
@@ -2239,6 +2239,16 @@ const U8 USBD_ConfigDescriptor_HS[] = {
     MSC_EP_HS
 #endif
 
+#if (USBD_CDC_ACM_ENABLE)
+#if (USBD_MULTI_IF)
+    CDC_ACM_DESC_IAD(USBD_CDC_ACM_CIF_NUM, 2)
+#endif
+    CDC_ACM_DESC_IF0
+    CDC_ACM_EP_IF0_HS
+    CDC_ACM_DESC_IF1
+    CDC_ACM_EP_IF1_HS
+#endif
+
 #if (USBD_HID_ENABLE)
     HID_DESC
 #if (USBD_HID_EP_INTOUT != 0)
@@ -2250,16 +2260,6 @@ const U8 USBD_ConfigDescriptor_HS[] = {
 
 #if (USBD_WEBUSB_ENABLE)
     WEBUSB_DESC
-#endif
-
-#if (USBD_CDC_ACM_ENABLE)
-#if (USBD_MULTI_IF)
-    CDC_ACM_DESC_IAD(USBD_CDC_ACM_CIF_NUM, 2)
-#endif
-    CDC_ACM_DESC_IF0
-    CDC_ACM_EP_IF0_HS
-    CDC_ACM_DESC_IF1
-    CDC_ACM_EP_IF1_HS
 #endif
 
     /* Terminator */                                                                                            \


### PR DESCRIPTION
USB descriptor is broken on Windows 10 machine after latest WebUSB Pull request. It is because order of interfaces is important on Windows machine. This PR fixes this behaviour.

@c1728p9 