### PR TITLE
Add an entry for Toshiba TZ family.

### DIFF
--- a/source/target/target_family.c
+++ b/source/target/target_family.c
@@ -64,6 +64,8 @@ __attribute__((weak))
 const target_family_descriptor_t g_wiznet_family  = {0};
 __attribute__((weak))
 const target_family_descriptor_t g_renesas_family  = {0};
+__attribute__((weak))
+const target_family_descriptor_t g_toshiba_tz_family  = {0};
 
 __attribute__((weak))
 const target_family_descriptor_t *g_families[] = { 
@@ -80,6 +82,7 @@ const target_family_descriptor_t *g_families[] = {
     &g_ti_family,
     &g_wiznet_family,
     &g_renesas_family,
+    &g_toshiba_tz_family,
     0 // list terminator 
 }; 
 


### PR DESCRIPTION
MSD does not work on the BlueNinja board.

usbd_class_init() is defined in usb_lib.c as described below.

```C
void usbd_class_init(void)
{   
#if !(defined(DAPLINK_BL)) &&  defined(DRAG_N_DROP_SUPPORT)
    //change descriptors here
    if (config_ram_get_disable_msd() == 1 || flash_algo_valid()==0 || target_family_valid()==0){
        usbd_if_num -= USBD_MSC_ENABLE;
        USB_CONFIGURATION_DESCRIPTOR * usb_conf_desc = (USB_CONFIGURATION_DESCRIPTOR *)USBD_ConfigDescriptor;
```

g_toshiba_tz_family, which is defined in target_family.c, does not have an entry for g_toshiba_tz_family.
So, target_family_valid() returns 0 in case of Toshiba TZ family. MSD descriptors are disabled.

