### PR TITLE
Make the JTAG2SWD function non-static

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -767,7 +767,7 @@ static uint8_t swd_read_idcode(uint32_t *id)
 }
 
 
-static uint8_t JTAG2SWD()
+uint8_t JTAG2SWD()
 {
     uint32_t tmp = 0;
 

--- a/source/daplink/interface/swd_host.h
+++ b/source/daplink/interface/swd_host.h
@@ -62,6 +62,7 @@ uint8_t swd_transfer_retry(uint32_t req, uint32_t *data);
 void int2array(uint8_t *res, uint32_t data, uint8_t len);
 void swd_set_reset_connect(SWD_CONNECT_TYPE type);
 void swd_set_soft_reset(uint32_t soft_reset_type);
+uint8_t JTAG2SWD(void);
 
 #ifdef __cplusplus
 }

--- a/source/daplink/interface/swd_host_ca.c
+++ b/source/daplink/interface/swd_host_ca.c
@@ -697,7 +697,7 @@ static uint8_t swd_read_idcode(uint32_t *id)
 }
 
 
-static uint8_t JTAG2SWD()
+uint8_t JTAG2SWD()
 {
     uint32_t tmp = 0;
 


### PR DESCRIPTION
I would like to call the JTAG2SWD() function from the target_before_init_debug() function