### PR TITLE
Add the missing include file

### DIFF
--- a/source/hic_hal/gpio.h
+++ b/source/hic_hal/gpio.h
@@ -22,6 +22,7 @@
 #ifndef GPIO_H
 #define GPIO_H
 
+#include "stdbool.h"
 #include "IO_Config.h"
 
 #ifdef __cplusplus

--- a/source/hic_hal/gpio.h
+++ b/source/hic_hal/gpio.h
@@ -22,7 +22,7 @@
 #ifndef GPIO_H
 #define GPIO_H
 
-#include "stdbool.h"
+#include <stdbool.h>
 #include "IO_Config.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Raised an error when compiling on uvision IDE v5.17 with ARM compiler v5.06.