### PR TITLE
microbit: Autodetect board type on runtime

### DIFF
--- a/source/board/microbit.c
+++ b/source/board/microbit.c
@@ -18,7 +18,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "MKL26Z4.h"
+#include "fsl_device_registers.h"
 #include "IO_Config.h"
 
 // URL_NAME and DRIVE_NAME must be 11 characters excluding
@@ -47,6 +47,8 @@ uint8_t read_board_type_pin(void) {
     // GPIO mode, Pull enable, pull down, input
     PIN_BOARD_TYPE_PORT->PCR[PIN_BOARD_TYPE_BIT] = PORT_PCR_MUX(1) | PORT_PCR_PE(1) | PORT_PCR_PS(0);
     PIN_BOARD_TYPE_GPIO->PDDR &= ~PIN_BOARD_TYPE;
+    // Wait to stabilise, based on gpio.c busy_wait(), at -O2 10000 iterations delay ~850us
+    for (volatile uint32_t i = 10000; i > 0; i--);
     // Read pin
     pin_state = (PIN_BOARD_TYPE_GPIO->PDIR & PIN_BOARD_TYPE);
     // Revert and disable

--- a/source/hic_hal/freescale/kl26z/IO_Config.h
+++ b/source/hic_hal/freescale/kl26z/IO_Config.h
@@ -96,6 +96,12 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_KL26);
 #define PIN_SW_RESET_BIT        (1)
 #define PIN_SW_RESET            (1<<PIN_SW_RESET_BIT)
 
+// BOARD TYPE
+#define PIN_BOARD_TYPE_PORT     PORTB
+#define PIN_BOARD_TYPE_GPIO     PTB
+#define PIN_BOARD_TYPE_BIT      (0)
+#define PIN_BOARD_TYPE          (1<<PIN_BOARD_TYPE_BIT)
+
 // Connected LED                Not available
 
 // Target Running LED           Not available


### PR DESCRIPTION
Pin 20 on the micro:bit KL26 has a no-fit part for an external-pull in v1.3 of the board (so it is left floating), and this external pull up is fitted in v1.5.
This PR sets the internal pull down on pin20, identifies the board and sets the respective `board_id ` based on the pin20 digital read.