### PR TITLE
Flash algo binding for no target builds but basically any build

### DIFF
--- a/source/hic_hal/flash_blob.h
+++ b/source/hic_hal/flash_blob.h
@@ -28,13 +28,13 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct __attribute__((__packed__)) {
     uint32_t breakpoint;
     uint32_t static_base;
     uint32_t stack_pointer;
 } program_syscall_t;
 
-typedef struct {
+typedef struct __attribute__((__packed__)) {
     const uint32_t  init;
     const uint32_t  uninit;
     const uint32_t  erase_chip;
@@ -49,7 +49,7 @@ typedef struct {
     const uint32_t  program_buffer_size;
 } program_target_t;
 
-typedef struct {
+typedef struct __attribute__((__packed__)) {
     const uint32_t start;
     const uint32_t size;
 } sector_info_t;

--- a/source/target/target_board.c
+++ b/source/target/target_board.c
@@ -51,7 +51,27 @@ uint16_t get_family_id(void)
     }
 }
 
-uint8_t flash_algo_valid(void) 
+#if (defined(__ICCARM__))
+#pragma optimize = none
+uint8_t flash_algo_valid(void)
+#elif (defined(__CC_ARM))
+#pragma push
+#pragma O0
+uint8_t flash_algo_valid(void)
+#elif (!defined(__GNUC__))
+/* #pragma GCC push_options */
+/* #pragma GCC optimize("O0") */
+uint8_t __attribute__((optimize("O0"))) flash_algo_valid(void)
+#else
+#error "Unknown compiler"
+#endif
 {
     return (g_board_info.target_cfg != 0);
 }
+
+#if (defined(__CC_ARM))
+#pragma pop
+#endif
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#endif

--- a/source/target/target_config.h
+++ b/source/target/target_config.h
@@ -50,11 +50,11 @@ enum _region_flags {
 };
 
 
-typedef struct region_info {
+typedef struct __attribute__((__packed__)) region_info {
     uint32_t start;
     uint32_t end;
     uint32_t flags;
-    uint8_t alias_index;            /*!<use with flags; will point to a different index if there is an alias region */
+    uint32_t alias_index;            /*!<use with flags; will point to a different index if there is an alias region */
     program_target_t *flash_algo;   /*!< A pointer to the flash algorithm structure */
 } region_info_t;
 
@@ -62,15 +62,16 @@ typedef struct region_info {
  @struct target_cfg_t
  @brief  The firmware configuration struct has unique about the chip its running on.
  */
-typedef struct target_cfg {
+typedef struct __attribute__((__packed__)) target_cfg {
     uint32_t version;                                       /*!< Target configuration version */
     const sector_info_t* sectors_info;                      /*!< Sector start and length list */
-    int sector_info_length;                                 /*!< Sector start and length list total */
+    uint32_t sector_info_length;                            /*!< Sector start and length list total */
     region_info_t flash_regions[MAX_EXTRA_FLASH_REGION];    /*!< Flash regions */
     region_info_t ram_regions[MAX_EXTRA_RAM_REGION];        /*!< RAM regions  */
-    uint8_t erase_reset;                                    /*!< Reset after performing an erase */
     const char *rt_board_id;                                /*!< If assigned, this is a flexible board ID */
-    uint16_t rt_family_id;                                     /*!< If assigned, this is a flexible board ID */
+    uint16_t rt_family_id;                                  /*!< If assigned, this is a flexible board ID */
+    uint8_t erase_reset;                                    /*!< Reset after performing an erase */
+    uint8_t pad;
 } target_cfg_t;
 
 extern target_cfg_t target_device;

--- a/source/target/target_family.c
+++ b/source/target/target_family.c
@@ -108,6 +108,10 @@ void init_family(void)
         }
         index++;
     }
+    
+    if(g_target_family == NULL){ //default family
+        g_target_family = &g_hw_reset_family;
+    }
 }
 
 uint8_t target_family_valid(void)

--- a/test/info.py
+++ b/test/info.py
@@ -122,6 +122,15 @@ PROJECT_RELEASE_INFO = {
     ('max32620_max32625mbed_if',                    False,      0x0000,     "bin"       ),
     ('max32625_max32620fthr_if',                    False,      0x0000,     "bin"       ),
     ('max32625_max32630fthr_if',                    False,      0x0000,     "bin"       ),
+    ('kl26z_if',                                    False,      0x0000,     "bin"       ),
+    ('k20dx_if',                                    False,      0x0000,     "bin"       ),
+    ('k26f_if',                                     False,      0x0000,     "bin"       ),
+    ('lpc11u35_if',                                 False,      0x0000,     "bin"       ),
+    ('lpc4322_if',                                  False,      0x0000,     "bin"       ),
+    ('max32620_if',                                 False,      0x0000,     "bin"       ),
+    ('max32625_if',                                 False,      0x0000,     "bin"       ),
+    ('sam3u2c_if',                                  False,      0x0000,     "bin"       ),
+    ('stm32f103xb_if',                              False,      0x0000,     "bin"       ),
 }
 
 # Add new HICs here
@@ -260,6 +269,15 @@ SUPPORTED_CONFIGURATIONS = [
     (   0xC000,     VENDOR_TO_FAMILY('Stub', 1),        'lpc11u35_cocorico_if',                     None,               'CoCo-ri-Co'                            ),
     (   0xC006,     VENDOR_TO_FAMILY('Nordic', 1),      'lpc11u35_vbluno51_if',                     None,               'VBLUNO51'                              ),
     (   0xC005,     VENDOR_TO_FAMILY('Nordic', 1),      'lpc11u35_mtconnect04s_if',                 None,               'MtConnect04S'                          ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'kl26z_if',                                 None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'k20dx_if',                                 None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'k26f_if',                                  None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'lpc11u35_if',                              None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'lpc4322_if',                               None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'max32620_if',                              None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'max32625_if',                              None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'sam3u2c_if',                               None,               None                                    ),
+    (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'stm32f103xb_if',                           None,               None                                    ),
 ]
 
 # Add new HICs here

--- a/tools/flash_algo.py
+++ b/tools/flash_algo.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python
+"""
+ mbed
+ Copyright (c) 2017-2017 ARM Limited
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+"""
+
+from __future__ import print_function
+import os
+import struct
+import binascii
+import argparse
+import logging
+import StringIO
+import jinja2
+from collections import namedtuple
+from itertools import count
+
+from elftools.common.py3compat import bytes2str
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Algo Extracter")
+    parser.add_argument("input", help="File to extract flash algo from")
+    parser.add_argument("template", default="py_blob.tmpl",
+                        help="Template to use")
+    parser.add_argument("output", help="Output file")
+    args = parser.parse_args()
+
+    with open(args.input, "rb") as file_handle:
+        data = file_handle.read()
+    algo = PackFlashAlgo(data)
+    algo.process_template(args.template, args.output)
+
+
+class PackFlashAlgo(object):
+    """
+    Class to wrap a flash algo
+
+    This class is intended to provide easy access to the information
+    provided by a flash algorithm, such as symbols and the flash
+    algorithm itself.
+    """
+
+    REQUIRED_SYMBOLS = set([
+        "Init",
+        "UnInit",
+        "EraseSector",
+        "ProgramPage",
+    ])
+
+    EXTRA_SYMBOLS = set([
+        "BlankCheck",
+        "EraseChip",
+        "Verify",
+    ])
+
+    def __init__(self, data):
+        """Construct a PackFlashAlgorithm from an ElfFileSimple"""
+        self.elf = ElfFileSimple(data)
+        self.flash_info = PackFlashInfo(self.elf)
+
+        self.flash_start = self.flash_info.start
+        self.flash_size = self.flash_info.size
+        self.page_size = self.flash_info.page_size
+        self.sector_sizes = self.flash_info.sector_info_list
+
+        symbols = {}
+        symbols.update(_extract_symbols(self.elf, self.REQUIRED_SYMBOLS))
+        symbols.update(_extract_symbols(self.elf, self.EXTRA_SYMBOLS,
+                                        default=0xFFFFFFFF))
+        self.symbols = symbols
+
+        sections_to_find = (
+            ("PrgCode", "SHT_PROGBITS"),
+            ("PrgData", "SHT_PROGBITS"),
+            ("PrgData", "SHT_NOBITS"),
+        )
+
+        ro_rw_zi = _find_sections(self.elf, sections_to_find)
+        ro_rw_zi = _algo_fill_zi_if_missing(ro_rw_zi)
+        error_msg = _algo_check_for_section_problems(ro_rw_zi)
+        if error_msg is not None:
+            raise Exception(error_msg)
+
+        sect_ro, sect_rw, sect_zi = ro_rw_zi
+        self.ro_start = sect_ro["sh_addr"]
+        self.ro_size = sect_ro["sh_size"]
+        self.rw_start = sect_rw["sh_addr"]
+        self.rw_size = sect_rw["sh_size"]
+        self.zi_start = sect_zi["sh_addr"]
+        self.zi_size = sect_zi["sh_size"]
+
+        self.algo_data = _create_algo_bin(ro_rw_zi)
+
+    def format_algo_data(self, spaces, group_size, fmt):
+        """"
+        Return a string representing algo_data suitable for use in a template
+
+        The string is intended for use in a template.
+
+        :param spaces: The number of leading spaces for each line
+        :param group_size: number of elements per line (element type
+            depends of format)
+        :param fmt: - format to create - can be either "hex" or "c"
+        """
+        padding = " " * spaces
+        if fmt == "hex":
+            blob = binascii.b2a_hex(self.algo_data)
+            line_list = []
+            for i in xrange(0, len(blob), group_size):
+                line_list.append('"' + blob[i:i + group_size] + '"')
+            return ("\n" + padding).join(line_list)
+        elif fmt == "c":
+            blob = self.algo_data[:]
+            pad_size = 0 if len(blob) % 4 == 0 else 4 - len(blob) % 4
+            blob = blob + "\x00" * pad_size
+            integer_list = struct.unpack("<" + "L" * (len(blob) / 4), blob)
+            line_list = []
+            for pos in range(0, len(integer_list), group_size):
+                group = ["0x%08x" % value for value in
+                         integer_list[pos:pos + group_size]]
+                line_list.append(", ".join(group))
+            return (",\n" + padding).join(line_list)
+        else:
+            raise Exception("Unsupported format %s" % fmt)
+
+    def process_template(self, template_path, output_path, data_dict=None):
+        """
+        Generate output from the supplied template
+
+        All the public methods and fields of this class can be accessed from
+        the template via "algo".
+
+        :param template_path: Relative or absolute file path to the template
+        :param output_path: Relative or absolute file path to create
+        :param data_dict: Additional data to use when generating
+        """
+        if data_dict is None:
+            data_dict = {}
+        else:
+            assert isinstance(data_dict, dict)
+            data_dict = dict(data_dict)
+        assert "algo" not in data_dict, "algo already set by user data"
+        data_dict["algo"] = self
+
+        with open(template_path) as file_handle:
+            template_text = file_handle.read()
+
+        template = jinja2.Template(template_text)
+        target_text = template.render(data_dict)
+
+        with open(output_path, "wb") as file_handle:
+            file_handle.write(target_text)
+
+
+def _extract_symbols(simple_elf, symbols, default=None):
+    """Fill 'symbols' field with required flash algo symbols"""
+    to_ret = {}
+    for symbol in symbols:
+        if symbol not in simple_elf.symbols:
+            if default is not None:
+                to_ret[symbol] = default
+                continue
+            raise Exception("Missing symbol %s" % symbol)
+        to_ret[symbol] = simple_elf.symbols[symbol].value
+    return to_ret
+
+
+def _find_sections(elf, name_type_pairs):
+    """Return a list of sections the same length and order of the input list"""
+    sections = [None] * len(name_type_pairs)
+    for section in elf.iter_sections():
+        section_name = bytes2str(section.name)
+        section_type = section["sh_type"]
+        for i, name_and_type in enumerate(name_type_pairs):
+            if name_and_type != (section_name, section_type):
+                continue
+            if sections[i] is not None:
+                raise Exception("Elf contains duplicate section %s attr %s" %
+                                (section_name, section_type))
+            sections[i] = section
+    return sections
+
+
+def _algo_fill_zi_if_missing(ro_rw_zi):
+    """Create an empty zi section if it is missing"""
+    s_ro, s_rw, s_zi = ro_rw_zi
+    if s_rw is None:
+        return ro_rw_zi
+    if s_zi is not None:
+        return ro_rw_zi
+    s_zi = {
+        "sh_addr": s_rw["sh_addr"] + s_rw["sh_size"],
+        "sh_size": 0
+    }
+    return s_ro, s_rw, s_zi
+
+
+def _algo_check_for_section_problems(ro_rw_zi):
+    """Return a string describing any errors with the layout or None if good"""
+    s_ro, s_rw, s_zi = ro_rw_zi
+    if s_ro is None:
+        return "RO section is missing"
+    if s_rw is None:
+        return "RW section is missing"
+    if s_zi is None:
+        return "ZI section is missing"
+    if s_ro["sh_addr"] != 0:
+        return "RO section does not start at address 0"
+    if s_ro["sh_addr"] + s_ro["sh_size"] != s_rw["sh_addr"]:
+        return "RW section does not follow RO section"
+    if s_rw["sh_addr"] + s_rw["sh_size"] != s_zi["sh_addr"]:
+        return "ZI section does not follow RW section"
+    return None
+
+
+def _create_algo_bin(ro_rw_zi):
+    """Create a binary blob of the flash algo which can execute from ram"""
+    sect_ro, sect_rw, sect_zi = ro_rw_zi
+    algo_size = sect_ro["sh_size"] + sect_rw["sh_size"] + sect_zi["sh_size"]
+    algo_data = bytearray(algo_size)
+    for section in (sect_ro, sect_rw):
+        start = section["sh_addr"]
+        size = section["sh_size"]
+        data = section.data()
+        assert len(data) == size
+        algo_data[start:start + size] = data
+    return algo_data
+
+
+class PackFlashInfo(object):
+    """Wrapper class for the non-executable information in an FLM file"""
+
+    FLASH_DEVICE_STRUCT = "<H128sHLLLLBxxxLL"
+    FLASH_SECTORS_STRUCT = "<LL"
+    FLASH_SECTORS_STRUCT_SIZE = struct.calcsize(FLASH_SECTORS_STRUCT)
+    SECTOR_END = 0xFFFFFFFF
+
+    def __init__(self, elf_simple):
+        dev_info = elf_simple.symbols["FlashDevice"]
+        info_start = dev_info.value
+        info_size = struct.calcsize(self.FLASH_DEVICE_STRUCT)
+        data = elf_simple.read(info_start, info_size)
+        values = struct.unpack(self.FLASH_DEVICE_STRUCT, data)
+
+        self.version = values[0]
+        self.name = values[1].strip("\x00")
+        self.type = values[2]
+        self.start = values[3]
+        self.size = values[4]
+        self.page_size = values[5]
+        self.value_empty = values[7]
+        self.prog_timeout_ms = values[8]
+        self.erase_timeout_ms = values[9]
+
+        sector_gen = self._sector_and_sz_itr(elf_simple,
+                                             info_start + info_size)
+        self.sector_info_list = list(sector_gen)
+
+    def __str__(self):
+        desc = ""
+        desc += "Flash Device:" + os.linesep
+        desc += "  name=%s" % self.name + os.linesep
+        desc += "  version=0x%x" % self.version + os.linesep
+        desc += "  type=%i" % self.type + os.linesep
+        desc += "  start=0x%x" % self.start + os.linesep
+        desc += "  size=0x%x" % self.size + os.linesep
+        desc += "  page_size=0x%x" % self.page_size + os.linesep
+        desc += "  value_empty=0x%x" % self.value_empty + os.linesep
+        desc += "  prog_timeout_ms=%i" % self.prog_timeout_ms + os.linesep
+        desc += "  erase_timeout_ms=%i" % self.erase_timeout_ms + os.linesep
+        desc += "  sectors:" + os.linesep
+        for sector_start, sector_size in self.sector_info_list:
+            desc += ("    start=0x%x, size=0x%x" %
+                     (sector_start, sector_size) + os.linesep)
+        return desc
+
+    def _sector_and_sz_itr(self, elf_simple, data_start):
+        """Iterator which returns starting address and sector size"""
+        for entry_start in count(data_start, self.FLASH_SECTORS_STRUCT_SIZE):
+            data = elf_simple.read(entry_start, self.FLASH_SECTORS_STRUCT_SIZE)
+            size, start = struct.unpack(self.FLASH_SECTORS_STRUCT, data)
+            start_and_size = start, size
+            if start_and_size == (self.SECTOR_END, self.SECTOR_END):
+                return
+            yield start_and_size
+
+
+SymbolSimple = namedtuple("SymbolSimple", "name, value, size")
+
+
+class ElfFileSimple(ELFFile):
+    """Wrapper for elf object which allows easy access to symbols and rom"""
+
+    def __init__(self, data):
+        """Construct a ElfFileSimple from bytes or a bytearray"""
+        super(ElfFileSimple, self).__init__(StringIO.StringIO(data))
+        self.symbols = self._read_symbol_table()
+
+    def _read_symbol_table(self):
+        """Read the symbol table into the field "symbols" for easy use"""
+        section = self.get_section_by_name(b".symtab")
+        if not section:
+            raise Exception("Missing symbol table")
+
+        if not isinstance(section, SymbolTableSection):
+            raise Exception("Invalid symbol table section")
+
+        symbols = {}
+        for symbol in section.iter_symbols():
+            name_str = bytes2str(symbol.name)
+            if name_str in symbols:
+                logging.debug("Duplicate symbol %s", name_str)
+            symbols[name_str] = SymbolSimple(name_str, symbol["st_value"],
+                                             symbol["st_size"])
+        return symbols
+
+    def read(self, addr, size):
+        """Read program data from the elf file
+
+        :param addr: physical address (load address) to read from
+        :param size: number of bytes to read
+        :return: Requested data or None if address is unmapped
+        """
+        for segment in self.iter_segments():
+            seg_addr = segment["p_paddr"]
+            seg_size = min(segment["p_memsz"], segment["p_filesz"])
+            if addr >= seg_addr + seg_size:
+                continue
+            if addr + size <= seg_addr:
+                continue
+            # There is at least some overlap
+
+            if addr >= seg_addr and addr + size <= seg_addr + seg_size:
+                # Region is fully contained
+                data = segment.data()
+                start = addr - seg_addr
+                return data[start:start + size]
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/post_build_script.py
+++ b/tools/post_build_script.py
@@ -26,19 +26,20 @@ import struct
 import intelhex
 import offset_update
 from os.path import dirname, join
+from flash_algo import PackFlashAlgo
 
 VECTOR_FMT = "<7I"
 CHECKSUM_FMT = "<1I"
 CHECKSUM_OFFSET = 0x1C
 TARGET_INFO_OFFSET = 13*4
-
+ALLIGN_PADS = 4
 
 def ranges(i):
     for _, b in itertools.groupby(enumerate(i), lambda x_y: x_y[1] - x_y[0]):
         b = list(b)
         yield b[0][1], b[-1][1]
 
-def post_build_script(input_file, output_file, board_id=None, family_id=None, bin_offset=None):
+def post_build_script(input_file, output_file, board_id=None, family_id=None, bin_offset=None, flash_algo_file=None, target_ram_start=None, target_ram_end=None, flash_blob_entry="0x20000000"):
     output_format_file = '-'.join(filter(None, (output_file, board_id, family_id, bin_offset)))
     print(output_format_file)
     output_file_hex = output_format_file + ".hex"
@@ -72,6 +73,11 @@ def post_build_script(input_file, output_file, board_id=None, family_id=None, bi
                           "hex file %i found." % regions)
     start, end = start_end_pairs[0]
 
+    pack_flash_algo = None
+    if flash_algo_file is not None:
+        with open(flash_algo_file, "rb") as file_handle:
+            pack_flash_algo = PackFlashAlgo(file_handle.read())
+
     # Checksum the vector table
     #
     # Note this is only required for NXP devices but
@@ -98,14 +104,75 @@ def post_build_script(input_file, output_file, board_id=None, family_id=None, bi
     if board_id is not None or family_id is not None:
         target_info_addr = new_hex_file.gets(start + TARGET_INFO_OFFSET, 4)
         target_addr_unpack = struct.unpack("<1I",target_info_addr)[0]
-        print("board_info addr: ",hex(target_addr_unpack-start))
+        print("board_info offset: ",hex(target_addr_unpack - start))
         #family_id is in integer hex
         if family_id is not None:
             new_hex_file.puts(target_addr_unpack + 2,struct.pack('<1H',int(family_id, 16)))
         #board_id is in string hex
         if board_id is not None:
             new_hex_file.puts(target_addr_unpack + 4,struct.pack('4s',"%.04X" % int(board_id, 16)))
-
+        if pack_flash_algo is not None:
+            blob_header = (0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2)
+            stack_size = 0x200
+            region_info_fmt = '5I'
+            region_info_total = 10            
+            target_cfg_fmt = '3I'+ region_info_fmt*region_info_total*2 + 'IHBB'
+            sector_info_fmt = '2I'
+            sector_info_len = len(pack_flash_algo.sector_sizes)
+            program_target_fmt = '14I'
+            flash_blob_entry = int(flash_blob_entry, 16)
+            blob_pad_size = ((len(pack_flash_algo.algo_data) + ALLIGN_PADS -1) // ALLIGN_PADS * ALLIGN_PADS) - len(pack_flash_algo.algo_data)
+            blob_header_size = len(blob_header) * 4
+            total_struct_size = blob_header_size + len(pack_flash_algo.algo_data) + blob_pad_size + sector_info_len*struct.calcsize(sector_info_fmt) + struct.calcsize(program_target_fmt) + struct.calcsize(target_cfg_fmt)
+            flash_blob_addr = end + 1 - 4 -  total_struct_size #make room for crc
+            print("flash_blob offset:", hex(flash_blob_addr - start))
+            new_hex_file.puts(flash_blob_addr, struct.pack('<'+'I'*len(blob_header), *blob_header))
+            new_hex_file.puts(flash_blob_addr + blob_header_size, pack_flash_algo.algo_data + "\x00" * blob_pad_size)
+            sector_info_addr = flash_blob_addr+blob_header_size + len(pack_flash_algo.algo_data) + blob_pad_size
+            sector_info_arr = []
+            for flash_start, flash_size in pack_flash_algo.sector_sizes:
+                sector_info_arr.append(flash_start + pack_flash_algo.flash_start)
+                sector_info_arr.append(flash_size)
+            print("sector_info offset:", hex(sector_info_addr - start))
+            new_hex_file.puts(sector_info_addr,struct.pack('<' + 'I'*len(sector_info_arr), *sector_info_arr))
+            program_target_addr = sector_info_addr + len(sector_info_arr)*4
+            stack_pointer = (flash_blob_entry + blob_header_size + pack_flash_algo.rw_start + pack_flash_algo.rw_size + stack_size + 0x100 - 1) // 0x100 * 0x100
+            print("program_target offset:", hex(program_target_addr - start))
+            new_hex_file.puts(program_target_addr,struct.pack('<' + program_target_fmt,
+                                                            pack_flash_algo.symbols['Init'] + blob_header_size + flash_blob_entry,
+                                                            pack_flash_algo.symbols['UnInit'] + blob_header_size + flash_blob_entry,
+                                                            pack_flash_algo.symbols['EraseChip'] + blob_header_size + flash_blob_entry if pack_flash_algo.symbols['EraseChip'] != 0xffffffffL else 0,
+                                                            pack_flash_algo.symbols['EraseSector'] + blob_header_size + flash_blob_entry,
+                                                            pack_flash_algo.symbols['ProgramPage'] + blob_header_size + flash_blob_entry,
+                                                            pack_flash_algo.symbols['Verify'] + blob_header_size + flash_blob_entry if pack_flash_algo.symbols['Verify'] != 0xffffffffL else 0,
+                                                            flash_blob_entry + 1, #BKPT : start of blob + 1
+                                                            flash_blob_entry + blob_header_size + pack_flash_algo.rw_start, #RSB  : blob start + header + rw data offset
+                                                            stack_pointer, #RSP  : stack pointer
+                                                            flash_blob_entry + 0x00000A00, #mem buffer location
+                                                            flash_blob_entry, #location to write prog_blob in target RAM
+                                                            blob_header_size + len(pack_flash_algo.algo_data) + blob_pad_size, #prog_blob size
+                                                            flash_blob_addr, #address of prog_blob
+                                                            pack_flash_algo.page_size #ram_to_flash_bytes_to_be_written
+                                                            ))
+            target_cfg_addr = program_target_addr + struct.calcsize(program_target_fmt)
+            print("target_cfg offset:", hex(target_cfg_addr - start))
+            if target_ram_start is None or target_ram_end is None:
+                 raise Exception("target_ram_start and target_ram_end should be defined!")
+            first_flash_region = (pack_flash_algo.flash_start, pack_flash_algo.flash_start + pack_flash_algo.flash_size, 1, 0, program_target_addr)
+            first_ram_region = (int(target_ram_start, 16), int(target_ram_end, 16), 0, 0, 0)
+            emypty_region = (0, 0, 0, 0, 0) * (region_info_total -1)
+            all_regions = first_flash_region + emypty_region + first_ram_region + emypty_region
+            target_flags = ( 0, 0, 0, 0) #realtime board ID, family ID and erase reset flag
+            regions_flags = all_regions + target_flags
+            new_hex_file.puts(target_cfg_addr, struct.pack('<' + target_cfg_fmt,
+                                                            0x1,                #script generated
+                                                            sector_info_addr,   # Sector start and length list
+                                                            sector_info_len,    #Sector start and length list total
+                                                            *regions_flags
+                                                            ))
+            board_info_flag = 1 if pack_flash_algo.symbols['EraseSector'] != 0xffffffffL else 0  #kEnablePageErase                     
+            new_hex_file.puts(target_addr_unpack + 12,struct.pack('<1I', board_info_flag)) #always enable page erase EraseSector is a required symbol in flash algo
+            new_hex_file.puts(target_addr_unpack + 16,struct.pack('<1I', target_cfg_addr))
 
     # CRC the entire image
     #
@@ -175,7 +242,7 @@ def post_build_script(input_file, output_file, board_id=None, family_id=None, bi
                                           start, pad_addr, 0x40)
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Post build tool for Board ID, Family ID and CRC generation')
+    parser = argparse.ArgumentParser(description='Post build tool for Board ID, Family ID, Target flash algo and CRC generation')
     parser.add_argument("input", type=str, help="Hex or bin file to read from.")
     parser.add_argument("output", type=str,
                         help="Output base file name to write crc, board_id and family_id.")
@@ -184,6 +251,14 @@ if __name__ == '__main__':
     parser.add_argument("--family-id", type=str,
                         help="family id to for the target in hex")
     parser.add_argument("--bin-offset", type=str,
-                        help="binary offset in hex")
+                        help="binary offset in hex can be supplied if input is bin")
+    parser.add_argument("--flash-algo-file", type=str,
+                        help="Elf, axf, or flm to extract flash algo from")
+    parser.add_argument("--target-ram-start", type=str,
+                        help="Lowest address of target RAM for flash algo in hex")
+    parser.add_argument("--target-ram-end", type=str,
+                        help="Highest address of target RAM for flash algo in hex")
+    parser.add_argument("--flash-blob-entry", type=str, default="0x20000000",
+                         help="Entry point of flash algo in the target")
     args = parser.parse_args()
-    post_build_script(args.input, args.output, args.board_id, args.family_id, args.bin_offset)
+    post_build_script(args.input, args.output, args.board_id, args.family_id, args.bin_offset, args.flash_algo_file, args.target_ram_start, args.target_ram_end, args.flash_blob_entry)


### PR DESCRIPTION
Notes:
1. The flash blob and data structs will be placed at the end of the binary before the crc.
2. Needed a target ram start and end arguments and only support single regions but can easily be extended.
3. Flash blob entry has a default 0x20000000 value but can be specified.
4. Imported flash_algo.py from mbed flash algo script project.