### PR TITLE
Force pyOCD version to 0.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 project_generator==0.9.13
 mbed_ls==1.6.0
 pyserial
-pyOCD>=0.7.0
+pyOCD==0.12.0
 requests
 intelhex
 six


### PR DESCRIPTION
This is in preparation for the 0.13 release of pyOCD that will break API compatibility.