### PR TITLE
Add JTAG support into LPC11U35

### DIFF
--- a/source/hic_hal/nxp/lpc11u35/DAP_config.h
+++ b/source/hic_hal/nxp/lpc11u35/DAP_config.h
@@ -42,12 +42,7 @@ Provides definitions about:
 // Configure JTAG option
 #if defined(BOARD_BAMBINO_210) || defined(BOARD_BAMBINO_210E)
 // LPC43xx multicore targets require JTAG to debug slave cores
-#define CONF_JTAG
-#endif
-
-// Configure SWD option by default
-#if !defined(CONF_JTAG) && !defined(CONF_SWD)
-#define CONF_SWD
+#define DAP_JTAG 1
 #endif
 
 /// Processor Clock of the Cortex-M MCU used in the Debug Unit.
@@ -64,18 +59,14 @@ Provides definitions about:
 
 /// Indicate that Serial Wire Debug (SWD) communication mode is available at the Debug Access Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#if defined(CONF_SWD)
+#ifndef DAP_SWD
 #define DAP_SWD                 1               ///< SWD Mode:  1 = available, 0 = not available
-#else
-#define DAP_SWD                 0               ///< SWD Mode:  1 = available, 0 = not available
 #endif
 
 /// Indicate that JTAG communication mode is available at the Debug Port.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.
-#if defined(CONF_JTAG)
-#define DAP_JTAG                1               ///< JTAG Mode: 1 = available
-#else
-#define DAP_JTAG                0               ///< JTAG Mode: 0 = not available
+#ifndef DAP_JTAG
+#define DAP_JTAG                0               ///< JTAG Mode: 1 = available, 0 = not available
 #endif
 
 /// Configure maximum number of JTAG devices on the scan chain connected to the Debug Access Port.
@@ -84,10 +75,12 @@ Provides definitions about:
 
 /// Default communication mode on the Debug Access Port.
 /// Used for the command \ref DAP_Connect when Port Default mode is selected.
-#if (DAP_SWD != 0)
+#if (DAP_SWD == 1)
 #define DAP_DEFAULT_PORT        1               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
-#else
+#elif (DAP_JTAG == 1)
 #define DAP_DEFAULT_PORT        2               ///< Default JTAG/SWJ Port Mode: 1 = SWD, 2 = JTAG.
+#else 
+#error Must enable DAP_SWD and/or DAP_JTAG
 #endif
 
 /// Default communication speed on the Debug Access Port for SWD and JTAG mode.
@@ -189,15 +182,23 @@ __STATIC_INLINE void PORT_JTAG_SETUP(void)
     LPC_GPIO->SET[PIN_SWCLK_PORT] = PIN_SWCLK;
     LPC_GPIO->SET[PIN_SWDIO_PORT] = PIN_SWDIO;
 #if !defined(PIN_nRESET_FET_DRIVE)
-    // open drain logic
+    /* Open drain logic (for ordinary board).
+     * nRESET line should be pulled up by the board.
+     * To output high level (reset release signal),
+     * set as input direction. */
     LPC_GPIO->DIR[PIN_nRESET_PORT] &= ~PIN_nRESET;
     LPC_GPIO->CLR[PIN_nRESET_PORT] = PIN_nRESET;
 #else
-    // FET drive logic
+    /* FET drive logic (for special board like as blueninja)
+     * This setting treats nRESET line as positive logic.
+     * High level indicates that reset signal is asserted.
+     * Low level indicates that reset signal is deasserted. */
     LPC_GPIO->DIR[PIN_nRESET_PORT] |= PIN_nRESET;
     LPC_GPIO->CLR[PIN_nRESET_PORT] = PIN_nRESET;
 #endif
+    // SWCLK and TCK are aliases for the same line.
     LPC_GPIO->DIR[PIN_SWCLK_PORT] |= PIN_SWCLK;
+    // SWDIO and TMS are aliases for the same line.
     LPC_GPIO->DIR[PIN_SWDIO_PORT] |= PIN_SWDIO;
 
     LPC_GPIO->SET[PIN_TDI_PORT]  =  PIN_TDI;
@@ -420,8 +421,13 @@ __STATIC_FORCEINLINE void     PIN_nTRST_OUT(uint32_t bit)
 __STATIC_FORCEINLINE uint32_t PIN_nRESET_IN(void)
 {
 #if !defined(PIN_nRESET_FET_DRIVE)
+    // open drain logic
     return LPC_GPIO->B[PIN_nRESET_BIT + PIN_nRESET_PORT * 32] & 0x1;
 #else
+    /* FET drive logic (for special board like as blueninja)
+     * This setting treats nRESET line as positive logic.
+     * High level indicates that reset signal is asserted.
+     * Low level indicates that reset signal is deasserted. */
     return (LPC_GPIO->B[PIN_nRESET_BIT + PIN_nRESET_PORT * 32] & 0x1) == 1 ? 0 : 1;
 #endif
 }


### PR DESCRIPTION
~~This PR consists of two commits.~~
4815db664d2e8e013e5800954888e9aefec5746e fixes #391.
~~e8c0e0c0840376b0a85546d050ccf0cd070c09e6 adds JTAG support for drag-n-drop programming.~~

## Fix #391

`PORT_JTAG_SETUP()` has no settings for `PIN_SWCLK_PORT` and `PIN_SWDIO_PORT` pins.
So JTAG had not been working correctly. This patch fixes this issue.

To enable JTAG, `DAP_JTAG=1` needs to be added to `records/board/your_board.yml`.

```YAML
common:
    macros:
        - DAP_JTAG=1
```

## ~~Add JTAG support for drag-n-drop programming~~

~~Functions for programming flash memory call CMSIS-DAP subroutines, which controls SWD directly.
So DAPLink cannot program via JTAG in spite of the above patch.
We implement the same features via JTAG at `daplink/interface/jtag_host.{c,h}`.
And wrapper functions are added to choose an interface (SWD or JTAG) at `daplink/interface/dap_host.{c,h}`.~~

~~To enable this patch, `source/target/<mfg>/target_reset.c` needs to be modified.
The prefix `swd_` should be changed to the prefix `dap_`.
It is shown below.~~

```C
#include "target_reset.h"
#include "dap_host.h"
void target_before_init_debug(void) {}
uint8_t target_unlock_sequence(void) {}
uint8_t target_set_state(TARGET_RESET_STATE state)
{
    return dap_set_target_state_hw(state);
}
uint8_t security_bits_set(uint32_t addr, uint8_t *data, uint32_t size)
{
    return 0;
}
```

~~If the target device is Cortex-A, `DEBUG_REGSITER_BASE_OVERRIDE` needs to be added to `records/board/your_board.yml`
It is shown below.~~

```YAML
common:
    macros:
        - CONF_JTAG
        - TARGET_MCU_CORTEX_A
        - DEBUG_REGSITER_BASE_OVERRIDE=0x80040000
```

~~These patches were tested on bluninja(lpc11u35_blueninja_if) board for Cortex-M target.
For Cortex-A target, we used the other board.~~
