### PR TITLE
MIMXRT1050: Undo changes to make drag-n-drop to work

### DIFF
--- a/source/board/mimxrt1050_evk.c
+++ b/source/board/mimxrt1050_evk.c
@@ -26,7 +26,6 @@ const board_info_t g_board_info = {
     .infoVersion = 0x0,
     .board_id = "0227",
     .family_id = kNXP_Mimxrt_FamilyID,
-    .flags = kEnablePageErase,
     .daplink_url_name =       "PRODINFOHTM",
     .daplink_drive_name = 		"RT1050-EVK",
     .daplink_target_url = "http://www.nxp.com/imxrt1050evk",

--- a/source/family/freescale/target_reset_mimxrt.c
+++ b/source/family/freescale/target_reset_mimxrt.c
@@ -31,7 +31,10 @@ static void target_before_init_debug(void)
     // RESET pin to high state ensure a successfully access. If external debugger not
     // connected. It's not necessary for doing that.
     swd_set_target_reset(0);
+}
 
+static void prerun_target_config(void)
+{
     // In some case the CPU will enter "cannot debug" state (low power, SWD pin mux changed, etc.).
     // Doing a hardware reset will clear those states (probably, depends on app). Also, if the
     // external flash's data is not a valid bootable image, DAPLink cannot attached to target. A
@@ -56,5 +59,6 @@ const target_family_descriptor_t g_nxp_mimxrt = {
     .default_reset_type = kSoftwareReset,
     .soft_reset_type = VECTRESET,
     .target_before_init_debug = target_before_init_debug,
+    .prerun_target_config = prerun_target_config,
     .validate_bin_nvic = validate_bin_nvic,
 };


### PR DESCRIPTION
Undo commits 3384e8c & 1755522. These changes were added to the original MXRT1050 code and cause failures during drag-n-drop operation