### PR TITLE
[Arch Max] Put into "supported"

### DIFF
--- a/test/info.py
+++ b/test/info.py
@@ -54,7 +54,7 @@ PROJECT_RELEASE_INFO = {
     ("k20dx_hvpke18f_if",                           True,       0x8000,     "bin"       ),
     ("lpc11u35_archble_if",                         False,      0x0000,     "bin"       ),
     ("lpc11u35_archpro_if",                         False,      0x0000,     "bin"       ),
-    #("lpc11u35_archmax_if",                        False,      0x0000,     "bin"       ),  # Unsupported currently
+    ("lpc11u35_archmax_if",                         False,      0x0000,     "bin"       ),
     ("lpc11u35_hrm1017_if",                         False,      0x0000,     "bin"       ),
     ("lpc11u35_sscity_if",                          False,      0x0000,     "bin"       ),
     ("lpc11u35_ssci824_if",                         False,      0x0000,     "bin"       ),


### PR DESCRIPTION
Sadly, Arch Max was commented out since it was [written](https://github.com/ARMmbed/DAPLink/commit/08c93474eb0c86eece5395f878fbc43e581fb370#diff-ac5becf6ddc4ec836128a2f7eaf64c3f) on info.py. So, getting into release. Of course, it was tested successfully build and works properly.