### PR TITLE
Change weak target family descriptors to references

### DIFF
--- a/source/target/target_family.c
+++ b/source/target/target_family.c
@@ -43,32 +43,32 @@ const target_family_descriptor_t g_sw_sysresetreq_family = {
     .soft_reset_type = SYSRESETREQ,
 };
 
-//Weakly define family
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_kinetis_kseries = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_kinetis_lseries = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_kinetis_k32w_series = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_mimxrt = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_rapid_iot = {0};
-__attribute__((weak))
-const target_family_descriptor_t  g_nordic_nrf51  = {0};
-__attribute__((weak))
-const target_family_descriptor_t  g_nordic_nrf52  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_realtek_rtl8195am  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_ti_family  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_wiznet_family  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_renesas_family  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_toshiba_tz_family  = {0};
+// Weak references to family definitions.
+extern __WEAK const target_family_descriptor_t g_nxp_kinetis_kseries;
+extern __WEAK const target_family_descriptor_t g_nxp_kinetis_lseries;
+extern __WEAK const target_family_descriptor_t g_nxp_kinetis_k32w_series;
+extern __WEAK const target_family_descriptor_t g_nxp_mimxrt;
+extern __WEAK const target_family_descriptor_t g_nxp_rapid_iot;
+extern __WEAK const target_family_descriptor_t g_nordic_nrf51;
+extern __WEAK const target_family_descriptor_t g_nordic_nrf52;
+extern __WEAK const target_family_descriptor_t g_realtek_rtl8195am;
+extern __WEAK const target_family_descriptor_t g_ti_family;
+extern __WEAK const target_family_descriptor_t g_wiznet_family;
+extern __WEAK const target_family_descriptor_t g_renesas_family;
+extern __WEAK const target_family_descriptor_t g_toshiba_tz_family;
 
+//! @brief Terminator value for g_families list.
+//!
+//! This terminator value is chosen so that weak references to the family descriptors that
+//! resolve to NULL at link time do not terminate the list early.
+#define FAMILY_LIST_TERMINATOR ((const target_family_descriptor_t *)(0xffffffff))
+
+//! @brief Default list of family descriptors.
+//!
+//! init_family() scans this list searching for a family descriptor with an ID that matches
+//! the family ID set in the board info or target config structs. Because each of the family
+//! descriptors has a weak reference defined above, the entry in this list for a family whose
+//! descriptor is not included in the link will resolve to NULL and init_family() can skip it.
 __attribute__((weak))
 const target_family_descriptor_t *g_families[] = {
     &g_hw_reset_family,
@@ -86,7 +86,7 @@ const target_family_descriptor_t *g_families[] = {
     &g_wiznet_family,
     &g_renesas_family,
     &g_toshiba_tz_family,
-    0 // list terminator
+    FAMILY_LIST_TERMINATOR // list terminator
 };
 
 __attribute__((weak))
@@ -95,21 +95,25 @@ const target_family_descriptor_t *g_target_family = NULL;
 
 void init_family(void)
 {
-    uint8_t index = 0;
-    uint16_t family_id = get_family_id();
-    if (g_target_family != NULL){ //already set
+    // Check if the family is already set.
+    if (g_target_family != NULL) {
         return;
     }
 
-    while (g_families[index]!=0) {
-        if (g_families[index]->family_id && (g_families[index]->family_id == family_id)) {
+    // Scan families table looking for matching family ID.
+    uint8_t index = 0;
+    uint16_t family_id = get_family_id();
+
+    while (g_families[index] != FAMILY_LIST_TERMINATOR) {
+        if ((g_families[index] != NULL) && (g_families[index]->family_id == family_id)) {
             g_target_family = g_families[index];
             break;
         }
         index++;
     }
 
-    if(g_target_family == NULL){ //default family
+    // Last resort is to use a default family.
+    if (g_target_family == NULL) {
         g_target_family = &g_hw_reset_family;
     }
 }
@@ -133,11 +137,11 @@ uint8_t target_set_state(target_state_t state)
                     swd_set_soft_reset(g_target_family->soft_reset_type);
                 }
                 return swd_set_target_state_sw(state);
-            }else {
+            } else {
                 return 1;
             }
         }
-    }else{
+    } else {
         return 0;
     }
 }
@@ -146,7 +150,7 @@ void swd_set_target_reset(uint8_t asserted)
 {
     if (g_target_family && g_target_family->swd_set_target_reset) {
         g_target_family->swd_set_target_reset(asserted);
-    }else {
+    } else {
         (asserted) ? PIN_nRESET_OUT(0) : PIN_nRESET_OUT(1);
     }
 }


### PR DESCRIPTION
This change replaces the default weak family descriptor structs (each taking up the full family descriptor size) in `target_family.c` with weak references. The purpose is to save `.rodata` space.