### PR TITLE
Add experimental GCC ARM toolchain

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -53,6 +53,9 @@ module:
     hic_lpc11u35: &module_hic_lpc11u35
         - records/rtos/rtos-cm0.yaml
         - records/hic_hal/lpc11u35.yaml
+    hic_lpc11u35_bm: &module_hic_lpc11u35_bm
+        - records/rtos/rtos-none.yaml
+        - records/hic_hal/lpc11u35.yaml
     hic_lpc4322: &module_hic_lpc4322
         - records/rtos/rtos-cm3.yaml
         - records/hic_hal/lpc4322.yaml
@@ -321,6 +324,10 @@ projects:
     lpc11u35_archble_if:
         - *module_if
         - *module_hic_lpc11u35
+        - records/board/archble.yaml
+    lpc11u35_archble_if_bm:
+        - *module_if
+        - *module_hic_lpc11u35_bm
         - records/board/archble.yaml
     lpc11u35_tiny_if:
         - *module_if

--- a/records/hic_hal/lpc11u35.yaml
+++ b/records/hic_hal/lpc11u35.yaml
@@ -9,11 +9,8 @@ common:
         - OS_CLOCK=48000000
     includes:
         - source/hic_hal/nxp/lpc11u35
-        - source/hic_hal/nxp/lpc11u35
     sources:
         hic_hal:
-            - source/hic_hal/nxp/lpc11u35
-            - source/hic_hal/nxp/lpc11u35/armcc
             - source/hic_hal/nxp/lpc11u35
 
 tool_specific:
@@ -21,7 +18,22 @@ tool_specific:
         misc:
             ld_flags:
                 - --predefine="-I..\..\..\source\hic_hal\nxp\lpc11u35"
+        sources:
+            hic_hal:
+                - source/hic_hal/nxp/lpc11u35/armcc
+
     make_armcc:
         misc:
             ld_flags:
                 - --predefine="-Isource\hic_hal\nxp\lpc11u35"
+        sources:
+            hic_hal:
+                - source/hic_hal/nxp/lpc11u35/armcc
+
+    make_gcc_arm:
+        linker_file:
+            - source/hic_hal/nxp/lpc11u35/gccarm/lpc11u35.ld
+
+        sources:
+            hic_hal:
+                - source/hic_hal/nxp/lpc11u35/gccarm

--- a/records/tools/make_gcc_arm.yaml
+++ b/records/tools/make_gcc_arm.yaml
@@ -3,20 +3,23 @@ tool_specific:
         mcu:
             - cortex-m0
         macros:
-            -
+            - __weak=__attribute__\(\(weak\)\)
+            - __forceinline=inline\ __attribute__\(\(always_inline\)\)
         misc:
             libraries:
                 - m
                 - gcc
                 - c
                 - nosys
-            optimization:
-                - O3
-            compiler_options:
-                - Wall
-                - ffunction-sections
-                - fdata-sections
-            linker_options:
-                - nostartfiles
+            c_flags:
+                - -std=gnu99
+                - -fshort-wchar
+            common_flags:
+                - -Os
+                - -Wall
+                - -ffunction-sections
+                - -fdata-sections
+            ld_flags:
+                - -nostartfiles
 
 

--- a/source/daplink/HardFault_Handler.c
+++ b/source/daplink/HardFault_Handler.c
@@ -24,6 +24,7 @@
 #include "util.h"
 #include "cortex_m.h"
 
+#if defined(__CC_ARM)
 register unsigned int _psp __asm("psp");
 register unsigned int _msp __asm("msp");
 register unsigned int _lr __asm("lr");
@@ -76,3 +77,12 @@ void HardFault_Handler()
 
     while (1); // Wait for reset
 }
+#else
+void HardFault_Handler()
+{
+    util_assert(0);
+    SystemReset();
+
+    while (1); // Wait for reset
+}
+#endif

--- a/source/daplink/cortex_m.h
+++ b/source/daplink/cortex_m.h
@@ -37,7 +37,14 @@ __attribute__((always_inline))
 static cortex_int_state_t cortex_int_get_and_disable(void)
 {
     cortex_int_state_t state;
+
+#if defined(__CC_ARM)
     state = __disable_irq();
+#else
+    // todo - get irq state, __disable_irq() doesn't have a return value
+    state = 0;
+   __disable_irq();
+#endif
     return state;
 }
 

--- a/source/daplink/info.c
+++ b/source/daplink/info.c
@@ -109,7 +109,7 @@ static void setup_basics(void)
 #pragma push
 #pragma O0
 static void setup_basics(void)
-#elif (!defined(__GNUC__))
+#elif (defined(__GNUC__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 static void __attribute__((optimize("O0"))) setup_basics(void)

--- a/source/family/nordic/target_reset_nrf51.c
+++ b/source/family/nordic/target_reset_nrf51.c
@@ -25,7 +25,7 @@
 #include "target_family.h"
 #include "target_board.h"
 
-static void swd_set_target_reset(uint8_t asserted)
+static void _swd_set_target_reset(uint8_t asserted)
 {
     if (asserted) {
         swd_init_debug();
@@ -59,5 +59,5 @@ const target_family_descriptor_t g_nordic_nrf51 = {
     .family_id = kNordic_Nrf51_FamilyID,
     .default_reset_type = kSoftwareReset,
     .soft_reset_type = SYSRESETREQ,
-    .swd_set_target_reset = swd_set_target_reset,
+    .swd_set_target_reset = _swd_set_target_reset,
 };

--- a/source/hic_hal/nxp/lpc11u35/gccarm/lpc11u35.ld
+++ b/source/hic_hal/nxp/lpc11u35/gccarm/lpc11u35.ld
@@ -5,8 +5,10 @@
 
 MEMORY
 {
-  irom  (rx)      : ORIGIN = 0x0,         LENGTH = 0x10000 /* 64k */
-  isram (rwx)     : ORIGIN = 0x10000000,  LENGTH = 0x2000  /* 8k   */
+  irom  (rx)      : ORIGIN = 0x0,         LENGTH = 0xF000  /* 60k  */
+  icfgrom  (rx)   : ORIGIN = 0x0000F000,  LENGTH = 0x1000  /* 4k   */
+  isram (rwx)     : ORIGIN = 0x10000000,  LENGTH = 0x1ED0  /* 8k - 0x120 */
+  icfgram (rwx)   : ORIGIN = 0x10001ED0,  LENGTH = 0x100   /* 0x120   */
   isramUsb (rwx)  : ORIGIN = 0x20004000,  LENGTH = 0x800   /* 2k   */
 }
 
@@ -48,6 +50,19 @@ SECTIONS
     KEEP(*(.ARM.exidx* .gnu.linkonce.armexidx.*))
   } > irom
   __exidx_end = .;
+
+  /* cfg rom */
+  .cfgrom : ALIGN(4)
+  {
+    KEEP(*(cfgrom))
+  } > icfgrom
+
+
+  /* cfg rom */
+  .cfgram : ALIGN(4)
+  {
+    KEEP(*(cfgram))
+  } > icfgram
 
   /* This is used for USB RAM section */
   .usb_ram (NOLOAD): ALIGN(4)

--- a/source/hic_hal/nxp/lpc11u35/gccarm/lpc11u35.ld
+++ b/source/hic_hal/nxp/lpc11u35/gccarm/lpc11u35.ld
@@ -1,0 +1,89 @@
+/*
+ * LPC11u35 linker script file.
+ * This linker is intended to use with libc.
+ */
+
+MEMORY
+{
+  irom  (rx)      : ORIGIN = 0x0,         LENGTH = 0x10000 /* 64k */
+  isram (rwx)     : ORIGIN = 0x10000000,  LENGTH = 0x2000  /* 8k   */
+  isramUsb (rwx)  : ORIGIN = 0x20004000,  LENGTH = 0x800   /* 2k   */
+}
+
+  /* Define a symbol for the top of stack */
+  /* It won't be used if user define FIXED_STACKHEAP_SIZE */
+  __StackTop = ORIGIN(isram) + LENGTH(isram);
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+  /* MAIN TEXT SECTION */
+  .text : ALIGN(4)
+  {
+    __text_start = .;
+    FILL(0xff)
+    /* Always keep this vector table */
+    KEEP(*(.isr_vector_table))
+    *(.after_vectors*)
+    *(.text*)
+    *(.rodata .rodata.*)
+    . = ALIGN(4);
+    __text_end = .;
+  } > irom
+
+  /*
+   * For exception handling/unwind - some Newlib functions (in common
+   * with C++ and STDC++) use this.
+   * Use KEEP so it's not discarded with --gc-sections
+   */
+  .ARM.extab : ALIGN(4)
+  {
+    KEEP(*(.ARM.extab* .gnu.linkonce.armextab.*))
+  } > irom
+  __exidx_start = .;
+
+  .ARM.exidx : ALIGN(4)
+  {
+    KEEP(*(.ARM.exidx* .gnu.linkonce.armexidx.*))
+  } > irom
+  __exidx_end = .;
+
+  /* This is used for USB RAM section */
+  .usb_ram (NOLOAD): ALIGN(4)
+  {
+    FILL(0xff)
+    *(USB_RAM)
+  } > isramUsb
+
+  /* MAIN BSS SECTION */
+  .bss 0x10000100: ALIGN(4)
+  {
+    __bss_start = .;
+    *(.bss*)
+    rt_*.o(COMMON)
+    *(COMMON)
+    *(.heap)
+    __fixed_heap_end = .;
+    *(.stack)
+    . = ALIGN(4) ;
+    __bss_end = .;
+    PROVIDE(end = .);
+  } > isram
+
+  __data_load_addr = LOADADDR (.data);
+  
+  .data : ALIGN(4)
+  {
+    FILL(0xff)
+    __data_start = .;
+    *(.data*)
+    . = ALIGN(4) ;
+    __data_end = .;
+  } > isram AT>irom
+  
+  
+  /* Define a symbol for the start of heap */
+  /* It won't be used if user defined FIXED_STACKHEAP_SIZE */
+  PROVIDE(_pvHeapStart = .);
+}

--- a/source/hic_hal/nxp/lpc11u35/gccarm/startup_LPC11Uxx.c
+++ b/source/hic_hal/nxp/lpc11u35/gccarm/startup_LPC11Uxx.c
@@ -1,0 +1,278 @@
+/*================================*/
+/*=====LPC11XX GNU STARTUP========*/
+/*==A CODERED COMPATIBLE STARTUP==*/
+/*================================*/
+#if defined (__cplusplus)
+#ifdef __REDLIB__
+#error Redlib does not support C++
+#else
+//*****************************************************************************
+//
+// The entry point for the C++ library startup
+//
+//*****************************************************************************
+extern "C"
+{
+  extern void __libc_init_array(void);
+}
+#endif
+#endif
+
+#define WEAK __attribute__ ((weak))
+#define ALIAS(f) __attribute__ ((weak, alias (#f)))
+
+#include "LPC11Uxx.h"
+
+//*****************************************************************************
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+extern unsigned int __data_load_addr;
+extern unsigned int __data_start;
+extern unsigned int __data_end;
+extern unsigned int __bss_start;
+extern unsigned int __bss_end;
+extern unsigned int __StackTop;
+#ifdef FIXED_STACKHEAP_SIZE
+#define STACK_SIZE  (800)
+#define HEAP_SIZE  (200)
+unsigned char StackMem[STACK_SIZE] __attribute__ ((section(".stack")));
+unsigned char HeapMem[HEAP_SIZE] __attribute__ ((section(".heap"), align(8)));
+#endif
+//*****************************************************************************
+//
+// Forward declaration of the default handlers. These are aliased.
+// When the application defines a handler (with the same name), this will
+// automatically take precedence over these weak definitions
+//
+//*****************************************************************************
+     void Reset_Handler(void);
+WEAK void NMI_Handler(void);
+WEAK void HardFault_Handler(void);
+WEAK void SVC_Handler(void);
+WEAK void PendSV_Handler(void);
+WEAK void SysTick_Handler(void);
+WEAK void IntDefaultHandler(void);
+//*****************************************************************************
+//
+// Forward declaration of the specific IRQ handlers. These are aliased
+// to the IntDefaultHandler, which is a 'forever' loop. When the application
+// defines a handler (with the same name), this will automatically take
+// precedence over these weak definitions
+//
+//*****************************************************************************
+
+void FLEX_INT0_IRQHandler (void) ALIAS(IntDefaultHandler);
+void FLEX_INT1_IRQHandler (void) ALIAS(IntDefaultHandler);
+void FLEX_INT2_IRQHandler (void) ALIAS(IntDefaultHandler);
+void FLEX_INT3_IRQHandler (void) ALIAS(IntDefaultHandler);
+void FLEX_INT4_IRQHandler (void) ALIAS(IntDefaultHandler);
+void FLEX_INT5_IRQHandler (void) ALIAS(IntDefaultHandler);
+void FLEX_INT6_IRQHandler (void) ALIAS(IntDefaultHandler);
+void FLEX_INT7_IRQHandler (void) ALIAS(IntDefaultHandler);
+void GINT0_IRQHandler     (void) ALIAS(IntDefaultHandler);
+void GINT1_IRQHandler     (void) ALIAS(IntDefaultHandler);
+void SSP1_IRQHandler      (void) ALIAS(IntDefaultHandler);
+void I2C_IRQHandler       (void) ALIAS(IntDefaultHandler);
+void TIMER16_0_IRQHandler (void) ALIAS(IntDefaultHandler);
+void TIMER16_1_IRQHandler (void) ALIAS(IntDefaultHandler);
+void TIMER32_0_IRQHandler (void) ALIAS(IntDefaultHandler);
+void TIMER32_1_IRQHandler (void) ALIAS(IntDefaultHandler);
+void SSP0_IRQHandler      (void) ALIAS(IntDefaultHandler);
+void UART_IRQHandler      (void) ALIAS(IntDefaultHandler);
+void USB_IRQHandler       (void) ALIAS(IntDefaultHandler);
+void USB_FIQHandler       (void) ALIAS(IntDefaultHandler);
+void ADC_IRQHandler       (void) ALIAS(IntDefaultHandler);
+void WDT_IRQHandler       (void) ALIAS(IntDefaultHandler);
+void BOD_IRQHandler       (void) ALIAS(IntDefaultHandler);
+void FMC_IRQHandler       (void) ALIAS(IntDefaultHandler);
+void USBWakeup_IRQHandler (void) ALIAS(IntDefaultHandler);
+
+//*****************************************************************************
+//
+// The entry point for the application.
+// __main() is the entry point for Redlib based applications
+// main() is the entry point for Newlib based applications
+//
+//*****************************************************************************
+#if defined (__REDLIB__)
+extern void __main(void);
+#else
+extern int main(void);
+#endif
+
+//*****************************************************************************
+#if defined (__cplusplus)
+} // extern "C"
+#endif
+
+__attribute__ ((section(".isr_vector_table")))
+void (* const Vectors[])(void) = {
+#ifdef FIXED_STACKHEAP_SIZE
+  (void (*)(void))(StackMem + STACK_SIZE),          // The initial stack pointer
+#else
+  (void (*)(void))&__StackTop,
+#endif
+  Reset_Handler,                    // The reset handler
+  NMI_Handler,                      // The NMI handler
+  HardFault_Handler,                // The hard fault handler
+  0,                                // Reserved
+  0,                                // Reserved
+  0,                                // Reserved
+  0,                                // Reserved
+  0,                                // Reserved
+  0,                                // Reserved
+  0,                                // Reserved
+  SVC_Handler,                      // SVCall handler
+  0,                                // Reserved
+  0,                                // Reserved
+  PendSV_Handler,                   // The PendSV handler
+  SysTick_Handler,                  // The SysTick handler
+
+  // LPC11U specific handlers
+  FLEX_INT0_IRQHandler,             //  0 - GPIO pin interrupt 0
+  FLEX_INT1_IRQHandler,             //  1 - GPIO pin interrupt 1
+  FLEX_INT2_IRQHandler,             //  2 - GPIO pin interrupt 2
+  FLEX_INT3_IRQHandler,             //  3 - GPIO pin interrupt 3
+  FLEX_INT4_IRQHandler,             //  4 - GPIO pin interrupt 4
+  FLEX_INT5_IRQHandler,             //  5 - GPIO pin interrupt 5
+  FLEX_INT6_IRQHandler,             //  6 - GPIO pin interrupt 6
+  FLEX_INT7_IRQHandler,             //  7 - GPIO pin interrupt 7
+  GINT0_IRQHandler,                 //  8 - GPIO GROUP0 interrupt
+  GINT1_IRQHandler,                 //  9 - GPIO GROUP1 interrupt
+  0,                                // 10 - Reserved
+  0,                                // 11 - Reserved
+  0,                                // 12 - Reserved
+  0,                                // 13 - Reserved
+  SSP1_IRQHandler,                  // 14 - SPI/SSP1 Interrupt
+  I2C_IRQHandler,                   // 15 - I2C0
+  TIMER16_0_IRQHandler,             // 16 - CT16B0 (16-bit Timer 0)
+  TIMER16_1_IRQHandler,             // 17 - CT16B1 (16-bit Timer 1)
+  TIMER32_0_IRQHandler,             // 18 - CT32B0 (32-bit Timer 0)
+  TIMER32_1_IRQHandler,             // 19 - CT32B1 (32-bit Timer 1)
+  SSP0_IRQHandler,                  // 20 - SPI/SSP0 Interrupt
+  UART_IRQHandler,                  // 21 - UART0
+  USB_IRQHandler,                   // 22 - USB IRQ
+  USB_FIQHandler,                   // 23 - USB FIQ
+  ADC_IRQHandler,                   // 24 - ADC (A/D Converter)
+  WDT_IRQHandler,                   // 25 - WDT (Watchdog Timer)
+  BOD_IRQHandler,                   // 26 - BOD (Brownout Detect)
+  FMC_IRQHandler,                   // 27 - IP2111 Flash Memory Controller
+  0,                                // 28 - Reserved
+  0,                                // 29 - Reserved
+  USBWakeup_IRQHandler,             // 30 - USB wake-up interrupt
+  0,                                // 31 - Reserved
+};
+
+//*****************************************************************************
+// Reset entry point for your code.
+// Sets up a simple runtime environment and initializes the C/C++
+// library.
+//*****************************************************************************
+__attribute__ ((section(".after_vectors")))
+void Reset_Handler(void)
+{
+  /*
+   * Only Initialize Internal SRAM
+   * USB RAM is used for USB purpose
+   */
+  unsigned int *src, *dst;
+  
+  // enable RAM1, RAM2, USB RAM
+  unsigned int *sys_clk_ctrl = (unsigned int *)0x40048080;
+  
+  *sys_clk_ctrl = 0x0C00001F;
+
+  /* Copy data section from flash to RAM */
+  src = &__data_load_addr;
+  dst = &__data_start;
+  while (dst < &__data_end)
+    *dst++ = *src++;
+
+  /* Zero fill the bss section */
+  dst = &__bss_start;
+  while (dst < &__bss_end)
+    *dst++ = 0;
+
+  SystemInit();
+
+#if defined (__cplusplus)
+  //
+  // Call C++ library initialisation
+  //
+  __libc_init_array();
+#endif
+
+#if defined (__REDLIB__)
+  // Call the Redlib library, which in turn calls main()
+  __main() ;
+#else
+  main();
+#endif
+  //
+  // main() shouldn't return, but if it does, we'll just enter an infinite loop
+  //
+  while (1) {
+    ;
+  }
+}
+
+//*****************************************************************************
+// Default exception handlers. Override the ones here by defining your own
+// handler routines in your application code.
+//*****************************************************************************
+__attribute__ ((section(".after_vectors")))
+void NMI_Handler(void)
+{
+    while(1)
+    {
+    }
+}
+
+__attribute__ ((section(".after_vectors")))
+void HardFault_Handler(void)
+{
+    while(1)
+    {
+    }
+}
+
+__attribute__ ((section(".after_vectors")))
+void SVC_Handler(void)
+{
+    while(1)
+    {
+    }
+}
+
+__attribute__ ((section(".after_vectors")))
+void PendSV_Handler(void)
+{
+    while(1)
+    {
+    }
+}
+
+__attribute__ ((section(".after_vectors")))
+void SysTick_Handler(void)
+{
+    while(1)
+    {
+    }
+}
+
+//*****************************************************************************
+//
+// Processor ends up here if an unexpected interrupt occurs or a specific
+// handler is not present in the application code.
+//
+//*****************************************************************************
+__attribute__ ((section(".after_vectors")))
+void IntDefaultHandler(void)
+{
+    while(1)
+    {
+    }
+}
+

--- a/source/rtos_none/cmsis_os2_port.c
+++ b/source/rtos_none/cmsis_os2_port.c
@@ -87,3 +87,8 @@ osThreadId_t osThreadGetId (void)
 {
     return (osThreadId_t)1;
 }
+
+uint32_t osKernelGetSysTimerCount (void)
+{
+    return sysTickTime();
+}

--- a/source/target/target_board.c
+++ b/source/target/target_board.c
@@ -58,7 +58,7 @@ uint8_t flash_algo_valid(void)
 #pragma push
 #pragma O0
 uint8_t flash_algo_valid(void)
-#elif (!defined(__GNUC__))
+#elif (defined(__GNUC__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 uint8_t __attribute__((optimize("O0"))) flash_algo_valid(void)

--- a/source/usb/usb_cdc.h
+++ b/source/usb/usb_cdc.h
@@ -189,7 +189,7 @@
 /* Header functional descriptor */
 /* (usbcdc11.pdf, 5.2.3.1) */
 /* This header must precede any list of class-specific descriptors. */
-typedef __packed struct _CDC_HEADER_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _CDC_HEADER_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* Header functional descriptor subtype */
@@ -199,7 +199,7 @@ typedef __packed struct _CDC_HEADER_DESCRIPTOR {
 /* Call management functional descriptor */
 /* (usbcdc11.pdf, 5.2.3.2) */
 /* Describes the processing of calls for the communication class interface. */
-typedef __packed struct _CDC_CALL_MANAGEMENT_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _CDC_CALL_MANAGEMENT_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* call management functional descriptor subtype */
@@ -210,7 +210,7 @@ typedef __packed struct _CDC_CALL_MANAGEMENT_DESCRIPTOR {
 /* Abstract control management functional descriptor */
 /* (usbcdc11.pdf, 5.2.3.3) */
 /* Describes the command supported by the communication interface class with the Abstract Control Model subclass code. */
-typedef __packed struct _CDC_ABSTRACT_CONTROL_MANAGEMENT_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _CDC_ABSTRACT_CONTROL_MANAGEMENT_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* abstract control management functional descriptor subtype */
@@ -220,7 +220,7 @@ typedef __packed struct _CDC_ABSTRACT_CONTROL_MANAGEMENT_DESCRIPTOR {
 /* Union functional descriptors */
 /* (usbcdc11.pdf, 5.2.3.8) */
 /* Describes the relationship between a group of interfaces that can be considered to form a functional unit. */
-typedef __packed struct _CDC_UNION_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _CDC_UNION_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* union functional descriptor subtype */
@@ -229,7 +229,7 @@ typedef __packed struct _CDC_UNION_DESCRIPTOR {
 
 /* Union functional descriptors with one slave interface */
 /* (usbcdc11.pdf, 5.2.3.8) */
-typedef __packed struct _CDC_UNION_1SLAVE_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _CDC_UNION_1SLAVE_DESCRIPTOR {
     CDC_UNION_DESCRIPTOR sUnion;              /* Union functional descriptor */
     U8                   bSlaveInterfaces[1]; /* Slave interface 0 */
 } CDC_UNION_1SLAVE_DESCRIPTOR;
@@ -237,7 +237,7 @@ typedef __packed struct _CDC_UNION_1SLAVE_DESCRIPTOR {
 /* Line coding structure */
 /* Format of the data returned when a GetLineCoding request is received */
 /* (usbcdc11.pdf, 6.2.13) */
-typedef __packed struct _CDC_LINE_CODING {
+typedef PRE_PACK struct POST_PACK _CDC_LINE_CODING {
     U32 dwDTERate;                            /* Data terminal rate in bits per second */
     U8  bCharFormat;                          /* Number of stop bits */
     U8  bParityType;                          /* Parity bit type */

--- a/source/usb/usb_def.h
+++ b/source/usb/usb_def.h
@@ -27,6 +27,27 @@
 #include <stdint.h>
 #include <stddef.h>
 
+
+#if defined(__GNUC__)
+/* As per http://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html#Attribute-Syntax,
+6.29 Attributes Syntax
+"An attribute specifier list may appear as part of a struct, union or
+enum specifier. It may go either immediately after the struct, union
+or enum keyword, or after the closing brace. The former syntax is
+preferred. Where attribute specifiers follow the closing brace, they
+are considered to relate to the structure, union or enumerated type
+defined, not to any enclosing declaration the type specifier appears
+in, and the type defined is not complete until after the attribute
+specifiers."
+So use POST_PACK immediately after struct keyword
+*/
+#define PRE_PACK
+#define POST_PACK	__attribute__((__packed__))
+#elif defined(__CC_ARM)
+#define PRE_PACK	__packed
+#define POST_PACK
+#endif
+
 #ifndef NULL
  #ifdef __cplusplus
   #define NULL          0
@@ -44,14 +65,14 @@
  typedef unsigned int   size_t;
 #endif
 
-typedef signed char     S8;
-typedef unsigned char   U8;
-typedef short           S16;
-typedef unsigned short  U16;
-typedef int             S32;
-typedef unsigned int    U32;
-typedef long long       S64;
-typedef unsigned long long U64;
+typedef int8_t          S8;
+typedef uint8_t         U8;
+typedef int16_t         S16;
+typedef uint16_t        U16;
+typedef int32_t         S32;
+typedef uint32_t        U32;
+typedef int64_t         S64;
+typedef uint64_t        U64;
 typedef unsigned char   BIT;
 typedef unsigned int    BOOL;
 
@@ -80,7 +101,7 @@ typedef unsigned int    BOOL;
 #define REQUEST_TO_OTHER           3
 
 /* bmRequestType Definition */
-typedef __packed struct _REQUEST_TYPE {
+typedef PRE_PACK struct POST_PACK _REQUEST_TYPE {
     U8 Recipient : 5;                     /* D4..0: Recipient */
     U8 Type      : 2;                     /* D6..5: Type */
     U8 Dir       : 1;                     /* D7:    Data Phase Txsfer Direction */
@@ -109,19 +130,19 @@ typedef __packed struct _REQUEST_TYPE {
 #define USB_FEATURE_REMOTE_WAKEUP              1
 
 /* USB Default Control Pipe Setup Packet */
-typedef __packed struct _USB_SETUP_PACKET {
+typedef PRE_PACK struct POST_PACK _USB_SETUP_PACKET {
     REQUEST_TYPE bmRequestType;           /* bmRequestType */
     U8  bRequest;                         /* bRequest */
-    __packed union {
+    PRE_PACK union POST_PACK {
         U16        wValue;                  /* wValue */
-        __packed struct {
+        PRE_PACK struct POST_PACK {
             U8         wValueL;
             U8         wValueH;
         };
     };
-    __packed union {
+    PRE_PACK union POST_PACK {
         U16        wIndex;                  /* wIndex */
-        __packed struct {
+        PRE_PACK struct POST_PACK {
             U8         wIndexL;
             U8         wIndexH;
         };
@@ -206,7 +227,7 @@ typedef __packed struct _USB_SETUP_PACKET {
 #define USB_DEVICE_CAPABILITY_WIRELESS_USB_EXT              12
 
 /* USB Standard Device Descriptor */
-typedef __packed struct _USB_DEVICE_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_DEVICE_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bcdUSB;
@@ -224,7 +245,7 @@ typedef __packed struct _USB_DEVICE_DESCRIPTOR {
 } USB_DEVICE_DESCRIPTOR;
 
 /* USB 2.0 Device Qualifier Descriptor */
-typedef __packed struct _USB_DEVICE_QUALIFIER_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_DEVICE_QUALIFIER_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bcdUSB;
@@ -237,7 +258,7 @@ typedef __packed struct _USB_DEVICE_QUALIFIER_DESCRIPTOR {
 } USB_DEVICE_QUALIFIER_DESCRIPTOR;
 
 /* USB Standard Configuration Descriptor */
-typedef __packed struct _USB_CONFIGURATION_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_CONFIGURATION_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 wTotalLength;
@@ -249,7 +270,7 @@ typedef __packed struct _USB_CONFIGURATION_DESCRIPTOR {
 } USB_CONFIGURATION_DESCRIPTOR;
 
 /* USB Standard Interface Descriptor */
-typedef __packed struct _USB_INTERFACE_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_INTERFACE_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bInterfaceNumber;
@@ -262,7 +283,7 @@ typedef __packed struct _USB_INTERFACE_DESCRIPTOR {
 } USB_INTERFACE_DESCRIPTOR;
 
 /* USB Standard Endpoint Descriptor */
-typedef __packed struct _USB_ENDPOINT_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_ENDPOINT_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bEndpointAddress;
@@ -272,20 +293,20 @@ typedef __packed struct _USB_ENDPOINT_DESCRIPTOR {
 } USB_ENDPOINT_DESCRIPTOR;
 
 /* USB String Descriptor */
-typedef __packed struct _USB_STRING_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_STRING_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bString/*[]*/;
 } USB_STRING_DESCRIPTOR;
 
 /* USB Common Descriptor */
-typedef __packed struct _USB_COMMON_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_COMMON_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
 } USB_COMMON_DESCRIPTOR;
 
 /* USB Interface Association Descriptor */
-typedef __packed struct _USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bFirstInterface;
@@ -297,7 +318,7 @@ typedef __packed struct _USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
 } USB_INTERFACE_ASSOCIATION_DESCRIPTOR;
 
 /* USB Binary Object Store Descriptor */
-typedef __packed struct _USB_BINARY_OBJECT_STORE_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_BINARY_OBJECT_STORE_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 wTotalLength;
@@ -305,7 +326,7 @@ typedef __packed struct _USB_BINARY_OBJECT_STORE_DESCRIPTOR {
 } USB_BINARY_OBJECT_STORE_DESCRIPTOR;
 
 /* Union Functional Descriptor */ 
-typedef __packed struct _UNION_FUNCTIONAL_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _UNION_FUNCTIONAL_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDescriptorSubtype;
@@ -313,7 +334,7 @@ typedef __packed struct _UNION_FUNCTIONAL_DESCRIPTOR {
     U8  bSlaveInterface0;
 } UNION_FUNCTIONAL_DESCRIPTOR;
 
-typedef __packed struct _WINUSB_FUNCTION_SUBSET_HEADER {
+typedef PRE_PACK struct POST_PACK _WINUSB_FUNCTION_SUBSET_HEADER {
     U16 wLength;
     U16 wDescriptorType; 
     U8  bFirstInterface;
@@ -321,7 +342,7 @@ typedef __packed struct _WINUSB_FUNCTION_SUBSET_HEADER {
 } WINUSB_FUNCTION_SUBSET_HEADER;
 
 /* USB Device Capability Descriptor */
-typedef __packed struct _USB_DEVICE_CAPABILITY_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _USB_DEVICE_CAPABILITY_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDevCapabilityType;

--- a/source/usb/usb_hid.h
+++ b/source/usb/usb_hid.h
@@ -42,14 +42,14 @@
 
 
 /* HID Descriptor */
-typedef __packed struct _HID_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _HID_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bcdHID;
     U8  bCountryCode;
     U8  bNumDescriptors;
     /* Array of one or more descriptors */
-    __packed struct _HID_DESCRIPTOR_LIST {
+    PRE_PACK struct POST_PACK _HID_DESCRIPTOR_LIST {
         U8  bDescriptorType;
         U16 wDescriptorLength;
     } DescriptorList[1];

--- a/source/usb/usb_msc.h
+++ b/source/usb/usb_msc.h
@@ -54,7 +54,7 @@
 
 
 /* Bulk-only Command Block Wrapper */
-typedef __packed struct _MSC_CBW {
+typedef PRE_PACK struct POST_PACK _MSC_CBW {
     U32 dSignature;
     U32 dTag;
     U32 dDataLength;
@@ -65,7 +65,7 @@ typedef __packed struct _MSC_CBW {
 } MSC_CBW;
 
 /* Bulk-only Command Status Wrapper */
-typedef __packed struct _MSC_CSW {
+typedef PRE_PACK struct POST_PACK _MSC_CSW {
     U32 dSignature;
     U32 dTag;
     U32 dDataResidue;

--- a/source/usb/usb_webusb.h
+++ b/source/usb/usb_webusb.h
@@ -29,7 +29,7 @@
 #define WEBUSB_URL_TYPE                         0x03
 
 /* WebUSB Platform Capability Descriptor */
-typedef __packed struct _WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDevCapabilityType;
@@ -40,7 +40,7 @@ typedef __packed struct _WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
     U8  iLandingPage;
 } WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR;
 
-typedef __packed struct _WEBUSB_URL_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _WEBUSB_URL_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bScheme;

--- a/source/usb/usb_winusb.h
+++ b/source/usb/usb_winusb.h
@@ -37,7 +37,7 @@
 #define WINUSB_PROP_DATA_TYPE_REG_MULTI_SZ          0x07
 
 /* WinUSB Microsoft OS 2.0 descriptor Platform Capability Descriptor */
-typedef __packed struct _WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
+typedef PRE_PACK struct POST_PACK _WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDevCapabilityType;
@@ -50,7 +50,7 @@ typedef __packed struct _WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
 } WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR;
 
 /* WinUSB Microsoft OS 2.0 descriptor set header */
-typedef __packed struct _WINUSB_DESCRIPTOR_SET_HEADER {
+typedef PRE_PACK struct POST_PACK _WINUSB_DESCRIPTOR_SET_HEADER {
     U16 wLength;
     U16 wDescriptorType;
     U32 dwWindowsVersion;

--- a/source/usb/usbd_core.c
+++ b/source/usb/usbd_core.c
@@ -44,12 +44,14 @@ OS_TID USBD_RTX_CoreTask;           /* USB Core Task ID */
 #endif
 
 
+#ifndef __GNUC__
 __asm void $$USBD$$version(void)
 {
     /* Export a version number symbol for a version control. */
     EXPORT  __RL_USBD_VER
 __RL_USBD_VER   EQU     0x470
 }
+#endif
 
 
 /*


### PR DESCRIPTION
To support GCC ARM toolchain:

1.  convert some attributes

    + [`__weak` to `__attribute__((weak))`](https://github.com/xiongyihui/DAPLink/blob/gccarm/records/tools/make_gcc_arm.yaml#L6)
    + `__forceinline` to `inline __attribute__((always_inline))`
    + `__packed` to `__attribute__((__packed__))`, also need to change its location, for example

      convert `__packed struct { char a; int b; } c;` to `struct __attribute__((__packed__)) { char a; int b; } c;`.
      it is used by USB stack

2.  wide character array defined by `L"a wide string"`

    By default, gcc uses 4 bytes to store a wide char, while armcc uses 2 bytes. In order to be compatible with armcc, add `-fshort-wchar` to gcc compiler flags.

3. convert asm code

Right now, it work partially. To test it.
```
rm source/daplink/interface/SVC_Table.s
progen generate -f projects.yaml -p lpc11u35_archble_if_bm -t make_gcc_arm
cd projectfiles/make_gcc_arm/lpc11u35_archble_if_bm
make
```


