### PR TITLE
Cleanup board info version

### DIFF
--- a/source/board/6LoWPAN_BorderRouterETHERNET.c
+++ b/source/board/6LoWPAN_BorderRouterETHERNET.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "7404",
     .family_id = kNXP_KinetisK_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/6LoWPAN_BorderRouterHAT.c
+++ b/source/board/6LoWPAN_BorderRouterHAT.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "7402",
     .family_id = kNXP_KinetisK_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/6LoWPAN_BorderRouterUSB.c
+++ b/source/board/6LoWPAN_BorderRouterUSB.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "7403",
     .family_id = kNXP_KinetisK_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/96b_nitrogen.c
+++ b/source/board/96b_nitrogen.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "9014",
     .family_id = kNordic_Nrf52_FamilyID,
     .target_cfg = &target_device_nrf52,

--- a/source/board/FF1705_L151.c
+++ b/source/board/FF1705_L151.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "8080",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_url_name =       "FF1705  HTM",

--- a/source/board/archble.c
+++ b/source/board/archble.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "9009",
     .family_id = kNordic_Nrf51_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/archlink.c
+++ b/source/board/archlink.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "9013",
     .family_id = kNordic_Nrf51_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/archmax.c
+++ b/source/board/archmax.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "9011",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/archpro.c
+++ b/source/board/archpro.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "9004",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/arm_watch_efm32.c
+++ b/source/board/arm_watch_efm32.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "5051",
     .family_id = kStub_SWSysReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/arm_watch_nrf51.c
+++ b/source/board/arm_watch_nrf51.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "5052",
     .family_id = kNordic_Nrf51_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/arm_watch_stm32f411.c
+++ b/source/board/arm_watch_stm32f411.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "5050",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/blueninja.c
+++ b/source/board/blueninja.c
@@ -35,7 +35,7 @@ static uint8_t target_set_state_by_board(TARGET_RESET_STATE state)
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "7010",
     .family_id = kToshiba_Tz_FamilyID,
     .target_set_state = target_set_state_by_board,

--- a/source/board/c027.c
+++ b/source/board/c027.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1234",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/cocorico.c
+++ b/source/board/cocorico.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "C000",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/dipdap_cc3220sf.c
+++ b/source/board/dipdap_cc3220sf.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "3300",
     .family_id = kTI_Cc3220sf_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/dipdap_sdt32429b.c
+++ b/source/board/dipdap_sdt32429b.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "3108",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/dipdap_sdt32439b.c
+++ b/source/board/dipdap_sdt32439b.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "3110",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/dipdap_sdt51822b.c
+++ b/source/board/dipdap_sdt51822b.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "3103",
     .family_id = kNordic_Nrf51_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/dipdap_sdt52832b.c
+++ b/source/board/dipdap_sdt52832b.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "3104",
     .family_id = kNordic_Nrf52_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/dipdap_sdt64b.c
+++ b/source/board/dipdap_sdt64b.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "3105",
     .family_id = kNXP_KinetisK_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/ep_agora.c
+++ b/source/board/ep_agora.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52840;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0002,
+    .info_version = kBoardInfoVersion,
     .flags = kEnablePageErase,
     .board_id = "2600",
     .family_id = kNordic_Nrf52_FamilyID,

--- a/source/board/ff_lpc546xx.c
+++ b/source/board/ff_lpc546xx.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "8081",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmk20dx.c
+++ b/source/board/frdmk20dx.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0230",
     .family_id = kNXP_KinetisK_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/frdmk22f.c
+++ b/source/board/frdmk22f.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0231",
     .family_id = kNXP_KinetisK_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/frdmk28f.c
+++ b/source/board/frdmk28f.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0224",
     .family_id = kNXP_KinetisK_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmk32w042.c
+++ b/source/board/frdmk32w042.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0225",
     .family_id = kNXP_KinetisK32W_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/frdmk64f.c
+++ b/source/board/frdmk64f.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0240",
     .family_id = kNXP_KinetisK_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/frdmk66f.c
+++ b/source/board/frdmk66f.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0311",
     .family_id = kNXP_KinetisK_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/frdmk82f.c
+++ b/source/board/frdmk82f.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0217",
     .family_id = kNXP_KinetisK_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmke15z.c
+++ b/source/board/frdmke15z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0213",
     .family_id = kNXP_KinetisL_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmkl02z.c
+++ b/source/board/frdmkl02z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0204",
     .family_id = kNXP_KinetisL_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/frdmkl05z.c
+++ b/source/board/frdmkl05z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0210",
     .family_id = kNXP_KinetisL_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/frdmkl25z.c
+++ b/source/board/frdmkl25z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0200",
     .family_id = kNXP_KinetisL_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/frdmkl26z.c
+++ b/source/board/frdmkl26z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0260",
     .family_id = kNXP_KinetisL_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/frdmkl27z.c
+++ b/source/board/frdmkl27z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0261",
     .family_id = kNXP_KinetisL_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmkl28z.c
+++ b/source/board/frdmkl28z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0205",
     .family_id = kNXP_KinetisL_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmkl43z.c
+++ b/source/board/frdmkl43z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0262",
     .family_id = kNXP_KinetisL_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmkl46z.c
+++ b/source/board/frdmkl46z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0220",
     .family_id = kNXP_KinetisL_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/frdmkl82z.c
+++ b/source/board/frdmkl82z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0218",
     .family_id = kNXP_KinetisL_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmkw24d.c
+++ b/source/board/frdmkw24d.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0250",
     .family_id = kNXP_KinetisK_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/frdmkw41z.c
+++ b/source/board/frdmkw41z.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0201",
     .family_id = kNXP_KinetisL_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/gr-lychee.c
+++ b/source/board/gr-lychee.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "5501",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/gr-peach.c
+++ b/source/board/gr-peach.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "5500",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/hani_iot.c
+++ b/source/board/hani_iot.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x11,
+    .info_version = kBoardInfoVersion,
     .board_id = "0360",
     .family_id = VENDOR_TO_FAMILY(kNXP_VendorID, 0), //ID not maching the predefined family ids
     .flags = kEnablePageErase,

--- a/source/board/hexiwear.c
+++ b/source/board/hexiwear.c
@@ -42,7 +42,7 @@ static void prerun_board_config(void);
 
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0214",
     .family_id = kNXP_RapidIot_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/hrm1017.c
+++ b/source/board/hrm1017.c
@@ -22,7 +22,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1017",
     .family_id = kNordic_Nrf51_FamilyID,
     .daplink_drive_name = 		"MBED       ",

--- a/source/board/hvpke18f.c
+++ b/source/board/hvpke18f.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0216",
     .family_id = kNXP_KinetisK_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/k20dx_bl.c
+++ b/source/board/k20dx_bl.c
@@ -56,7 +56,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name = 		"MAINTENANCE",

--- a/source/board/k26f_bl.c
+++ b/source/board/k26f_bl.c
@@ -55,7 +55,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =   "HELP_FAQHTM",
     .daplink_drive_name = "BOOTLOADER",

--- a/source/board/kl26z_bl.c
+++ b/source/board/kl26z_bl.c
@@ -55,7 +55,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name =       "MAINTENANCE",

--- a/source/board/lpc4088dm.c
+++ b/source/board/lpc4088dm.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1062",
     .family_id = VENDOR_TO_FAMILY(kNXP_VendorID, 0), //custom
     .target_cfg = &target_device,

--- a/source/board/lpc4088qsb.c
+++ b/source/board/lpc4088qsb.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1060",
     .family_id = VENDOR_TO_FAMILY(kNXP_VendorID, 0), //custom
     .target_cfg = &target_device,

--- a/source/board/lpc4322_bl.c
+++ b/source/board/lpc4322_bl.c
@@ -56,7 +56,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name =       "MAINTENANCE",

--- a/source/board/lpc54114xpresso.c
+++ b/source/board/lpc54114xpresso.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1054",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/lpc54608xpresso.c
+++ b/source/board/lpc54608xpresso.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1056",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/lpc55S69xpresso.c
+++ b/source/board/lpc55S69xpresso.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0236",
     .family_id = VENDOR_TO_FAMILY(kNXP_VendorID, 0), //ID not maching the predefined family ids
     .flags = kEnablePageErase,

--- a/source/board/lpc812xpresso.c
+++ b/source/board/lpc812xpresso.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1050",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/lpc824xpresso.c
+++ b/source/board/lpc824xpresso.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0824",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/m48ssidae_bl.c
+++ b/source/board/m48ssidae_bl.c
@@ -46,7 +46,7 @@ target_cfg_t target_device = {
     .sector_info_length         = (sizeof(sectors_info))/(sizeof(sector_info_t)),
     .flash_regions[0].start     = DAPLINK_ROM_IF_START,
     .flash_regions[0].end       = DAPLINK_ROM_IF_START + DAPLINK_ROM_IF_SIZE,
-    .flash_regions[0].flags     = kRegionIsDefault,  
+    .flash_regions[0].flags     = kRegionIsDefault,
     .ram_regions[0].start       = DAPLINK_RAM_START,
     .ram_regions[0].end         = DAPLINK_RAM_START + DAPLINK_RAM_SIZE,
     /* .flash_algo not needed for bootloader */
@@ -56,7 +56,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion                = 0x0,
+    .info_version               = kBoardInfoVersion,
     .board_id                   = "0000",
     .daplink_url_name           = "HELP_FAQHTM",
     .daplink_drive_name         = "MAINTENANCE",

--- a/source/board/max32620_bl.c
+++ b/source/board/max32620_bl.c
@@ -50,7 +50,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name =       "MAINTENANCE",

--- a/source/board/max32625_bl.c
+++ b/source/board/max32625_bl.c
@@ -52,7 +52,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name =       "MAINTENANCE",

--- a/source/board/mbed_cloud_connect.c
+++ b/source/board/mbed_cloud_connect.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "2410",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/microbit.c
+++ b/source/board/microbit.c
@@ -79,7 +79,7 @@ uint8_t usbd_hid_no_activity(uint8_t *buf)
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .family_id = kNordic_Nrf51_FamilyID,
     .daplink_url_name =       "MICROBITHTM",
     .daplink_drive_name =       "MICROBIT   ",

--- a/source/board/mimxrt1020_evk.c
+++ b/source/board/mimxrt1020_evk.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0226",
     .family_id = kNXP_Mimxrt_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/mimxrt1050_evk.c
+++ b/source/board/mimxrt1050_evk.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0227",
     .family_id = kNXP_Mimxrt_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/mkit_dk_dongle_nrf5x.c
+++ b/source/board/mkit_dk_dongle_nrf5x.c
@@ -132,7 +132,7 @@ static void nrf_swd_set_target_reset(uint8_t asserted){
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .flags = kEnablePageErase,
     .prerun_board_config = nrf_prerun_board_config,
     .swd_set_target_reset = nrf_swd_set_target_reset,

--- a/source/board/mtb_laird_bl652.c
+++ b/source/board/mtb_laird_bl652.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0461",
     .family_id = kNordic_Nrf52_FamilyID,
     .target_cfg = &target_device_nrf52,

--- a/source/board/mtb_laird_bl654.c
+++ b/source/board/mtb_laird_bl654.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52840_256;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0465",
     .family_id = kNordic_Nrf52_FamilyID,
     .target_cfg = &target_device_nrf52840_256,

--- a/source/board/mtb_mts_dragonfly.c
+++ b/source/board/mtb_mts_dragonfly.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0454",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/mtb_mts_xdot.c
+++ b/source/board/mtb_mts_xdot.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0453",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/mtb_murata_abz_078.c
+++ b/source/board/mtb_murata_abz_078.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0456",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/mtb_murata_bl241.c
+++ b/source/board/mtb_murata_bl241.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52_64;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0466",
     .family_id = kNordic_Nrf52_FamilyID,
     .target_cfg = &target_device_nrf52_64,

--- a/source/board/mtb_mxchip_emw3166.c
+++ b/source/board/mtb_mxchip_emw3166.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0451",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/mtb_nina_b112.c
+++ b/source/board/mtb_nina_b112.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0455",
     .family_id = kNordic_Nrf52_FamilyID,
     .target_cfg = &target_device_nrf52,

--- a/source/board/mtb_rak811.c
+++ b/source/board/mtb_rak811.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0457",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/mtb_stm_s2lp.c
+++ b/source/board/mtb_stm_s2lp.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0467",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/mtb_ublox_odin_w2.c
+++ b/source/board/mtb_ublox_odin_w2.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0450",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase|kEnableUnderResetConnect,

--- a/source/board/mtb_usi_wm_bn_bm_22.c
+++ b/source/board/mtb_usi_wm_bn_bm_22.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0462",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/mtb_wise1510.c
+++ b/source/board/mtb_wise1510.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0458",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/mtb_wise1530.c
+++ b/source/board/mtb_wise1530.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0459",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/mtb_wise1570.c
+++ b/source/board/mtb_wise1570.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0460",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase|kEnableUnderResetConnect,

--- a/source/board/mtconnect04s.c
+++ b/source/board/mtconnect04s.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "C005",
     .family_id = kNordic_Nrf51_FamilyID,
     .daplink_url_name =       "HELP    HTM",

--- a/source/board/ncs36510rf.c
+++ b/source/board/ncs36510rf.c
@@ -24,7 +24,7 @@ static void prerun_board_config()
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1200",
     .family_id = kStub_SWSysReset_FamilyID,
     .prerun_board_config = prerun_board_config,

--- a/source/board/nina_b1.c
+++ b/source/board/nina_b1.c
@@ -25,7 +25,7 @@
 extern target_cfg_t target_device_nrf52;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1238",
     .family_id = kNordic_Nrf51_FamilyID,
     .daplink_target_url = "https://os.mbed.com/platforms/VBLUNO51/",

--- a/source/board/numaker_iot_m263a.c
+++ b/source/board/numaker_iot_m263a.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id    = "1310",
     .family_id   = kStub_SWSysReset_FamilyID,
     .flags       = kEnablePageErase,

--- a/source/board/numaker_m252kg.c
+++ b/source/board/numaker_m252kg.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id    = "1309",
     .family_id   = kStub_SWSysReset_FamilyID,
     .flags       = kEnablePageErase,

--- a/source/board/nz32_sc151.c
+++ b/source/board/nz32_sc151.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "6660",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_url_name =       "NZ32-SC151 ",

--- a/source/board/rapid_iot.c
+++ b/source/board/rapid_iot.c
@@ -43,7 +43,7 @@ static void prerun_board_config(void);
 
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0228",
     .family_id = kNXP_RapidIot_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/rbl.c
+++ b/source/board/rbl.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1090",
     .family_id = kNordic_Nrf51_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/rblnano.c
+++ b/source/board/rblnano.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1095",
     .family_id = kNordic_Nrf51_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/ro359b.c
+++ b/source/board/ro359b.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1022",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_drive_name = 	"MBED       ",

--- a/source/board/rtl8195am.c
+++ b/source/board/rtl8195am.c
@@ -24,7 +24,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "4600",
     .family_id = kRealtek_Rtl8195am_FamilyID,
     .flags = kEnablePageErase,

--- a/source/board/sam3u2c_bl.c
+++ b/source/board/sam3u2c_bl.c
@@ -56,7 +56,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name =       "MAINTENANCE",

--- a/source/board/scci824.c
+++ b/source/board/scci824.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1018",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_drive_name =       "MBED       ",

--- a/source/board/ssci1114.c
+++ b/source/board/ssci1114.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1114",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_drive_name =       "MBED       ",

--- a/source/board/ssci_chibi.c
+++ b/source/board/ssci_chibi.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1021",
     .family_id = kNordic_Nrf51_FamilyID,
     .daplink_drive_name = 		"MBED       ",

--- a/source/board/sscity.c
+++ b/source/board/sscity.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1019",
     .family_id = kNordic_Nrf51_FamilyID,
     .daplink_drive_name = 		"MBED       ",

--- a/source/board/stm32f072rb.c
+++ b/source/board/stm32f072rb.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0720",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32f103rb.c
+++ b/source/board/stm32f103rb.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0700",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32f103xb_bl.c
+++ b/source/board/stm32f103xb_bl.c
@@ -50,7 +50,7 @@ target_cfg_t target_device = {
 const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0000",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name = 		"MAINTENANCE",

--- a/source/board/stm32f207zg.c
+++ b/source/board/stm32f207zg.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0835",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32f334r8.c
+++ b/source/board/stm32f334r8.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0735",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32f401re.c
+++ b/source/board/stm32f401re.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0720",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32f411re.c
+++ b/source/board/stm32f411re.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0740",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32f429zi.c
+++ b/source/board/stm32f429zi.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0796",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32f746zg.c
+++ b/source/board/stm32f746zg.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0816",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/stm32l476rg.c
+++ b/source/board/stm32l476rg.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0765",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/swdap-lpc11u35.c
+++ b/source/board/swdap-lpc11u35.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "7401",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/tiny.c
+++ b/source/board/tiny.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "9012",
     .family_id = kNordic_Nrf51_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/twrke18f.c
+++ b/source/board/twrke18f.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0206",
     .family_id = kNXP_KinetisK_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/twrkl28z72m.c
+++ b/source/board/twrkl28z72m.c
@@ -23,7 +23,7 @@
 #include "target_family.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0203",
     .family_id = kNXP_KinetisL_FamilyID,
     .daplink_url_name =       "PRODINFOHTM",

--- a/source/board/ublox_evk_nina_b1.c
+++ b/source/board/ublox_evk_nina_b1.c
@@ -30,7 +30,7 @@ static void nina_swd_set_target_reset(uint8_t asserted){
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1237",
     .family_id = kNordic_Nrf52_FamilyID,
     .swd_set_target_reset = nina_swd_set_target_reset,

--- a/source/board/ublox_evk_odin_w2.c
+++ b/source/board/ublox_evk_odin_w2.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "1236",
     .family_id = kStub_HWReset_FamilyID,
     .target_cfg = &target_device,

--- a/source/board/vbluno51.c
+++ b/source/board/vbluno51.c
@@ -29,7 +29,7 @@ static void vbluno_prerun_board_config()
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "C006",
     .family_id = kNordic_Nrf51_FamilyID,
     .daplink_target_url = "https://os.mbed.com/platforms/VBLUNO51/",

--- a/source/board/wio_emw3166.c
+++ b/source/board/wio_emw3166.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "9017",
     .family_id = kStub_HWReset_FamilyID,
     .flags = kEnablePageErase|kEnableUnderResetConnect,

--- a/source/board/wizwiki_w7500.c
+++ b/source/board/wizwiki_w7500.c
@@ -41,7 +41,7 @@ static uint8_t target_set_state_by_board(TARGET_RESET_STATE state)
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "2201",
     .family_id = kWiznet_W7500_FamilyID,
     .target_set_state = target_set_state_by_board,

--- a/source/board/wizwiki_w7500_eco.c
+++ b/source/board/wizwiki_w7500_eco.c
@@ -41,7 +41,7 @@ static uint8_t target_set_state_by_board(TARGET_RESET_STATE state)
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "2202",
     .family_id = kWiznet_W7500_FamilyID,
     .target_set_state = target_set_state_by_board,

--- a/source/board/wizwiki_w7500p.c
+++ b/source/board/wizwiki_w7500p.c
@@ -41,7 +41,7 @@ static uint8_t target_set_state_by_board(TARGET_RESET_STATE state)
 }
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "2203",
     .family_id = kWiznet_W7500_FamilyID,
     .target_set_state = target_set_state_by_board,

--- a/source/board/xDot-L151.c
+++ b/source/board/xDot-L151.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 const board_info_t g_board_info = {
-    .infoVersion = 0x0,
+    .info_version = kBoardInfoVersion,
     .board_id = "0350",
     .family_id = kStub_HWReset_FamilyID,
     .daplink_url_name =       "XDOT    HTM",

--- a/source/daplink/interface/main.c
+++ b/source/daplink/interface/main.c
@@ -213,6 +213,9 @@ void main_task(void * arg)
     // Initialize the DAP
     DAP_Setup();
 
+    // make sure we have a valid board info structure.
+    util_assert(g_board_info.info_version == kBoardInfoVersion);
+
     // do some init with the target before USB and files are configured
     if (g_board_info.prerun_board_config) {
         g_board_info.prerun_board_config();

--- a/source/target/target_board.c
+++ b/source/target/target_board.c
@@ -25,7 +25,7 @@
 // Default empty board info. 
 __attribute__((weak)) 
 const board_info_t g_board_info = {
-		.infoVersion = 0x1234,
+		.info_version = kBoardInfoVersion,
 		.board_id = "0000",
 		.daplink_url_name =       "MBED    HTM",
 		.daplink_drive_name = 		"DAPLINK    ",

--- a/source/target/target_board.h
+++ b/source/target/target_board.h
@@ -27,6 +27,13 @@
 #include "target_reset.h"
 #include "virtual_fs.h" 
 
+//! @brief Current board info version.
+//!
+//! - Version 1: Initial version.
+enum _board_info_version {
+    kBoardInfoVersion = 1, //!< The current board info version.
+};
+
 // Flags for board_info 
 enum { 
 	kEnablePageErase = 1,               /*!< Enable page programming and sector erase for drag and drop */
@@ -34,7 +41,7 @@ enum {
 };
 
 typedef struct __attribute__((__packed__)) board_info { 
-    uint16_t infoVersion;               /*!< Version number of the board */ 
+    uint16_t info_version;              /*!< Version number of the board info */ 
     uint16_t family_id;                 /*!< Use to select or identify target family from defined target family or custom ones */ 
     char board_id[5];                   /*!< 4-char board ID plus null terminator */
     uint8_t _padding[3]; 


### PR DESCRIPTION
The `board_info_t::infoVersion` member was intended to be used as the version number for the `board_info_t` struct itself, not the version of the board. This is important to ensure that board info added via post-processing a firmware binary has a known format. This PR clarifies and standardizes the usage of this version member.

Defined a `kBoardInfoVersion` constant (currently equal to 1), and set it as the current version in all defined `board_info_t` structures. Also renamed `infoVersion` to `info_version`. The interface main task asserts that `g_board_info.info_version` is valid.

(Extracted from #688.)