### PR TITLE
Added checking to prevent target reset while flashing

### DIFF
--- a/source/daplink/drag-n-drop/flash_intf.h
+++ b/source/daplink/drag-n-drop/flash_intf.h
@@ -37,6 +37,7 @@ typedef error_t (*flash_intf_erase_sector_cb_t)(uint32_t sector);
 typedef error_t (*flash_intf_erase_chip_cb_t)(void);
 typedef uint32_t (*flash_program_page_min_size_cb_t)(uint32_t addr);
 typedef uint32_t (*flash_erase_sector_size_cb_t)(uint32_t addr);
+typedef uint8_t (*flash_busy_cb_t)(void);
 
 typedef struct {
     flash_intf_init_cb_t init;
@@ -46,6 +47,7 @@ typedef struct {
     flash_intf_erase_chip_cb_t erase_chip;
     flash_program_page_min_size_cb_t program_page_min_size;
     flash_erase_sector_size_cb_t erase_sector_size;
+    flash_busy_cb_t flash_busy;
 } flash_intf_t;
 
 // All flash interfaces.  Unsupported interfaces are NULL.

--- a/source/daplink/drag-n-drop/flash_manager.c
+++ b/source/daplink/drag-n-drop/flash_manager.c
@@ -276,6 +276,10 @@ static bool flash_intf_valid(const flash_intf_t *flash_intf)
     if (0 == flash_intf->erase_sector_size) {
         return false;
     }
+    
+    if (0 == flash_intf->flash_busy) {
+        return false;
+    }
 
     return true;
 }

--- a/source/daplink/drag-n-drop/iap_flash_intf.c
+++ b/source/daplink/drag-n-drop/iap_flash_intf.c
@@ -63,6 +63,7 @@ static bool sector_erase_allowed(uint32_t addr);
 static error_t intercept_page_write(uint32_t addr, const uint8_t *buf, uint32_t size);
 static error_t intercept_sector_erase(uint32_t addr);
 static error_t critical_erase_and_program(uint32_t addr, const uint8_t *data, uint32_t size);
+static uint8_t target_flash_busy(void);
 
 static const flash_intf_t flash_intf = {
     init,
@@ -72,6 +73,7 @@ static const flash_intf_t flash_intf = {
     erase_chip,
     program_page_min_size,
     erase_sector_size,
+    target_flash_busy,
 };
 
 const flash_intf_t *const flash_intf_iap_protected = &flash_intf;
@@ -496,4 +498,8 @@ static error_t critical_erase_and_program(uint32_t addr, const uint8_t *data, ui
     }
 
     return ERROR_SUCCESS;
+}
+
+static uint8_t target_flash_busy(void){
+    return (state == STATE_OPEN);
 }

--- a/source/daplink/interface/main.c
+++ b/source/daplink/interface/main.c
@@ -41,6 +41,7 @@
 #include "bootloader.h"
 #include "cortex_m.h"
 #include "sdk.h"
+#include "flash_intf.h"
 
 // Event flags for main task
 // Timers events
@@ -328,7 +329,7 @@ __task void main_task(void)
         if (flags & FLAGS_MAIN_30MS) {
 
             // handle reset button without eventing
-            if (!reset_pressed && gpio_get_reset_btn_fwrd()) {
+            if (!reset_pressed && gpio_get_reset_btn_fwrd() && !flash_intf_target->flash_busy()) { //added checking if flashing on target is in progress
                 // Reset button pressed
                 target_set_state(RESET_HOLD);
                 reset_pressed = 1;


### PR DESCRIPTION
It is implementation dependent that some platforms recovers DP and AP from DAPABORT, some wont. i.e. Cortex-A targets