### PR TITLE
Update the ep_agora config to closer match the nRF52840DK config

### DIFF
--- a/source/board/ep_agora.c
+++ b/source/board/ep_agora.c
@@ -22,11 +22,12 @@
 #include "target_board.h"
 #include "target_family.h"
 
-extern target_cfg_t target_device_nrf52840_256;
+extern target_cfg_t target_device_nrf52840;
 
 const board_info_t g_board_info = {
     .infoVersion = 0x0002,
+    .flags = kEnablePageErase,
     .board_id = "2600",
     .family_id = kNordic_Nrf52_FamilyID,
-    .target_cfg = &target_device_nrf52840_256,
+    .target_cfg = &target_device_nrf52840,
 };


### PR DESCRIPTION
This PR brings the `ep_agora` board configuration closer in line with the configuration of the nRF52840DK.

@flit @0xc0170 @ARMmbed/team-embeddedplanet 