### PR TITLE
Test order: load interface before bootloader.

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -225,14 +225,15 @@ class TestManager(object):
                            test_configuration.bl_firmware)
             test_info.info("Target: %s" % test_configuration.target)
 
+            
+            if self._load_if:
+                if_path = test_configuration.if_firmware.hex_path
+                board.load_interface(if_path, test_info)
+
             valid_bl = test_configuration.bl_firmware is not None
             if self._load_bl and valid_bl:
                 bl_path = test_configuration.bl_firmware.hex_path
                 board.load_bootloader(bl_path, test_info)
-
-            if self._load_if:
-                if_path = test_configuration.if_firmware.hex_path
-                board.load_interface(if_path, test_info)
 
             board.set_check_fs_on_remount(True)
 


### PR DESCRIPTION
If bootloader size bumps up, crc check will fail if bootloader is loaded first.