### PR TITLE
flashalgo flags are introduced:

### DIFF
--- a/source/daplink/interface/swd_host.c
+++ b/source/daplink/interface/swd_host.c
@@ -4,6 +4,8 @@
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
+ * Copyright 2019, Cypress Semiconductor Corporation 
+ * or a subsidiary of Cypress Semiconductor Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -687,7 +689,7 @@ static uint8_t swd_wait_until_halted(void)
     return 0;
 }
 
-uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4)
+uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4, flash_algo_return_t return_type)
 {
     DEBUG_STATE state = {{0}, 0};
     // Call flash algorithm function on target and wait for result.
@@ -718,9 +720,17 @@ uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t e
         return 0;
     }
 
-    // Flash functions return 0 if successful.
-    if (state.r[0] != 0) {
-        return 0;
+    if ( return_type == FLASHALGO_RETURN_POINTER ) {
+        // Flash verify functions return pointer to byte following the buffer if successful.
+        if (state.r[0] != (arg1 + arg2)) {
+            return 0;
+        }
+    }
+    else {
+        // Flash functions return 0 if successful.
+        if (state.r[0] != 0) {
+            return 0;
+        }
     }
 
     return 1;

--- a/source/daplink/interface/swd_host.h
+++ b/source/daplink/interface/swd_host.h
@@ -4,6 +4,8 @@
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
+ * Copyright 2019, Cypress Semiconductor Corporation 
+ * or a subsidiary of Cypress Semiconductor Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -39,6 +41,11 @@ typedef enum {
     CONNECT_UNDER_RESET,
 } SWD_CONNECT_TYPE;
 
+typedef enum {
+    FLASHALGO_RETURN_BOOL,
+    FLASHALGO_RETURN_POINTER
+} flash_algo_return_t;
+
 uint8_t swd_init(void);
 uint8_t swd_off(void);
 uint8_t swd_init_debug(void);
@@ -55,7 +62,7 @@ uint8_t swd_read_memory(uint32_t address, uint8_t *data, uint32_t size);
 uint8_t swd_write_memory(uint32_t address, uint8_t *data, uint32_t size);
 uint8_t swd_read_core_register(uint32_t n, uint32_t *val);
 uint8_t swd_write_core_register(uint32_t n, uint32_t val);
-uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4);
+uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4, flash_algo_return_t return_type);
 uint8_t swd_set_target_state_hw(target_state_t state);
 uint8_t swd_set_target_state_sw(target_state_t state);
 uint8_t swd_transfer_retry(uint32_t req, uint32_t *data);

--- a/source/daplink/interface/swd_host_ca.c
+++ b/source/daplink/interface/swd_host_ca.c
@@ -4,6 +4,8 @@
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
+ * Copyright 2019, Cypress Semiconductor Corporation 
+ * or a subsidiary of Cypress Semiconductor Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -618,7 +620,7 @@ static uint8_t swd_wait_until_halted(void)
     return 0;
 }
 
-uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4)
+uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t entry, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4, flash_algo_return_t return_type)
 {
     DEBUG_STATE state = {{0}, 0};
     // Call flash algorithm function on target and wait for result.
@@ -648,9 +650,17 @@ uint8_t swd_flash_syscall_exec(const program_syscall_t *sysCallParam, uint32_t e
         return 0;
     }
 
-    // Flash functions return 0 if successful.
-    if (state.r[0] != 0) {
-        return 0;
+    if ( return_type == FLASHALGO_RETURN_POINTER ) {
+        // Flash verify functions return pointer to byte following the buffer if successful.
+        if (state.r[0] != (arg1 + arg2)) {
+            return 0;
+        }
+    }
+    else {
+        // Flash functions return 0 if successful.
+        if (state.r[0] != 0) {
+            return 0;
+        }
     }
 
     return 1;

--- a/source/hic_hal/flash_blob.h
+++ b/source/hic_hal/flash_blob.h
@@ -4,6 +4,8 @@
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
+ * Copyright 2019, Cypress Semiconductor Corporation 
+ * or a subsidiary of Cypress Semiconductor Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -28,6 +30,13 @@
 extern "C" {
 #endif
 
+// Flags for program_target
+enum { 
+    kAlgoVerifyReturnsAddress = (1u << 0u),     /*!< Verify function returns address if bit set */
+    kAlgoSingleInitType =       (1u << 1u),     /*!< The init function ignores the function code. */
+    kAlgoSkipChipErase =        (1u << 2u),     /*!< Skip region when erase.act action triggers. */
+};
+
 typedef struct __attribute__((__packed__)) {
     uint32_t breakpoint;
     uint32_t static_base;
@@ -47,6 +56,7 @@ typedef struct __attribute__((__packed__)) {
     const uint32_t  algo_size;
     const uint32_t *algo_blob;
     const uint32_t  program_buffer_size;
+    const uint32_t  algo_flags;         /*!< Combination of kAlgoVerifyReturnsAddress, kAlgoSingleInitType and kAlgoSkipChipErase*/
 } program_target_t;
 
 typedef struct __attribute__((__packed__)) {


### PR DESCRIPTION
kAlgoVerifyReturnsAddress - Verify function returns address if this flag is set
kAlgoSingleInitType - The Init/UnInit functions contain just return, so can be skipped
kAlgoSkipChipErase - Skip region when erase.act action triggers. ChipErase on Some SPI Flash Memory take much more time that is allowed per drag-n-drop programming.