### PR TITLE
Code cleanup in preparation for gcc support

### DIFF
--- a/source/board/hani_iot.c
+++ b/source/board/hani_iot.c
@@ -25,7 +25,7 @@
 const board_info_t g_board_info = {
     .info_version = kBoardInfoVersion,
     .board_id = "0360",
-    .family_id = VENDOR_TO_FAMILY(kNXP_VendorID, 0), //ID not maching the predefined family ids
+    .family_id = kNXP_LPC55xx_FamilyID, //ID not maching the predefined family ids
     .flags = kEnablePageErase,
     .daplink_url_name =       "PRODINFOHTM",
     .daplink_drive_name =       "HANI_IOT",

--- a/source/board/lpc55S69xpresso.c
+++ b/source/board/lpc55S69xpresso.c
@@ -25,7 +25,7 @@
 const board_info_t g_board_info = {
     .info_version = kBoardInfoVersion,
     .board_id = "0236",
-    .family_id = VENDOR_TO_FAMILY(kNXP_VendorID, 0), //ID not maching the predefined family ids
+    .family_id = kNXP_LPC55xx_FamilyID,
     .flags = kEnablePageErase,
     .daplink_url_name =       "PRODINFOHTM",
     .daplink_drive_name =       "LPC55S69",

--- a/source/daplink/HardFault_Handler.c
+++ b/source/daplink/HardFault_Handler.c
@@ -3,7 +3,7 @@
  * @brief   Entry point for interface program logic
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2018, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -24,18 +24,15 @@
 #include "util.h"
 #include "cortex_m.h"
 
-register unsigned int _psp __asm("psp");
-register unsigned int _msp __asm("msp");
-register unsigned int _lr __asm("lr");
-register unsigned int _control __asm("control");
-void HardFault_Handler()
-{
+
 //hexdump logic on hardfault
+__NO_RETURN void _fault_handler(uint32_t _lr)
+{
     uint32_t stk_ptr;
-    uint32_t * stack = (uint32_t *)_msp;
-    
+    uint32_t * stack = (uint32_t *)__get_MSP();
+
     if ((_lr & 0xF) == 0xD) { //process stack
-        stack = (uint32_t *)_psp;
+        stack = (uint32_t *)__get_PSP();
     }
 
     //calculate stack ptr before fault
@@ -46,33 +43,45 @@ void HardFault_Handler()
     if ((_lr & 0x10) == 0) { //fp
         stk_ptr += 0x48;
     }
-    
+
     config_ram_add_hexdump(_lr);  //EXC_RETURN
-    config_ram_add_hexdump(_psp);
-    config_ram_add_hexdump(_msp);
-    config_ram_add_hexdump(_control);
+    config_ram_add_hexdump(__get_PSP());
+    config_ram_add_hexdump(__get_MSP());
+    config_ram_add_hexdump(__get_CONTROL());
     config_ram_add_hexdump(stk_ptr); //SP
     config_ram_add_hexdump(stack[5]);  //LR
     config_ram_add_hexdump(stack[6]);  //PC
-    config_ram_add_hexdump(stack[7]);  //xPSR 
+    config_ram_add_hexdump(stack[7]);  //xPSR
 
-#ifndef __CORTEX_M
-#error __CORTEX_M not defined!!
-#else
-
-#if (__CORTEX_M > 0x00)
+#if !defined(__CORTEX_M)
+#error "__CORTEX_M not defined!!"
+#elif (__CORTEX_M > 0x00)
     config_ram_add_hexdump(SCB->HFSR);
     config_ram_add_hexdump(SCB->CFSR);
     config_ram_add_hexdump(SCB->DFSR);
     config_ram_add_hexdump(SCB->AFSR);
     config_ram_add_hexdump(SCB->MMFAR);
     config_ram_add_hexdump(SCB->BFAR);
-#endif  
-
-#endif //#ifndef __CORTEX_M
+#endif // __CORTEX_M
 
     util_assert(0);
     SystemReset();
 
     while (1); // Wait for reset
 }
+
+#if defined(__CC_ARM)
+void HardFault_Handler()
+{
+    register unsigned int _lr __asm("lr");
+    _fault_handler(_lr);
+}
+#else
+void HardFault_Handler()
+{
+    asm volatile (
+        "    mov    r0, lr              \n\t"
+        "    bl     _fault_handler      \n\t"
+    );
+}
+#endif

--- a/source/daplink/cmsis-dap/DAP.c
+++ b/source/daplink/cmsis-dap/DAP.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
- * Copyright 2019, Cypress Semiconductor Corporation 
+ * Copyright 2019, Cypress Semiconductor Corporation
  * or a subsidiary of Cypress Semiconductor Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -1624,7 +1624,7 @@ __WEAK uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *respon
 //   response: pointer to response data
 //   return:   number of bytes in response (lower 16 bits)
 //             number of bytes in request (upper 16 bits)
-__weak uint32_t DAP_ProcessVendorCommandEx(const uint8_t *request, uint8_t *response) {
+__WEAK uint32_t DAP_ProcessVendorCommandEx(const uint8_t *request, uint8_t *response) {
   *response = ID_DAP_Invalid;
   return ((1U << 16) | 1U);
 }
@@ -1643,7 +1643,7 @@ uint32_t DAP_ProcessCommand(const uint8_t *request, uint8_t *response) {
 
   if ((*request >= ID_DAP_VendorExFirst) && (*request <= ID_DAP_VendorExLast)) {
     return DAP_ProcessVendorCommandEx(request, response);
-  }  
+  }
 
   *response++ = *request;
 

--- a/source/daplink/compiler.h
+++ b/source/daplink/compiler.h
@@ -39,7 +39,23 @@ extern "C" {
 // conflicts resulting from the same enum being declared multiple times.
 #define COMPILER_ASSERT(e) enum { COMPILER_CONCAT(compiler_assert_, __COUNTER__) = 1/((e) ? 1 : 0) }
 
-#define __at(_addr) __attribute__ ((at(_addr)))
+// Macros to disable optimisation of a function.
+#if (defined(__ICCARM__))
+#define NO_OPTIMIZE_PRE _Pragma("optimize = none")
+#define NO_OPTIMIZE_INLINE
+#define NO_OPTIMIZE_POST
+#elif (defined(__CC_ARM))
+#define NO_OPTIMIZE_PRE _Pragma("push") \
+                        _Pragma("O0")
+#define NO_OPTIMIZE_INLINE
+#define NO_OPTIMIZE_POST _Pragma("pop")
+#elif (defined(__GNUC__))
+#define NO_OPTIMIZE_PRE
+#define NO_OPTIMIZE_INLINE __attribute__((optimize("O0")))
+#define NO_OPTIMIZE_POST
+#else
+#error "Unknown compiler"
+#endif
 
 #ifdef __cplusplus
 }

--- a/source/daplink/compiler.h
+++ b/source/daplink/compiler.h
@@ -22,6 +22,8 @@
 #ifndef COMPILER_H
 #define COMPILER_H
 
+#include "cmsis_compiler.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/source/daplink/cortex_m.c
+++ b/source/daplink/cortex_m.c
@@ -3,7 +3,7 @@
  * @brief   ARM Cortex-Mx cpu functions
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2009-2017, ARM Limited, All Rights Reserved
+ * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -21,8 +21,7 @@
 
 #include "cortex_m.h"
 
-__attribute__((weak))
-void SystemReset(void)
+__WEAK void SystemReset(void)
 {
     NVIC_SystemReset();
 }

--- a/source/daplink/cortex_m.h
+++ b/source/daplink/cortex_m.h
@@ -24,33 +24,28 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-
-#include "IO_Config.h"
+#include "device.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef int cortex_int_state_t;
+typedef uint32_t cortex_int_state_t;
 
-__attribute__((always_inline))
-static cortex_int_state_t cortex_int_get_and_disable(void)
+__STATIC_FORCEINLINE cortex_int_state_t cortex_int_get_and_disable(void)
 {
     cortex_int_state_t state;
-    state = __disable_irq();
+    state = __get_PRIMASK();
+    __disable_irq();
     return state;
 }
 
-__attribute__((always_inline))
-static void cortex_int_restore(cortex_int_state_t state)
+__STATIC_FORCEINLINE void cortex_int_restore(cortex_int_state_t state)
 {
-    if (!state) {
-        __enable_irq();
-    }
+    __set_PRIMASK(state);
 }
 
-__attribute__((always_inline))
-static bool cortex_in_isr(void)
+__STATIC_FORCEINLINE bool cortex_in_isr(void)
 {
     return (__get_xPSR() & 0x1F) != 0;
 }

--- a/source/daplink/drag-n-drop/flash_intf.c
+++ b/source/daplink/drag-n-drop/flash_intf.c
@@ -20,11 +20,8 @@
  */
 
 #include "flash_intf.h"
+#include "compiler.h"
 
-
-__attribute__((weak))
-const flash_intf_t *const flash_intf_iap_protected = 0;
-__attribute__((weak))
-const flash_intf_t *const flash_intf_target = 0;
-__attribute__((weak))
-const flash_intf_t *const flash_intf_target_custom = 0;
+__WEAK const flash_intf_t *const flash_intf_iap_protected = 0;
+__WEAK const flash_intf_t *const flash_intf_target = 0;
+__WEAK const flash_intf_t *const flash_intf_target_custom = 0;

--- a/source/daplink/info.c
+++ b/source/daplink/info.c
@@ -100,22 +100,8 @@ const char *info_get_unique_id_string_descriptor(void)
     return usb_desc_unique_id;
 }
 
-//prevent the compiler to optimize boad and family id
-#if (defined(__ICCARM__))
-#pragma optimize = none
+//prevent the compiler to optimize board and family id
 static void setup_basics(void)
-#elif (defined(__CC_ARM))
-#pragma push
-#pragma O0
-static void setup_basics(void)
-#elif (!defined(__GNUC__))
-/* #pragma GCC push_options */
-/* #pragma GCC optimize("O0") */
-static void __attribute__((optimize("O0"))) setup_basics(void)
-#else
-#error "Unknown compiler"
-#endif
-
 {
     uint8_t i = 0, idx = 0;
     uint16_t family_id = get_family_id();
@@ -149,22 +135,22 @@ static void __attribute__((optimize("O0"))) setup_basics(void)
     string_board_id[4] = 0;
     idx = 0;
     //Family ID
-    string_family_id[idx++] = hex_to_ascii(((family_id >> 12) & 0xF));    
+    string_family_id[idx++] = hex_to_ascii(((family_id >> 12) & 0xF));
     string_family_id[idx++] = hex_to_ascii(((family_id >> 8) & 0xF));
-#if !(defined(DAPLINK_BL)) &&  defined(DRAG_N_DROP_SUPPORT)   //need to change the unique id when the msd is disabled 
+#if !(defined(DAPLINK_BL)) &&  defined(DRAG_N_DROP_SUPPORT)   //need to change the unique id when the msd is disabled
     #if defined(MSC_ENDPOINT)
     if (config_ram_get_disable_msd() == 1 || flash_algo_valid()==0){
-        string_family_id[idx++] = hex_to_ascii((((family_id >> 4) | 0x08) & 0xF)); 
+        string_family_id[idx++] = hex_to_ascii((((family_id >> 4) | 0x08) & 0xF));
     } else {
         string_family_id[idx++] = hex_to_ascii(((family_id >> 4) & 0xF));
     }
     #else //no msd support always have the most significant bit set for family id 2nd byte
-        string_family_id[idx++] = hex_to_ascii((((family_id >> 4) | 0x08) & 0xF)); 
+        string_family_id[idx++] = hex_to_ascii((((family_id >> 4) | 0x08) & 0xF));
     #endif
 #else
     string_family_id[idx++] = hex_to_ascii(((family_id >> 4) & 0xF));
 #endif
-    string_family_id[idx++] = hex_to_ascii(((family_id) & 0xF));    
+    string_family_id[idx++] = hex_to_ascii(((family_id) & 0xF));
     string_family_id[idx++] = 0;
     // Version
     idx = 0;
@@ -338,9 +324,3 @@ uint32_t info_get_interface_version(void)
     return info_if->version;
 }
 
-#if (defined(__CC_ARM))
-#pragma pop
-#endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
-#endif

--- a/source/daplink/sdk_stub.c
+++ b/source/daplink/sdk_stub.c
@@ -19,7 +19,9 @@
  * limitations under the License.
  */
 
-__weak void sdk_init()
+#include "device.h"
+
+__WEAK void sdk_init()
 {
     // Do nothing
 }

--- a/source/daplink/util.c
+++ b/source/daplink/util.c
@@ -26,7 +26,7 @@
 #include "cortex_m.h"
 
 //remove dependency from vfs_manager
-__attribute__((weak)) void vfs_mngr_fs_remount(void) {}
+__WEAK void vfs_mngr_fs_remount(void) {}
 
 uint32_t util_write_hex8(char *str, uint8_t value)
 {

--- a/source/daplink/util.c
+++ b/source/daplink/util.c
@@ -110,21 +110,6 @@ uint32_t util_write_string(char *str, const char *data)
     return pos;
 }
 
-uint32_t util_div_round_up(uint32_t dividen, uint32_t divisor)
-{
-    return (dividen + divisor - 1) / divisor;
-}
-
-uint32_t util_div_round_down(uint32_t dividen, uint32_t divisor)
-{
-    return dividen / divisor;
-}
-
-uint32_t util_div_round(uint32_t dividen, uint32_t divisor)
-{
-    return (dividen + divisor / 2) / divisor;
-}
-
 void _util_assert(bool expression, const char *filename, uint16_t line)
 {
     bool assert_set;

--- a/source/daplink/util.h
+++ b/source/daplink/util.h
@@ -24,9 +24,13 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "compiler.h"
 
 // Protect commonly-defined macros with ifdefs, to prevent conflicts if redefined
 // in imported sources (mostly vendor SDKs).
+
+//! @brief Round up division to nearest number of words.
+#define WORDS(s) (((s) + sizeof(uint32_t) - 1) / sizeof(uint32_t))
 
 #if !defined(ARRAY_SIZE)
 //! @brief Get number of elements in the array.
@@ -62,9 +66,20 @@ uint32_t util_write_uint32(char *str, uint32_t value);
 uint32_t util_write_uint32_zp(char *str, uint32_t value, uint16_t total_size);
 uint32_t util_write_string(char *str, const char *data);
 
-uint32_t util_div_round_up(uint32_t dividen, uint32_t divisor);
-uint32_t util_div_round_down(uint32_t dividen, uint32_t divisor);
-uint32_t util_div_round(uint32_t dividen, uint32_t divisor);
+__STATIC_INLINE uint32_t util_div_round_up(uint32_t dividen, uint32_t divisor)
+{
+    return (dividen + divisor - 1) / divisor;
+}
+
+__STATIC_INLINE uint32_t util_div_round_down(uint32_t dividen, uint32_t divisor)
+{
+    return dividen / divisor;
+}
+
+__STATIC_INLINE uint32_t util_div_round(uint32_t dividen, uint32_t divisor)
+{
+    return (dividen + divisor / 2) / divisor;
+}
 
 #if !(defined(DAPLINK_NO_ASSERT_FILENAMES) && defined(DAPLINK_BL))
 // With the filename enabled.

--- a/source/family/nxp/lpc55S6X/target_reset.c
+++ b/source/family/nxp/lpc55S6X/target_reset.c
@@ -106,7 +106,7 @@ static uint8_t lpc55s6x_target_set_state(target_state_t state)
 }
 
 const target_family_descriptor_t g_target_family_lpc55S6X = {
-    .family_id = VENDOR_TO_FAMILY(kNXP_VendorID, 0), //ID not maching the predefined family ids
+    .family_id = kNXP_LPC55xx_FamilyID, //ID not maching the predefined family ids
     .target_set_state = lpc55s6x_target_set_state,
 };
 

--- a/source/hic_hal/atmel/sam3u2c/usb_config.c
+++ b/source/hic_hal/atmel/sam3u2c/usb_config.c
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+#include "util.h"
+
 // <e> USB Device
 //   <i> Enable the USB Device functionality
 #define USBD_ENABLE                 1
@@ -395,7 +397,7 @@
 
 #define USBD_IF_NUM_MAX             (USBD_BULK_ENABLE+USBD_WEBUSB_ENABLE+USBD_HID_ENABLE+USBD_MSC_ENABLE+(USBD_ADC_ENABLE*2)+(USBD_CDC_ACM_ENABLE*2)+USBD_CLS_ENABLE)
 #define USBD_MULTI_IF               (USBD_CDC_ACM_ENABLE*(USBD_HID_ENABLE|USBD_MSC_ENABLE|USBD_ADC_ENABLE|USBD_CLS_ENABLE|USBD_WEBUSB_ENABLE|USBD_BULK_ENABLE))
-#define MAX(x, y)                   (((x) < (y)) ? (y) : (x))
+// #define MAX(x, y)                   (((x) < (y)) ? (y) : (x))
 #define USBD_EP_NUM_CALC0           MAX((USBD_HID_ENABLE    *(USBD_HID_EP_INTIN     )), (USBD_HID_ENABLE    *(USBD_HID_EP_INTOUT!=0)*(USBD_HID_EP_INTOUT)))
 #define USBD_EP_NUM_CALC1           MAX((USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKIN    )), (USBD_MSC_ENABLE    *(USBD_MSC_EP_BULKOUT)))
 #define USBD_EP_NUM_CALC2           MAX((USBD_ADC_ENABLE    *(USBD_ADC_EP_ISOOUT    )), (USBD_CDC_ACM_ENABLE*(USBD_CDC_ACM_EP_INTIN)))

--- a/source/hic_hal/freescale/iap/fsl_flash.c
+++ b/source/hic_hal/freescale/iap/fsl_flash.c
@@ -2102,7 +2102,7 @@ void flash_cache_clear(flash_config_t *config)
 #pragma push
 #pragma O0
 void flash_cache_clear(flash_config_t *config)
-#elif (!defined(__GNUC__))
+#elif (defined(__GNUC__))
 /* #pragma GCC push_options */
 /* #pragma GCC optimize("O0") */
 void __attribute__((optimize("O0"))) flash_cache_clear(flash_config_t *config)

--- a/source/hic_hal/freescale/k26f/usbd_MK26F.c
+++ b/source/hic_hal/freescale/k26f/usbd_MK26F.c
@@ -79,8 +79,8 @@ uint8_t __align(4096) EPBufPool[
     USBD_MSC_ENABLE     *  (HS(USBD_MSC_HS_ENABLE)      ? USBD_MSC_HS_WMAXPACKETSIZE     : USBD_MSC_WMAXPACKETSIZE)      * 2 +
     USBD_ADC_ENABLE     *  (HS(USBD_ADC_HS_ENABLE)      ? USBD_ADC_HS_WMAXPACKETSIZE     : USBD_ADC_WMAXPACKETSIZE)          +
     USBD_CDC_ACM_ENABLE * ((HS(USBD_CDC_ACM_HS_ENABLE) ? USBD_CDC_ACM_HS_WMAXPACKETSIZE  : USBD_CDC_ACM_WMAXPACKETSIZE)      +
-                           (HS(USBD_CDC_ACM_HS_ENABLE) ? USBD_CDC_ACM_HS_WMAXPACKETSIZE1 : USBD_CDC_ACM_WMAXPACKETSIZE1) * 2) + 
-    USBD_BULK_ENABLE     *  (HS(USBD_BULK_HS_ENABLE)      ? USBD_BULK_HS_WMAXPACKETSIZE     : USBD_BULK_WMAXPACKETSIZE)      * 2 
+                           (HS(USBD_CDC_ACM_HS_ENABLE) ? USBD_CDC_ACM_HS_WMAXPACKETSIZE1 : USBD_CDC_ACM_WMAXPACKETSIZE1) * 2) +
+    USBD_BULK_ENABLE     *  (HS(USBD_BULK_HS_ENABLE)      ? USBD_BULK_HS_WMAXPACKETSIZE     : USBD_BULK_WMAXPACKETSIZE)      * 2
 ];
 #endif
 
@@ -582,8 +582,8 @@ uint32_t USBD_ReadEP(uint32_t EPNum, uint8_t *pData, uint32_t size)
         while (USBHS->EPSETUPSR & 1);
 
         do {
-            *((__packed uint32_t *) pData)      = EPQHx[EP_OUT_IDX(0)].setup[0];
-            *((__packed uint32_t *)(pData + 4)) = EPQHx[EP_OUT_IDX(0)].setup[1];
+            __UNALIGNED_UINT32_WRITE(pData, EPQHx[EP_OUT_IDX(0)].setup[0]);
+            __UNALIGNED_UINT32_WRITE(pData + 4, EPQHx[EP_OUT_IDX(0)].setup[1]);
             cnt = 8;
             USBHS->USBCMD |= (1UL << 13);
         } while (!(USBHS->USBCMD & (1UL << 13)));

--- a/source/hic_hal/freescale/k26f/usbd_MK26F.c
+++ b/source/hic_hal/freescale/k26f/usbd_MK26F.c
@@ -53,8 +53,8 @@ typedef struct __EP {
     uint32_t maxPacket;
 } EP;
 
-EPQH __align(2048) EPQHx[(USBD_EP_NUM + 1) * 2];
-dTD  __align(32) dTDx[(USBD_EP_NUM + 1) * 2];
+EPQH __ALIGNED(2048) EPQHx[(USBD_EP_NUM + 1) * 2];
+dTD  __ALIGNED(32) dTDx[(USBD_EP_NUM + 1) * 2];
 
 EP Ep[(USBD_EP_NUM + 1) * 2];
 uint32_t BufUsed;
@@ -70,10 +70,10 @@ uint32_t cmpl_pnd;
 #if USBD_VENDOR_ENABLE
 /* custom class: user defined buffer size */
 #define EP_BUF_POOL_SIZE 0x1000
-uint8_t __align(4096) EPBufPool[EP_BUF_POOL_SIZE]
+uint8_t __ALIGNED(4096) EPBufPool[EP_BUF_POOL_SIZE]
 #else
 /* supported classes are used */
-uint8_t __align(4096) EPBufPool[
+uint8_t __ALIGNED(4096) EPBufPool[
     USBD_MAX_PACKET0                                                                                                     * 2 +
     USBD_HID_ENABLE     *  (HS(USBD_HID_HS_ENABLE)      ? USBD_HID_HS_WMAXPACKETSIZE     : USBD_HID_WMAXPACKETSIZE)      * 2 +
     USBD_MSC_ENABLE     *  (HS(USBD_MSC_HS_ENABLE)      ? USBD_MSC_HS_WMAXPACKETSIZE     : USBD_MSC_WMAXPACKETSIZE)      * 2 +
@@ -158,7 +158,7 @@ void USBD_Init(void)
  *    Return Value:    None
  */
 
-void USBD_Connect(uint32_t con)
+void USBD_Connect(BOOL con)
 {
     if (con) {
         USBHS->USBCMD |= 1;            /* run */
@@ -281,7 +281,7 @@ void USBD_WakeUp(void)
  *    Return Value:    None
  */
 
-void USBD_WakeUpCfg(uint32_t cfg)
+void USBD_WakeUpCfg(BOOL cfg)
 {
     /* Not needed */
 }
@@ -308,7 +308,7 @@ void USBD_SetAddress(uint32_t adr, uint32_t setup)
  *    Return Value:    None
  */
 
-void USBD_Configure(uint32_t cfg)
+void USBD_Configure(BOOL cfg)
 {
     uint32_t i;
 

--- a/source/hic_hal/freescale/usbd_kinetis.c
+++ b/source/hic_hal/freescale/usbd_kinetis.c
@@ -1,6 +1,6 @@
 /**
  * @file    usbd_kinetis.c
- * @brief   
+ * @brief
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -35,7 +35,7 @@ typedef struct __BUF_DESC {
     uint32_t   buf_addr;
 } BUF_DESC;
 
-BUF_DESC __align(512) BD[(USBD_EP_NUM + 1) * 2 * 2];
+BUF_DESC __ALIGNED(512) BD[(USBD_EP_NUM + 1) * 2 * 2];
 uint8_t EPBuf[(USBD_EP_NUM + 1) * 2 * 2][64];
 uint8_t OutEpSize[USBD_EP_NUM + 1];
 uint8_t StatQueue[(USBD_EP_NUM + 1) * 2 * 2 + 1];
@@ -43,7 +43,7 @@ uint32_t StatQueueHead = 0;
 uint32_t StatQueueTail = 0;
 uint32_t LastIstat = 0;
 uint8_t UsbSuspended = 0;
-uint8_t Ep0ZlpOut = 0; 
+uint8_t Ep0ZlpOut = 0;
 
 uint32_t Data1  = 0x55555555;
 
@@ -182,7 +182,7 @@ void USBD_Init(void)
  *    Return Value:    None
  */
 
-void USBD_Connect(uint32_t con)
+void USBD_Connect(BOOL con)
 {
     if (con) {
         USB0->CTL  |= USB_CTL_USBENSOFEN_MASK;            /* enable USB           */
@@ -276,7 +276,7 @@ void USBD_WakeUp(void)
         USB0->CTL |=  USB_CTL_RESUME_MASK;
 
         while (i--) {
-            __nop();
+            __NOP();
         }
 
         USB0->CTL &= ~USB_CTL_RESUME_MASK;
@@ -290,7 +290,7 @@ void USBD_WakeUp(void)
  *    Return Value:    None
  */
 
-void USBD_WakeUpCfg(uint32_t cfg)
+void USBD_WakeUpCfg(BOOL cfg)
 {
     /* Not needed                                                               */
 }
@@ -316,7 +316,7 @@ void USBD_SetAddress(uint32_t  adr, uint32_t setup)
  *    Return Value:    None
  */
 
-void USBD_Configure(uint32_t cfg)
+void USBD_Configure(BOOL cfg)
 {
 }
 

--- a/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
+++ b/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
@@ -1,6 +1,6 @@
 /**
  * @file    usbd_LPC11Uxx.c
- * @brief   
+ * @brief
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -552,9 +552,9 @@ U32 USBD_ReadEP(U32 EPNum, U8 *pData, U32 size)
         cnt = EPBufInfo[EP_OUT_IDX(EPNum)].buf_len - ((*ptr >> 16) & 0x3FF);
         dataptr = (U8 *)EPBufInfo[EP_OUT_IDX(EPNum)].buf_ptr;
 
-        while ((timeout-- > 0) && (*ptr & BUF_ACTIVE)); //spin on the hardware until it's done        
+        while ((timeout-- > 0) && (*ptr & BUF_ACTIVE)); //spin on the hardware until it's done
         util_assert(!(*ptr & BUF_ACTIVE)); //check for timeout
-        
+
         if (size < cnt) {
             util_assert(0);
             cnt = size;
@@ -612,7 +612,7 @@ U32 USBD_WriteEP(U32 EPNum, U8 *pData, U32 cnt)
     dataptr = (U32 *)EPBufInfo[EP_IN_IDX(EPNum)].buf_ptr;
 
     for (i = 0; i < (cnt + 3) / 4; i++) {
-        dataptr[i] = * ((__packed U32 *)pData);
+        dataptr[i] = __UNALIGNED_UINT32_READ(pData);
         pData += 4;
     }
 

--- a/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
+++ b/source/hic_hal/nxp/lpc11u35/usbd_LPC11Uxx.c
@@ -49,7 +49,11 @@ typedef struct BUF_INFO {
 } EP_BUF_INFO;
 
 EP_BUF_INFO EPBufInfo[(USBD_EP_NUM + 1) * 2];
-volatile U32 EPList[(USBD_EP_NUM + 1) * 2]  __at(EP_LIST_BASE);
+#if defined ( __CC_ARM ) || defined (__ARMCC_VERSION)
+volatile U32 EPList[(USBD_EP_NUM + 1) * 2] __attribute__((at(EP_LIST_BASE)));
+#else
+#error "Unsupported compiler!"
+#endif
 
 static U32 addr = 3 * 64 + EP_BUF_BASE;
 static U32 ctrl_out_next = 0;

--- a/source/hic_hal/nxp/lpc4322/usbd_LPC43xx_USB0.c
+++ b/source/hic_hal/nxp/lpc4322/usbd_LPC43xx_USB0.c
@@ -1,6 +1,6 @@
 /**
  * @file    usbd_LPC43xx_USBD0.c
- * @brief   
+ * @brief
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -80,8 +80,8 @@ uint8_t __align(4096) EPBufPool[
     USBD_MSC_ENABLE     *  (HS(USBD_MSC_HS_ENABLE)      ? USBD_MSC_HS_WMAXPACKETSIZE     : USBD_MSC_WMAXPACKETSIZE)      * 2 +
     USBD_ADC_ENABLE     *  (HS(USBD_ADC_HS_ENABLE)      ? USBD_ADC_HS_WMAXPACKETSIZE     : USBD_ADC_WMAXPACKETSIZE)          +
     USBD_CDC_ACM_ENABLE * ((HS(USBD_CDC_ACM_HS_ENABLE) ? USBD_CDC_ACM_HS_WMAXPACKETSIZE  : USBD_CDC_ACM_WMAXPACKETSIZE)      +
-                           (HS(USBD_CDC_ACM_HS_ENABLE) ? USBD_CDC_ACM_HS_WMAXPACKETSIZE1 : USBD_CDC_ACM_WMAXPACKETSIZE1) * 2) + 
-    USBD_BULK_ENABLE     *  (HS(USBD_BULK_HS_ENABLE)      ? USBD_BULK_HS_WMAXPACKETSIZE     : USBD_BULK_WMAXPACKETSIZE)      * 2 
+                           (HS(USBD_CDC_ACM_HS_ENABLE) ? USBD_CDC_ACM_HS_WMAXPACKETSIZE1 : USBD_CDC_ACM_WMAXPACKETSIZE1) * 2) +
+    USBD_BULK_ENABLE     *  (HS(USBD_BULK_HS_ENABLE)      ? USBD_BULK_HS_WMAXPACKETSIZE     : USBD_BULK_WMAXPACKETSIZE)      * 2
 ];
 #endif
 
@@ -592,8 +592,8 @@ uint32_t USBD_ReadEP(uint32_t EPNum, uint8_t *pData, U32 size)
         while (LPC_USBx->ENDPTSETUPSTAT & 1);
 
         do {
-            *((__packed uint32_t *) pData)      = EPQHx[EP_OUT_IDX(0)].setup[0];
-            *((__packed uint32_t *)(pData + 4)) = EPQHx[EP_OUT_IDX(0)].setup[1];
+            __UNALIGNED_UINT32_WRITE(pData, EPQHx[EP_OUT_IDX(0)].setup[0]);
+            __UNALIGNED_UINT32_WRITE(pData + 4, EPQHx[EP_OUT_IDX(0)].setup[1]);
             cnt = 8;
             LPC_USBx->USBCMD_D |= (1UL << 13);
         } while (!(LPC_USBx->USBCMD_D & (1UL << 13)));

--- a/source/hic_hal/nxp/lpc4322/usbd_LPC43xx_USB0.c
+++ b/source/hic_hal/nxp/lpc4322/usbd_LPC43xx_USB0.c
@@ -53,8 +53,8 @@ typedef struct __EP {
     uint32_t maxPacket;
 } EP;
 
-EPQH __align(2048) EPQHx[(USBD_EP_NUM + 1) * 2];
-dTD  __align(32) dTDx[(USBD_EP_NUM + 1) * 2];
+EPQH __ALIGNED(2048) EPQHx[(USBD_EP_NUM + 1) * 2];
+dTD  __ALIGNED(32) dTDx[(USBD_EP_NUM + 1) * 2];
 
 EP Ep[(USBD_EP_NUM + 1) * 2];
 uint32_t BufUsed;
@@ -71,10 +71,10 @@ uint32_t cmpl_pnd;
 #if USBD_VENDOR_ENABLE
 /* custom class: user defined buffer size */
 #define EP_BUF_POOL_SIZE 0x1000
-uint8_t __align(4096) EPBufPool[EP_BUF_POOL_SIZE]
+uint8_t __ALIGNED(4096) EPBufPool[EP_BUF_POOL_SIZE]
 #else
 /* supported classes are used */
-uint8_t __align(4096) EPBufPool[
+uint8_t __ALIGNED(4096) EPBufPool[
     USBD_MAX_PACKET0                                                                                                     * 2 +
     USBD_HID_ENABLE     *  (HS(USBD_HID_HS_ENABLE)      ? USBD_HID_HS_WMAXPACKETSIZE     : USBD_HID_WMAXPACKETSIZE)      * 2 +
     USBD_MSC_ENABLE     *  (HS(USBD_MSC_HS_ENABLE)      ? USBD_MSC_HS_WMAXPACKETSIZE     : USBD_MSC_WMAXPACKETSIZE)      * 2 +
@@ -168,7 +168,7 @@ void USBD_Init(void)
  *    Return Value:    None
  */
 
-void USBD_Connect(uint32_t con)
+void USBD_Connect(BOOL con)
 {
     if (con) {
         LPC_USBx->USBCMD_D |= 1;            /* run */
@@ -291,7 +291,7 @@ void USBD_WakeUp(void)
  *    Return Value:    None
  */
 
-void USBD_WakeUpCfg(uint32_t cfg)
+void USBD_WakeUpCfg(BOOL cfg)
 {
     /* Not needed */
 }
@@ -318,7 +318,7 @@ void USBD_SetAddress(uint32_t adr, uint32_t setup)
  *    Return Value:    None
  */
 
-void USBD_Configure(uint32_t cfg)
+void USBD_Configure(BOOL cfg)
 {
     uint32_t i;
 

--- a/source/hic_hal/stm32/stm32f103xb/usbd_STM32F103.c
+++ b/source/hic_hal/stm32/stm32f103xb/usbd_STM32F103.c
@@ -38,7 +38,7 @@
 
 #define USB_ISTR_W0C_MASK   (ISTR_PMAOVR | ISTR_ERR | ISTR_WKUP | ISTR_SUSP | ISTR_RESET | ISTR_SOF | ISTR_ESOF)
 #define VAL_MASK            0xFFFF
-#define VAL_SHIFT           16 
+#define VAL_SHIFT           16
 #define EP_NUM_MASK         0xFFFF
 #define EP_NUM_SHIFT        0
 
@@ -490,7 +490,7 @@ U32 USBD_ReadEP(U32 EPNum, U8 *pData, U32 bufsz)
     }
 
     for (n = 0; n < (cnt + 1) / 2; n++) {
-        *((__packed U16 *)pData) = *pv++;
+        __UNALIGNED_UINT16_WRITE(pData, *pv++);
         pData += 2;
     }
 
@@ -518,7 +518,7 @@ U32 USBD_WriteEP(U32 EPNum, U8 *pData, U32 cnt)
     pv  = (U32 *)(USB_PMA_ADDR + 2 * ((pBUF_DSCR + num)->ADDR_TX));
 
     for (n = 0; n < (cnt + 1) / 2; n++) {
-        *pv++ = *((__packed U16 *)pData);
+        *pv++ = __UNALIGNED_UINT16_READ(pData);
         pData += 2;
     }
 
@@ -587,13 +587,13 @@ void USB_LP_CAN1_RX0_IRQHandler(void)
                     && (0 == ((pBUF_DSCR + num)->COUNT_RX & EP_COUNT_MASK))) {
                 if (val & EP_CTR_TX) {
                     // Drop the RX event but not TX
-                    stat_enque((((val & VAL_MASK) & ~EP_CTR_RX) << VAL_SHIFT) | 
+                    stat_enque((((val & VAL_MASK) & ~EP_CTR_RX) << VAL_SHIFT) |
                                ((num & EP_NUM_MASK) << EP_NUM_SHIFT));
                 } else {
                     // Drop the event
                 }
             } else {
-                stat_enque(((val & VAL_MASK) << VAL_SHIFT) | 
+                stat_enque(((val & VAL_MASK) << VAL_SHIFT) |
                            ((num & EP_NUM_MASK) << EP_NUM_SHIFT));
             }
 
@@ -607,7 +607,7 @@ void USB_LP_CAN1_RX0_IRQHandler(void)
             }
         }
     }
-    
+
     USBD_SignalHandler();
 }
 

--- a/source/rtos/RTL.h
+++ b/source/rtos/RTL.h
@@ -1,6 +1,6 @@
 /**
  * @file    RTL.h
- * @brief   
+ * @brief
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -21,6 +21,8 @@
 
 #ifndef __RTL_H__
 #define __RTL_H__
+
+#include <stdint.h>
 
 /* RL-ARM version number. */
 #define __RL_ARM_VER    471
@@ -45,14 +47,14 @@
  typedef unsigned int   size_t;
 #endif
 
-typedef signed char     S8;
-typedef unsigned char   U8;
-typedef short           S16;
-typedef unsigned short  U16;
-typedef int             S32;
-typedef unsigned int    U32;
-typedef long long       S64;
-typedef unsigned long long U64;
+typedef int8_t   S8;
+typedef uint8_t  U8;
+typedef int16_t  S16;
+typedef uint16_t U16;
+typedef int32_t  S32;
+typedef uint32_t U32;
+typedef int64_t  S64;
+typedef uint64_t U64;
 typedef unsigned char   BIT;
 typedef unsigned int    BOOL;
 

--- a/source/rtos/RTL.h
+++ b/source/rtos/RTL.h
@@ -565,8 +565,10 @@ typedef struct sockaddr {         /* << Generic Socket Address structure >>  */
   char sa_data[14];               /* Direct address (up to 14 bytes)         */
 } SOCKADDR;
 
+#if defined ( __CC_ARM)
 #pragma push
 #pragma anon_unions
+#endif
 
 typedef struct in_addr {          /* << Generic IPv4 Address structure >>    */
   union {
@@ -579,7 +581,9 @@ typedef struct in_addr {          /* << Generic IPv4 Address structure >>    */
     U32 s_addr;                   /* IP address in network byte order        */
   };
 } IN_ADDR;
+#if defined ( __CC_ARM)
 #pragma pop
+#endif
 
 typedef struct sockaddr_in {      /* << IPv4 Socket Address structure >>     */
   S16 sin_family;                 /* Socket domain                           */

--- a/source/rtos/rt_TypeDef.h
+++ b/source/rtos/rt_TypeDef.h
@@ -1,6 +1,6 @@
 /**
  * @file    rt_TypeDef.h
- * @brief   
+ * @brief
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2016, ARM Limited, All Rights Reserved
@@ -19,15 +19,17 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
+
 /* Types */
-typedef char               S8;
-typedef unsigned char      U8;
-typedef short              S16;
-typedef unsigned short     U16;
-typedef int                S32;
-typedef unsigned int       U32;
-typedef long long          S64;
-typedef unsigned long long U64;
+typedef int8_t   S8;
+typedef uint8_t  U8;
+typedef int16_t  S16;
+typedef uint16_t U16;
+typedef int32_t  S32;
+typedef uint32_t U32;
+typedef int64_t  S64;
+typedef uint64_t U64;
 typedef unsigned char      BIT;
 typedef unsigned int       BOOL;
 typedef void               (*FUNCP)(void);

--- a/source/target/target_board.c
+++ b/source/target/target_board.c
@@ -33,46 +33,42 @@ const board_info_t g_board_info = {
 		.daplink_target_url = "https://mbed.org/device/?code=@U?version=@V?target_id=@T",
 };
 
+// Disable optimization of these functions.
+//
+// This is required because for the "no target" builds, the compiler sees g_board_info fields as
+// defined above and will elide entire expressions. However, the board and target info may be
+// modified using the post processor script, changing what the code sees at runtime.
 
-const char * get_board_id(void)
+NO_OPTIMIZE_PRE
+const char * NO_OPTIMIZE_INLINE get_board_id(void)
 {
     if (g_board_info.target_cfg && g_board_info.target_cfg->rt_board_id) {
         return g_board_info.target_cfg->rt_board_id; //flexible board id
-    }else{
+    } else {
         return g_board_info.board_id;
     }
 }
+NO_OPTIMIZE_POST
 
-uint16_t get_family_id(void)
+NO_OPTIMIZE_PRE
+uint16_t NO_OPTIMIZE_INLINE get_family_id(void)
 {
     if (g_board_info.target_cfg && g_board_info.target_cfg->rt_family_id) {
         return g_board_info.target_cfg->rt_family_id; //flexible family id
-    }else{
+    } else {
         return g_board_info.family_id;
     }
 }
+NO_OPTIMIZE_POST
 
-#if (defined(__ICCARM__))
-#pragma optimize = none
-uint8_t flash_algo_valid(void)
-#elif (defined(__CC_ARM))
-#pragma push
-#pragma O0
-uint8_t flash_algo_valid(void)
-#elif (!defined(__GNUC__))
-/* #pragma GCC push_options */
-/* #pragma GCC optimize("O0") */
-uint8_t __attribute__((optimize("O0"))) flash_algo_valid(void)
-#else
-#error "Unknown compiler"
-#endif
+// Disable optimization of this function.
+//
+// This is required because for the "no target" builds, the compiler sees g_board_info.target_cfg as
+// NULL and will elide the entire expression. However, the board and target info may be modified
+// using the post processor script, changing what the code sees at runtime.
+NO_OPTIMIZE_PRE
+uint8_t NO_OPTIMIZE_INLINE flash_algo_valid(void)
 {
     return (g_board_info.target_cfg != 0);
 }
-
-#if (defined(__CC_ARM))
-#pragma pop
-#endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
-#endif
+NO_OPTIMIZE_POST

--- a/source/target/target_board.c
+++ b/source/target/target_board.c
@@ -23,7 +23,7 @@
 #include "target_board.h"
 
 // Default empty board info.
-__attribute__((weak))
+__WEAK
 const board_info_t g_board_info = {
 		.info_version = kBoardInfoVersion,
 		.board_id = "0000",

--- a/source/target/target_board.c
+++ b/source/target/target_board.c
@@ -21,6 +21,7 @@
 
 #include <string.h>
 #include "target_board.h"
+#include "compiler.h"
 
 // Default empty board info.
 __WEAK

--- a/source/target/target_board.h
+++ b/source/target/target_board.h
@@ -54,7 +54,7 @@ enum _board_info_flags {
  * The board initialization function pointers allow the board to override the routines defined
  * by the device family.
  */
-typedef struct __attribute__((__packed__)) board_info {
+typedef struct board_info {
     uint16_t info_version;              /*!< Version number of the board info */ 
     uint16_t family_id;                 /*!< Use to select or identify target family from defined target family or custom ones */
     char board_id[5];                   /*!< 4-char board ID plus null terminator */

--- a/source/target/target_family.c
+++ b/source/target/target_family.c
@@ -43,35 +43,33 @@ const target_family_descriptor_t g_sw_sysresetreq_family = {
     .soft_reset_type = SYSRESETREQ,
 };
 
-//Weakly define family
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_kinetis_kseries = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_kinetis_lseries = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_kinetis_k32w_series = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_mimxrt = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_nxp_rapid_iot = {0};
-__attribute__((weak))
-const target_family_descriptor_t  g_nordic_nrf51  = {0};
-__attribute__((weak))
-const target_family_descriptor_t  g_nordic_nrf52  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_realtek_rtl8195am  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_ti_family  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_wiznet_family  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_renesas_family  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_toshiba_tz_family  = {0};
-__attribute__((weak))
-const target_family_descriptor_t g_ambiq_ama3b1kk  = {0};
+// Weak references to family definitions.
+extern __WEAK const target_family_descriptor_t g_nxp_kinetis_kseries;
+extern __WEAK const target_family_descriptor_t g_nxp_kinetis_lseries;
+extern __WEAK const target_family_descriptor_t g_nxp_kinetis_k32w_series;
+extern __WEAK const target_family_descriptor_t g_nxp_mimxrt;
+extern __WEAK const target_family_descriptor_t g_nxp_rapid_iot;
+extern __WEAK const target_family_descriptor_t g_nordic_nrf51;
+extern __WEAK const target_family_descriptor_t g_nordic_nrf52;
+extern __WEAK const target_family_descriptor_t g_realtek_rtl8195am;
+extern __WEAK const target_family_descriptor_t g_ti_family;
+extern __WEAK const target_family_descriptor_t g_wiznet_family;
+extern __WEAK const target_family_descriptor_t g_renesas_family;
+extern __WEAK const target_family_descriptor_t g_toshiba_tz_family;
+extern __WEAK const target_family_descriptor_t g_ambiq_ama3b1kk;
 
+//! @brief Terminator value for g_families list.
+//!
+//! This terminator value is chosen so that weak references to the family descriptors that
+//! resolve to NULL at link time do not terminate the list early.
+#define FAMILY_LIST_TERMINATOR ((const target_family_descriptor_t *)(0xffffffff))
 
+//! @brief Default list of family descriptors.
+//!
+//! init_family() scans this list searching for a family descriptor with an ID that matches
+//! the family ID set in the board info or target config structs. Because each of the family
+//! descriptors has a weak reference defined above, the entry in this list for a family whose
+//! descriptor is not included in the link will resolve to NULL and init_family() can skip it.
 __attribute__((weak))
 const target_family_descriptor_t *g_families[] = {
     &g_hw_reset_family,
@@ -90,7 +88,7 @@ const target_family_descriptor_t *g_families[] = {
     &g_renesas_family,
     &g_toshiba_tz_family,
     &g_ambiq_ama3b1kk,
-    0 // list terminator
+    FAMILY_LIST_TERMINATOR // list terminator
 };
 
 __attribute__((weak))
@@ -99,21 +97,25 @@ const target_family_descriptor_t *g_target_family = NULL;
 
 void init_family(void)
 {
-    uint8_t index = 0;
-    uint16_t family_id = get_family_id();
-    if (g_target_family != NULL){ //already set
+    // Check if the family is already set.
+    if (g_target_family != NULL) {
         return;
     }
 
-    while (g_families[index]!=0) {
-        if (g_families[index]->family_id && (g_families[index]->family_id == family_id)) {
+    // Scan families table looking for matching family ID.
+    uint8_t index = 0;
+    uint16_t family_id = get_family_id();
+
+    while (g_families[index] != FAMILY_LIST_TERMINATOR) {
+        if ((g_families[index] != NULL) && (g_families[index]->family_id == family_id)) {
             g_target_family = g_families[index];
             break;
         }
         index++;
     }
 
-    if(g_target_family == NULL){ //default family
+    // Last resort is to use a default family.
+    if (g_target_family == NULL) {
         g_target_family = &g_hw_reset_family;
     }
 }
@@ -137,11 +139,11 @@ uint8_t target_set_state(target_state_t state)
                     swd_set_soft_reset(g_target_family->soft_reset_type);
                 }
                 return swd_set_target_state_sw(state);
-            }else {
+            } else {
                 return 1;
             }
         }
-    }else{
+    } else {
         return 0;
     }
 }
@@ -150,7 +152,7 @@ void swd_set_target_reset(uint8_t asserted)
 {
     if (g_target_family && g_target_family->swd_set_target_reset) {
         g_target_family->swd_set_target_reset(asserted);
-    }else {
+    } else {
         (asserted) ? PIN_nRESET_OUT(0) : PIN_nRESET_OUT(1);
     }
 }

--- a/source/target/target_family.c
+++ b/source/target/target_family.c
@@ -49,6 +49,7 @@ extern __WEAK const target_family_descriptor_t g_nxp_kinetis_lseries;
 extern __WEAK const target_family_descriptor_t g_nxp_kinetis_k32w_series;
 extern __WEAK const target_family_descriptor_t g_nxp_mimxrt;
 extern __WEAK const target_family_descriptor_t g_nxp_rapid_iot;
+extern __WEAK const target_family_descriptor_t g_nxp_lpc55xx_series;
 extern __WEAK const target_family_descriptor_t g_nordic_nrf51;
 extern __WEAK const target_family_descriptor_t g_nordic_nrf52;
 extern __WEAK const target_family_descriptor_t g_realtek_rtl8195am;
@@ -78,6 +79,7 @@ const target_family_descriptor_t *g_families[] = {
     &g_nxp_kinetis_kseries,
     &g_nxp_kinetis_lseries,
     &g_nxp_kinetis_k32w_series,
+    &g_nxp_lpc55xx_series,
     &g_nxp_mimxrt,
     &g_nxp_rapid_iot,
     &g_nordic_nrf51,

--- a/source/target/target_family.c
+++ b/source/target/target_family.c
@@ -71,7 +71,7 @@ extern __WEAK const target_family_descriptor_t g_ambiq_ama3b1kk;
 //! the family ID set in the board info or target config structs. Because each of the family
 //! descriptors has a weak reference defined above, the entry in this list for a family whose
 //! descriptor is not included in the link will resolve to NULL and init_family() can skip it.
-__attribute__((weak))
+__WEAK
 const target_family_descriptor_t *g_families[] = {
     &g_hw_reset_family,
     &g_sw_vectreset_family,
@@ -93,7 +93,7 @@ const target_family_descriptor_t *g_families[] = {
     FAMILY_LIST_TERMINATOR // list terminator
 };
 
-__attribute__((weak))
+__WEAK
 const target_family_descriptor_t *g_target_family = NULL;
 
 

--- a/source/target/target_family.h
+++ b/source/target/target_family.h
@@ -96,6 +96,7 @@ typedef enum _family_id {
     kNXP_Mimxrt_FamilyID = VENDOR_TO_FAMILY(kNXP_VendorID, 3),
     kNXP_RapidIot_FamilyID = VENDOR_TO_FAMILY(kNXP_VendorID, 4),
     kNXP_KinetisK32W_FamilyID = VENDOR_TO_FAMILY(kNXP_VendorID, 5),
+    kNXP_LPC55xx_FamilyID = VENDOR_TO_FAMILY(kNXP_VendorID, 6),
     kNordic_Nrf51_FamilyID = VENDOR_TO_FAMILY(kNordic_VendorID, 1),
     kNordic_Nrf52_FamilyID = VENDOR_TO_FAMILY(kNordic_VendorID, 2),
     kRealtek_Rtl8195am_FamilyID = VENDOR_TO_FAMILY(kRealtek_VendorID, 1),

--- a/source/usb/cdc/usbd_cdc_acm.c
+++ b/source/usb/cdc/usbd_cdc_acm.c
@@ -55,27 +55,27 @@ CDC_LINE_CODING line_coding;           /*!< Communication settings */
 
 /* Functions that should be provided by user to use standard Virtual COM port
    functionality                                                              */
-__weak int32_t USBD_CDC_ACM_PortInitialize(void)
+__WEAK int32_t USBD_CDC_ACM_PortInitialize(void)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_PortUninitialize(void)
+__WEAK int32_t USBD_CDC_ACM_PortUninitialize(void)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_PortReset(void)
+__WEAK int32_t USBD_CDC_ACM_PortReset(void)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_PortSetLineCoding(CDC_LINE_CODING *line_coding)
+__WEAK int32_t USBD_CDC_ACM_PortSetLineCoding(CDC_LINE_CODING *line_coding)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_PortGetLineCoding(CDC_LINE_CODING *line_coding)
+__WEAK int32_t USBD_CDC_ACM_PortGetLineCoding(CDC_LINE_CODING *line_coding)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_PortSetControlLineState(uint16_t ctrl_bmp)
+__WEAK int32_t USBD_CDC_ACM_PortSetControlLineState(uint16_t ctrl_bmp)
 {
     return (0);
 }
@@ -86,7 +86,7 @@ int32_t USBD_CDC_ACM_DataSend(const uint8_t *buf, int32_t len);
 int32_t USBD_CDC_ACM_PutChar(const uint8_t  ch);
 int32_t USBD_CDC_ACM_DataRead(uint8_t *buf, int32_t len);
 int32_t USBD_CDC_ACM_GetChar(void);
-__weak int32_t USBD_CDC_ACM_DataReceived(int32_t len)
+__WEAK int32_t USBD_CDC_ACM_DataReceived(int32_t len)
 {
     return (0);
 }
@@ -95,27 +95,27 @@ int32_t USBD_CDC_ACM_Notify(uint16_t stat);
 
 /* Functions handling CDC ACM requests (can be overridden to provide custom
    handling of CDC ACM requests)                                              */
-__weak int32_t USBD_CDC_ACM_SendEncapsulatedCommand(void)
+__WEAK int32_t USBD_CDC_ACM_SendEncapsulatedCommand(void)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_GetEncapsulatedResponse(void)
+__WEAK int32_t USBD_CDC_ACM_GetEncapsulatedResponse(void)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_SetCommFeature(uint16_t feat)
+__WEAK int32_t USBD_CDC_ACM_SetCommFeature(uint16_t feat)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_GetCommFeature(uint16_t feat)
+__WEAK int32_t USBD_CDC_ACM_GetCommFeature(uint16_t feat)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_ClearCommFeature(uint16_t feat)
+__WEAK int32_t USBD_CDC_ACM_ClearCommFeature(uint16_t feat)
 {
     return (0);
 }
-__weak int32_t USBD_CDC_ACM_SendBreak(uint16_t dur)
+__WEAK int32_t USBD_CDC_ACM_SendBreak(uint16_t dur)
 {
     return (0);
 }
@@ -137,7 +137,7 @@ static void USBD_CDC_ACM_EP_BULKIN_HandleData(void);
     \return             1        Function succeeded.
  */
 
-__weak int32_t USBD_CDC_ACM_Initialize(void)
+__WEAK int32_t USBD_CDC_ACM_Initialize(void)
 {
     data_send_access            = 0;
     data_send_active            = 0;
@@ -170,7 +170,7 @@ __weak int32_t USBD_CDC_ACM_Initialize(void)
     \return             1        Function succeeded.
  */
 
-__weak int32_t USBD_CDC_ACM_Uninitialization(void)
+__WEAK int32_t USBD_CDC_ACM_Uninitialization(void)
 {
     return (USBD_CDC_ACM_PortUninitialize());
 }
@@ -188,7 +188,7 @@ __weak int32_t USBD_CDC_ACM_Uninitialization(void)
     \return             1        Function succeeded.
  */
 
-__weak int32_t USBD_CDC_ACM_Reset(void)
+__WEAK int32_t USBD_CDC_ACM_Reset(void)
 {
     data_send_access            = 0;
     data_send_active            = 0;
@@ -222,7 +222,7 @@ __weak int32_t USBD_CDC_ACM_Reset(void)
     \return             1        Function succeeded.
  */
 
-__weak int32_t USBD_CDC_ACM_SetLineCoding(void)
+__WEAK int32_t USBD_CDC_ACM_SetLineCoding(void)
 {
     line_coding.dwDTERate   = (USBD_EP0Buf[0] <<  0) |
                               (USBD_EP0Buf[1] <<  8) |
@@ -244,7 +244,7 @@ __weak int32_t USBD_CDC_ACM_SetLineCoding(void)
     \return             1        Function succeeded.
  */
 
-__weak int32_t USBD_CDC_ACM_GetLineCoding(void)
+__WEAK int32_t USBD_CDC_ACM_GetLineCoding(void)
 {
     if (USBD_CDC_ACM_PortGetLineCoding(&line_coding)) {
         USBD_EP0Buf[0] = (line_coding.dwDTERate >>  0) & 0xFF;
@@ -273,7 +273,7 @@ __weak int32_t USBD_CDC_ACM_GetLineCoding(void)
     \return             1        Function succeeded.
  */
 
-__weak int32_t USBD_CDC_ACM_SetControlLineState(uint16_t ctrl_bmp)
+__WEAK int32_t USBD_CDC_ACM_SetControlLineState(uint16_t ctrl_bmp)
 {
     control_line_state = ctrl_bmp;
     return (USBD_CDC_ACM_PortSetControlLineState(ctrl_bmp));

--- a/source/usb/cdc/usbd_core_cdc.c
+++ b/source/usb/cdc/usbd_core_cdc.c
@@ -31,7 +31,7 @@
  *    Return Value:    TRUE - Setup class request ok, FALSE - Setup class request not supported
  */
 
-__weak BOOL USBD_EndPoint0_Setup_CDC_ReqToIF(void)
+__WEAK BOOL USBD_EndPoint0_Setup_CDC_ReqToIF(void)
 {
     if ((USBD_SetupPacket.wIndexL == usbd_cdc_acm_cif_num)  || /* IF number correct? */
             (USBD_SetupPacket.wIndexL == usbd_cdc_acm_dif_num)) {
@@ -111,7 +111,7 @@ __weak BOOL USBD_EndPoint0_Setup_CDC_ReqToIF(void)
  *    Return Value:    TRUE - Out class request ok, FALSE - Out class request not supported
  */
 
-__weak BOOL USBD_EndPoint0_Out_CDC_ReqToIF(void)
+__WEAK BOOL USBD_EndPoint0_Out_CDC_ReqToIF(void)
 {
     if ((USBD_SetupPacket.wIndexL == usbd_cdc_acm_cif_num) || /* IF number correct? */
             (USBD_SetupPacket.wIndexL == usbd_cdc_acm_dif_num)) {

--- a/source/usb/hid/usbd_core_hid.c
+++ b/source/usb/hid/usbd_core_hid.c
@@ -31,7 +31,7 @@
  *    Return Value:    TRUE - Success, FALSE - Error
  */
 
-__weak BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
+__WEAK BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
 {
     switch (USBD_SetupPacket.wValueH) {
         case HID_HID_DESCRIPTOR_TYPE:
@@ -81,7 +81,7 @@ __weak BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
  *    Return Value:    TRUE - Setup class request ok, FALSE - Setup class request not supported
  */
 
-__weak BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
+__WEAK BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
 {
     if (USBD_SetupPacket.wIndexL == usbd_hid_if_num ||
         USBD_SetupPacket.wIndexL == usbd_webusb_if_num) {
@@ -155,7 +155,7 @@ __weak BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
  *    Return Value:    TRUE - Out class request ok, FALSE - Out class request not supported
  */
 
-__weak BOOL USBD_EndPoint0_Out_HID_ReqToIF(void)
+__WEAK BOOL USBD_EndPoint0_Out_HID_ReqToIF(void)
 {
     if (USBD_SetupPacket.wIndexL == usbd_hid_if_num ||
         USBD_SetupPacket.wIndexL == usbd_webusb_if_num) {

--- a/source/usb/hid/usbd_hid.c
+++ b/source/usb/hid/usbd_hid.c
@@ -43,23 +43,23 @@ U16 DataFeatReceLen;
 
 
 /* Dummy Weak Functions that need to be provided by user */
-__weak void usbd_hid_init(void)
+__WEAK void usbd_hid_init(void)
 {
 
 }
-__weak int usbd_hid_get_report(U8 rtype, U8 rid, U8 *buf, U8 req)
+__WEAK int usbd_hid_get_report(U8 rtype, U8 rid, U8 *buf, U8 req)
 {
     return (0);
 };
-__weak void usbd_hid_set_report(U8  rtype, U8 rid, U8 *buf, int len, U8 req)
+__WEAK void usbd_hid_set_report(U8  rtype, U8 rid, U8 *buf, int len, U8 req)
 {
 
 }
-__weak U8 usbd_hid_get_protocol(void)
+__WEAK U8 usbd_hid_get_protocol(void)
 {
     return (0);
 };
-__weak void usbd_hid_set_protocol(U8  protocol)
+__WEAK void usbd_hid_set_protocol(U8  protocol)
 {
 
 };

--- a/source/usb/msc/usbd_core_msc.c
+++ b/source/usb/msc/usbd_core_msc.c
@@ -31,7 +31,7 @@
  *    Return Value:    None
  */
 
-__weak void USBD_ReqClrFeature_MSC(U32 EPNum)
+__WEAK void USBD_ReqClrFeature_MSC(U32 EPNum)
 {
     USBD_MSC_ClrStallEP(EPNum);
 }
@@ -43,7 +43,7 @@ __weak void USBD_ReqClrFeature_MSC(U32 EPNum)
  *    Return Value:    TRUE - Setup class request ok, FALSE - Setup class request not supported
  */
 
-__weak BOOL USBD_EndPoint0_Setup_MSC_ReqToIF(void)
+__WEAK BOOL USBD_EndPoint0_Setup_MSC_ReqToIF(void)
 {
     if (USBD_SetupPacket.wIndexL == usbd_msc_if_num) {         /* IF number correct? */
         switch (USBD_SetupPacket.bRequest) {

--- a/source/usb/msc/usbd_msc.c
+++ b/source/usb/msc/usbd_msc.c
@@ -48,19 +48,19 @@ U32 BulkLen;    /* Bulk In/Out Length */
 
 
 /* Dummy Weak Functions that need to be provided by user */
-__weak void usbd_msc_init()
+__WEAK void usbd_msc_init()
 {
 
 }
-__weak void usbd_msc_read_sect(U32 block, U8 *buf, U32 num_of_blocks)
+__WEAK void usbd_msc_read_sect(U32 block, U8 *buf, U32 num_of_blocks)
 {
 
 }
-__weak void usbd_msc_write_sect(U32 block, U8 *buf, U32 num_of_blocks)
+__WEAK void usbd_msc_write_sect(U32 block, U8 *buf, U32 num_of_blocks)
 {
 
 }
-__weak void usbd_msc_start_stop(BOOL start)
+__WEAK void usbd_msc_start_stop(BOOL start)
 {
 
 }

--- a/source/usb/usb_cdc.h
+++ b/source/usb/usb_cdc.h
@@ -189,7 +189,7 @@
 /* Header functional descriptor */
 /* (usbcdc11.pdf, 5.2.3.1) */
 /* This header must precede any list of class-specific descriptors. */
-typedef __packed struct _CDC_HEADER_DESCRIPTOR {
+typedef __PACKED_STRUCT _CDC_HEADER_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* Header functional descriptor subtype */
@@ -199,7 +199,7 @@ typedef __packed struct _CDC_HEADER_DESCRIPTOR {
 /* Call management functional descriptor */
 /* (usbcdc11.pdf, 5.2.3.2) */
 /* Describes the processing of calls for the communication class interface. */
-typedef __packed struct _CDC_CALL_MANAGEMENT_DESCRIPTOR {
+typedef __PACKED_STRUCT _CDC_CALL_MANAGEMENT_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* call management functional descriptor subtype */
@@ -210,7 +210,7 @@ typedef __packed struct _CDC_CALL_MANAGEMENT_DESCRIPTOR {
 /* Abstract control management functional descriptor */
 /* (usbcdc11.pdf, 5.2.3.3) */
 /* Describes the command supported by the communication interface class with the Abstract Control Model subclass code. */
-typedef __packed struct _CDC_ABSTRACT_CONTROL_MANAGEMENT_DESCRIPTOR {
+typedef __PACKED_STRUCT _CDC_ABSTRACT_CONTROL_MANAGEMENT_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* abstract control management functional descriptor subtype */
@@ -220,7 +220,7 @@ typedef __packed struct _CDC_ABSTRACT_CONTROL_MANAGEMENT_DESCRIPTOR {
 /* Union functional descriptors */
 /* (usbcdc11.pdf, 5.2.3.8) */
 /* Describes the relationship between a group of interfaces that can be considered to form a functional unit. */
-typedef __packed struct _CDC_UNION_DESCRIPTOR {
+typedef __PACKED_STRUCT _CDC_UNION_DESCRIPTOR {
     U8  bFunctionLength;                      /* size of this descriptor in bytes */
     U8  bDescriptorType;                      /* CS_INTERFACE descriptor type */
     U8  bDescriptorSubtype;                   /* union functional descriptor subtype */
@@ -229,7 +229,7 @@ typedef __packed struct _CDC_UNION_DESCRIPTOR {
 
 /* Union functional descriptors with one slave interface */
 /* (usbcdc11.pdf, 5.2.3.8) */
-typedef __packed struct _CDC_UNION_1SLAVE_DESCRIPTOR {
+typedef __PACKED_STRUCT _CDC_UNION_1SLAVE_DESCRIPTOR {
     CDC_UNION_DESCRIPTOR sUnion;              /* Union functional descriptor */
     U8                   bSlaveInterfaces[1]; /* Slave interface 0 */
 } CDC_UNION_1SLAVE_DESCRIPTOR;
@@ -237,7 +237,7 @@ typedef __packed struct _CDC_UNION_1SLAVE_DESCRIPTOR {
 /* Line coding structure */
 /* Format of the data returned when a GetLineCoding request is received */
 /* (usbcdc11.pdf, 6.2.13) */
-typedef __packed struct _CDC_LINE_CODING {
+typedef __PACKED_STRUCT _CDC_LINE_CODING {
     U32 dwDTERate;                            /* Data terminal rate in bits per second */
     U8  bCharFormat;                          /* Number of stop bits */
     U8  bParityType;                          /* Parity bit type */

--- a/source/usb/usb_def.h
+++ b/source/usb/usb_def.h
@@ -24,6 +24,7 @@
 
 #pragma anon_unions
 
+#include "compiler.h"
 #include <stdint.h>
 #include <stddef.h>
 
@@ -80,7 +81,7 @@ typedef unsigned int    BOOL;
 #define REQUEST_TO_OTHER           3
 
 /* bmRequestType Definition */
-typedef __packed struct _REQUEST_TYPE {
+typedef __PACKED_STRUCT _REQUEST_TYPE {
     U8 Recipient : 5;                     /* D4..0: Recipient */
     U8 Type      : 2;                     /* D6..5: Type */
     U8 Dir       : 1;                     /* D7:    Data Phase Txsfer Direction */
@@ -109,19 +110,19 @@ typedef __packed struct _REQUEST_TYPE {
 #define USB_FEATURE_REMOTE_WAKEUP              1
 
 /* USB Default Control Pipe Setup Packet */
-typedef __packed struct _USB_SETUP_PACKET {
+typedef __PACKED_STRUCT _USB_SETUP_PACKET {
     REQUEST_TYPE bmRequestType;           /* bmRequestType */
     U8  bRequest;                         /* bRequest */
-    __packed union {
+    __PACKED_UNION {
         U16        wValue;                  /* wValue */
-        __packed struct {
+        __PACKED_STRUCT {
             U8         wValueL;
             U8         wValueH;
         };
     };
-    __packed union {
+    __PACKED_UNION {
         U16        wIndex;                  /* wIndex */
-        __packed struct {
+        __PACKED_STRUCT {
             U8         wIndexL;
             U8         wIndexH;
         };
@@ -206,7 +207,7 @@ typedef __packed struct _USB_SETUP_PACKET {
 #define USB_DEVICE_CAPABILITY_WIRELESS_USB_EXT              12
 
 /* USB Standard Device Descriptor */
-typedef __packed struct _USB_DEVICE_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_DEVICE_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bcdUSB;
@@ -224,7 +225,7 @@ typedef __packed struct _USB_DEVICE_DESCRIPTOR {
 } USB_DEVICE_DESCRIPTOR;
 
 /* USB 2.0 Device Qualifier Descriptor */
-typedef __packed struct _USB_DEVICE_QUALIFIER_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_DEVICE_QUALIFIER_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bcdUSB;
@@ -237,7 +238,7 @@ typedef __packed struct _USB_DEVICE_QUALIFIER_DESCRIPTOR {
 } USB_DEVICE_QUALIFIER_DESCRIPTOR;
 
 /* USB Standard Configuration Descriptor */
-typedef __packed struct _USB_CONFIGURATION_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_CONFIGURATION_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 wTotalLength;
@@ -249,7 +250,7 @@ typedef __packed struct _USB_CONFIGURATION_DESCRIPTOR {
 } USB_CONFIGURATION_DESCRIPTOR;
 
 /* USB Standard Interface Descriptor */
-typedef __packed struct _USB_INTERFACE_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_INTERFACE_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bInterfaceNumber;
@@ -262,7 +263,7 @@ typedef __packed struct _USB_INTERFACE_DESCRIPTOR {
 } USB_INTERFACE_DESCRIPTOR;
 
 /* USB Standard Endpoint Descriptor */
-typedef __packed struct _USB_ENDPOINT_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_ENDPOINT_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bEndpointAddress;
@@ -272,20 +273,20 @@ typedef __packed struct _USB_ENDPOINT_DESCRIPTOR {
 } USB_ENDPOINT_DESCRIPTOR;
 
 /* USB String Descriptor */
-typedef __packed struct _USB_STRING_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_STRING_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bString/*[]*/;
 } USB_STRING_DESCRIPTOR;
 
 /* USB Common Descriptor */
-typedef __packed struct _USB_COMMON_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_COMMON_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
 } USB_COMMON_DESCRIPTOR;
 
 /* USB Interface Association Descriptor */
-typedef __packed struct _USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bFirstInterface;
@@ -297,15 +298,15 @@ typedef __packed struct _USB_INTERFACE_ASSOCIATION_DESCRIPTOR {
 } USB_INTERFACE_ASSOCIATION_DESCRIPTOR;
 
 /* USB Binary Object Store Descriptor */
-typedef __packed struct _USB_BINARY_OBJECT_STORE_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_BINARY_OBJECT_STORE_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 wTotalLength;
     U8  bNumDeviceCaps;
 } USB_BINARY_OBJECT_STORE_DESCRIPTOR;
 
-/* Union Functional Descriptor */ 
-typedef __packed struct _UNION_FUNCTIONAL_DESCRIPTOR {
+/* Union Functional Descriptor */
+typedef __PACKED_STRUCT _UNION_FUNCTIONAL_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDescriptorSubtype;
@@ -313,15 +314,15 @@ typedef __packed struct _UNION_FUNCTIONAL_DESCRIPTOR {
     U8  bSlaveInterface0;
 } UNION_FUNCTIONAL_DESCRIPTOR;
 
-typedef __packed struct _WINUSB_FUNCTION_SUBSET_HEADER {
+typedef __PACKED_STRUCT _WINUSB_FUNCTION_SUBSET_HEADER {
     U16 wLength;
-    U16 wDescriptorType; 
+    U16 wDescriptorType;
     U8  bFirstInterface;
     U8  bReserved;
 } WINUSB_FUNCTION_SUBSET_HEADER;
 
 /* USB Device Capability Descriptor */
-typedef __packed struct _USB_DEVICE_CAPABILITY_DESCRIPTOR {
+typedef __PACKED_STRUCT _USB_DEVICE_CAPABILITY_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDevCapabilityType;

--- a/source/usb/usb_def.h
+++ b/source/usb/usb_def.h
@@ -22,7 +22,9 @@
 #ifndef __USB_DEF_H__
 #define __USB_DEF_H__
 
+#if defined ( __CC_ARM)
 #pragma anon_unions
+#endif
 
 #include "compiler.h"
 #include <stdint.h>

--- a/source/usb/usb_def.h
+++ b/source/usb/usb_def.h
@@ -45,14 +45,14 @@
  typedef unsigned int   size_t;
 #endif
 
-typedef signed char     S8;
-typedef unsigned char   U8;
-typedef short           S16;
-typedef unsigned short  U16;
-typedef int             S32;
-typedef unsigned int    U32;
-typedef long long       S64;
-typedef unsigned long long U64;
+typedef int8_t   S8;
+typedef uint8_t  U8;
+typedef int16_t  S16;
+typedef uint16_t U16;
+typedef int32_t  S32;
+typedef uint32_t U32;
+typedef int64_t  S64;
+typedef uint64_t U64;
 typedef unsigned char   BIT;
 typedef unsigned int    BOOL;
 

--- a/source/usb/usb_hid.h
+++ b/source/usb/usb_hid.h
@@ -42,14 +42,14 @@
 
 
 /* HID Descriptor */
-typedef __packed struct _HID_DESCRIPTOR {
+typedef __PACKED_STRUCT _HID_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U16 bcdHID;
     U8  bCountryCode;
     U8  bNumDescriptors;
     /* Array of one or more descriptors */
-    __packed struct _HID_DESCRIPTOR_LIST {
+    __PACKED_STRUCT _HID_DESCRIPTOR_LIST {
         U8  bDescriptorType;
         U16 wDescriptorLength;
     } DescriptorList[1];

--- a/source/usb/usb_lib.c
+++ b/source/usb/usb_lib.c
@@ -23,6 +23,7 @@
 #include "rl_usb.h"
 #include "usb.h"
 #include "settings.h"
+#include "compiler.h"
 
 #pragma thumb
 #pragma O3
@@ -2337,12 +2338,15 @@ U8 USBD_ConfigDescriptor_HS[200] = { 0 };
 
 #endif
 
+// Verify that wchar_t is UTF-16.
+COMPILER_ASSERT(sizeof(wchar_t) == 2);
+
 /* USB Device Create String Descriptor */
 #define USBD_STR_DEF(n)                 \
   struct {                              \
     U8  len;                            \
     U8  type;                           \
-    U16 str[sizeof(USBD_##n)/2-1];      \
+    wchar_t str[sizeof(USBD_##n)/2-1];      \
   } desc##n
 
 #define USBD_STR_VAL(n)                  \

--- a/source/usb/usb_lib.c
+++ b/source/usb/usb_lib.c
@@ -1060,7 +1060,7 @@ void USBD_Reset_Event(void)
 #endif
 #if    (USBD_MSC_ENABLE)
     USBD_MSC_Reset_Event();
-#endif    
+#endif
 }
 #endif
 #endif  /* ((USBD_CDC_ACM_ENABLE)) */
@@ -1086,13 +1086,13 @@ void USBD_SOF_Event(void)
 #endif  /* ((USBD_HID_ENABLE) || (USBD_ADC_ENABLE) || (USBD_CDC_ACM_ENABLE) || (USBD_CLS_ENABLE)) */
 
 /* USB Device - Device Events Callback Functions */
-__weak void USBD_Power_Event(BOOL power);
-__weak void USBD_Reset_Event(void);
-__weak void USBD_Suspend_Event(void);
-__weak void USBD_Resume_Event(void);
-__weak void USBD_WakeUp_Event(void);
-__weak void USBD_SOF_Event(void);
-__weak void USBD_Error_Event(U32 error);
+__WEAK void USBD_Power_Event(BOOL power);
+__WEAK void USBD_Reset_Event(void);
+__WEAK void USBD_Suspend_Event(void);
+__WEAK void USBD_Resume_Event(void);
+__WEAK void USBD_WakeUp_Event(void);
+__WEAK void USBD_SOF_Event(void);
+__WEAK void USBD_Error_Event(U32 error);
 
 /* USB Device - Device Events Callback Pointers */
 void (* const USBD_P_Power_Event)(BOOL power) = USBD_Power_Event;
@@ -1106,49 +1106,49 @@ void (* const USBD_P_Error_Event)(U32 error) = USBD_Error_Event;
 /* USB Device - Endpoint Events Callback Functions */
 extern void USBD_EndPoint0(U32 event);
 #ifndef       USBD_EndPoint1
-__weak void USBD_EndPoint1(U32 event);
+__WEAK void USBD_EndPoint1(U32 event);
 #endif
 #ifndef       USBD_EndPoint2
-__weak void USBD_EndPoint2(U32 event);
+__WEAK void USBD_EndPoint2(U32 event);
 #endif
 #ifndef       USBD_EndPoint3
-__weak void USBD_EndPoint3(U32 event);
+__WEAK void USBD_EndPoint3(U32 event);
 #endif
 #ifndef       USBD_EndPoint4
-__weak void USBD_EndPoint4(U32 event);
+__WEAK void USBD_EndPoint4(U32 event);
 #endif
 #ifndef       USBD_EndPoint5
-__weak void USBD_EndPoint5(U32 event);
+__WEAK void USBD_EndPoint5(U32 event);
 #endif
 #ifndef       USBD_EndPoint6
-__weak void USBD_EndPoint6(U32 event);
+__WEAK void USBD_EndPoint6(U32 event);
 #endif
 #ifndef       USBD_EndPoint7
-__weak void USBD_EndPoint7(U32 event);
+__WEAK void USBD_EndPoint7(U32 event);
 #endif
 #ifndef       USBD_EndPoint8
-__weak void USBD_EndPoint8(U32 event);
+__WEAK void USBD_EndPoint8(U32 event);
 #endif
 #ifndef       USBD_EndPoint9
-__weak void USBD_EndPoint9(U32 event);
+__WEAK void USBD_EndPoint9(U32 event);
 #endif
 #ifndef       USBD_EndPoint10
-__weak void USBD_EndPoint10(U32 event);
+__WEAK void USBD_EndPoint10(U32 event);
 #endif
 #ifndef       USBD_EndPoint11
-__weak void USBD_EndPoint11(U32 event);
+__WEAK void USBD_EndPoint11(U32 event);
 #endif
 #ifndef       USBD_EndPoint12
-__weak void USBD_EndPoint12(U32 event);
+__WEAK void USBD_EndPoint12(U32 event);
 #endif
 #ifndef       USBD_EndPoint13
-__weak void USBD_EndPoint13(U32 event);
+__WEAK void USBD_EndPoint13(U32 event);
 #endif
 #ifndef       USBD_EndPoint14
-__weak void USBD_EndPoint14(U32 event);
+__WEAK void USBD_EndPoint14(U32 event);
 #endif
 #ifndef       USBD_EndPoint15
-__weak void USBD_EndPoint15(U32 event);
+__WEAK void USBD_EndPoint15(U32 event);
 #endif
 
 /* USB Device - Endpoint Events Callback Pointers */
@@ -1172,9 +1172,9 @@ void (* const USBD_P_EP[16])(U32 event) = {
 };
 
 /* USB Device - Core Events Callback Functions */
-__weak void USBD_Configure_Event(void);
-__weak void USBD_Interface_Event(void);
-__weak void USBD_Feature_Event(void);
+__WEAK void USBD_Configure_Event(void);
+__WEAK void USBD_Interface_Event(void);
+__WEAK void USBD_Feature_Event(void);
 
 /* USB Device - Core Events Callback Pointers */
 void (* const USBD_P_Configure_Event)(void) = USBD_Configure_Event;
@@ -1185,7 +1185,7 @@ void (* const USBD_P_Feature_Event)(void) = USBD_Feature_Event;
 const BOOL __rtx = __TRUE;
 
 #if   ((USBD_HID_ENABLE) || (USBD_ADC_ENABLE) || (USBD_CDC_ACM_ENABLE) || (USBD_CLS_ENABLE))
-__weak void USBD_RTX_Device(void)
+__WEAK void USBD_RTX_Device(void)
 {
     U16 evt;
 
@@ -1199,7 +1199,7 @@ __weak void USBD_RTX_Device(void)
 #endif
 #if (USBD_MSC_ENABLE)
             USBD_MSC_Reset_Event();
-#endif    
+#endif
         }
 
         if (evt & USBD_EVT_SOF) {
@@ -1219,7 +1219,7 @@ __weak void USBD_RTX_Device(void)
     }
 }
 #else
-__weak void USBD_RTX_Device(void);
+__WEAK void USBD_RTX_Device(void);
 #endif
 
 /* USB Device - Device Events Callback Pointer */
@@ -1228,53 +1228,53 @@ void (* const USBD_RTX_P_Device)(void) = USBD_RTX_Device;
 /* USB Device Endpoint Events Callback Functions */
 extern void USBD_RTX_EndPoint0(void);
 #ifndef       USBD_RTX_EndPoint1
-__weak void USBD_RTX_EndPoint1(void);
+__WEAK void USBD_RTX_EndPoint1(void);
 #endif
 #ifndef       USBD_RTX_EndPoint2
-__weak void USBD_RTX_EndPoint2(void);
+__WEAK void USBD_RTX_EndPoint2(void);
 #endif
 #ifndef       USBD_RTX_EndPoint3
-__weak void USBD_RTX_EndPoint3(void);
+__WEAK void USBD_RTX_EndPoint3(void);
 #endif
 #ifndef       USBD_RTX_EndPoint4
-__weak void USBD_RTX_EndPoint4(void);
+__WEAK void USBD_RTX_EndPoint4(void);
 #endif
 #ifndef       USBD_RTX_EndPoint5
-__weak void USBD_RTX_EndPoint5(void);
+__WEAK void USBD_RTX_EndPoint5(void);
 #endif
 #ifndef       USBD_RTX_EndPoint6
-__weak void USBD_RTX_EndPoint6(void);
+__WEAK void USBD_RTX_EndPoint6(void);
 #endif
 #ifndef       USBD_RTX_EndPoint7
-__weak void USBD_RTX_EndPoint7(void);
+__WEAK void USBD_RTX_EndPoint7(void);
 #endif
 #ifndef       USBD_RTX_EndPoint8
-__weak void USBD_RTX_EndPoint8(void);
+__WEAK void USBD_RTX_EndPoint8(void);
 #endif
 #ifndef       USBD_RTX_EndPoint9
-__weak void USBD_RTX_EndPoint9(void);
+__WEAK void USBD_RTX_EndPoint9(void);
 #endif
 #ifndef       USBD_RTX_EndPoint10
-__weak void USBD_RTX_EndPoint10(void);
+__WEAK void USBD_RTX_EndPoint10(void);
 #endif
 #ifndef       USBD_RTX_EndPoint11
-__weak void USBD_RTX_EndPoint11(void);
+__WEAK void USBD_RTX_EndPoint11(void);
 #endif
 #ifndef       USBD_RTX_EndPoint12
-__weak void USBD_RTX_EndPoint12(void);
+__WEAK void USBD_RTX_EndPoint12(void);
 #endif
 #ifndef       USBD_RTX_EndPoint13
-__weak void USBD_RTX_EndPoint13(void);
+__WEAK void USBD_RTX_EndPoint13(void);
 #endif
 #ifndef       USBD_RTX_EndPoint14
-__weak void USBD_RTX_EndPoint14(void);
+__WEAK void USBD_RTX_EndPoint14(void);
 #endif
 #ifndef       USBD_RTX_EndPoint15
-__weak void USBD_RTX_EndPoint15(void);
+__WEAK void USBD_RTX_EndPoint15(void);
 #endif
 
 #if    (USBD_HID_ENABLE)
-__weak void USBD_RTX_Core(void)
+__WEAK void USBD_RTX_Core(void)
 {
     U16 evt;
 
@@ -1288,7 +1288,7 @@ __weak void USBD_RTX_Core(void)
     }
 }
 #else
-__weak void USBD_RTX_Core(void);
+__WEAK void USBD_RTX_Core(void);
 #endif
 
 /* USB Device - Core Events Callback Pointer */
@@ -1334,7 +1334,7 @@ const BOOL __rtx = __FALSE;
 
 void usbd_os_evt_set(U16 event_flags, U32 task)
 {
-    
+
 }
 U16  usbd_os_evt_get(void)
 {
@@ -1587,7 +1587,7 @@ void USBD_RTX_TaskInit(void)
 
 #define USBD_HID_DESC_OFS                 (USB_CONFIGUARTION_DESC_SIZE + USB_INTERFACE_DESC_SIZE                                                + \
                                            USBD_MSC_ENABLE * USBD_MSC_DESC_LEN + USBD_CDC_ACM_ENABLE * USBD_CDC_ACM_DESC_LEN)
-  
+
 #define USBD_WTOTALLENGTH_MAX              (USB_CONFIGUARTION_DESC_SIZE +                 \
                                            USBD_CDC_ACM_DESC_LEN * USBD_CDC_ACM_ENABLE + \
                                            USBD_HID_DESC_LEN     * USBD_HID_ENABLE     + \
@@ -1610,7 +1610,7 @@ void USBD_RTX_TaskInit(void)
       7     IN7          OUT7
 */
 
-__weak \
+__WEAK \
 const U8 USBD_HID_ReportDescriptor[] = {
     HID_UsagePageVendor(0x00),
     HID_Usage(0x01),
@@ -1642,14 +1642,14 @@ const U8 USBD_HID_ReportDescriptor[] = {
     HID_EndCollection,
 };
 
-__weak \
+__WEAK \
 const U16 USBD_HID_ReportDescriptorSize = sizeof(USBD_HID_ReportDescriptor);
 
-__weak \
+__WEAK \
 U16 USBD_HID_DescriptorOffset     = USBD_HID_DESC_OFS;
 
 /* USB Device Standard Descriptor */
-__weak \
+__WEAK \
 const U8 USBD_DeviceDescriptor[] = {
     USB_DEVICE_DESC_SIZE,                 /* bLength */
     USB_DEVICE_DESCRIPTOR_TYPE,           /* bDescriptorType */
@@ -1685,7 +1685,7 @@ const U8 USBD_DeviceDescriptor[] = {
 
 #if (USBD_HS_ENABLE)
 /* USB Device Qualifier Descriptor (for Full Speed) */
-__weak \
+__WEAK \
 const U8 USBD_DeviceQualifier[] = {
     USB_DEVICE_QUALI_SIZE,                /* bLength */
     USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -1703,7 +1703,7 @@ const U8 USBD_DeviceQualifier[] = {
 };
 
 /* USB Device Qualifier Descriptor for High Speed */
-__weak \
+__WEAK \
 const U8 USBD_DeviceQualifier_HS[] = {
     USB_DEVICE_QUALI_SIZE,                /* bLength */
     USB_DEVICE_QUALIFIER_DESCRIPTOR_TYPE, /* bDescriptorType */
@@ -1721,11 +1721,11 @@ const U8 USBD_DeviceQualifier_HS[] = {
 };
 #else
 /* USB Device Qualifier Descriptor (for Full Speed) */
-__weak \
+__WEAK \
 const U8 USBD_DeviceQualifier[]    = { 0 };
 
 /* USB Device Qualifier Descriptor for High Speed */
-__weak \
+__WEAK \
 const U8 USBD_DeviceQualifier_HS[] = { 0 };
 #endif
 
@@ -1741,24 +1741,24 @@ U8 USBD_WinUSBDescriptorSetDescriptor[] = {
     WBVAL(WINUSB_SET_HEADER_DESCRIPTOR_TYPE), /* wDescriptorType */
     0x00, 0x00, 0x03, 0x06, /* >= Win 8.1 */  /* dwWindowsVersion*/
     WBVAL(USBD_WINUSB_DESC_SET_LEN),          /* wDescriptorSetTotalLength */
-#if (USBD_WEBUSB_ENABLE)    
-    WBVAL(WINUSB_FUNCTION_SUBSET_HEADER_SIZE),// wLength 
-    WBVAL(WINUSB_SUBSET_HEADER_FUNCTION_TYPE),// wDescriptorType 
+#if (USBD_WEBUSB_ENABLE)
+    WBVAL(WINUSB_FUNCTION_SUBSET_HEADER_SIZE),// wLength
+    WBVAL(WINUSB_SUBSET_HEADER_FUNCTION_TYPE),// wDescriptorType
     0,                                        // bFirstInterface USBD_WINUSB_IF_NUM
-    0,                                        // bReserved 
-    WBVAL(FUNCTION_SUBSET_LEN),               // wSubsetLength 
-    WBVAL(WINUSB_FEATURE_COMPATIBLE_ID_SIZE), // wLength 
-    WBVAL(WINUSB_FEATURE_COMPATIBLE_ID_TYPE), // wDescriptorType 
+    0,                                        // bReserved
+    WBVAL(FUNCTION_SUBSET_LEN),               // wSubsetLength
+    WBVAL(WINUSB_FEATURE_COMPATIBLE_ID_SIZE), // wLength
+    WBVAL(WINUSB_FEATURE_COMPATIBLE_ID_TYPE), // wDescriptorType
     'W', 'I', 'N', 'U', 'S', 'B', 0, 0,       // CompatibleId
     0, 0, 0, 0, 0, 0, 0, 0,                   // SubCompatibleId
-    WBVAL(DEVICE_INTERFACE_GUIDS_FEATURE_LEN),// wLength 
-    WBVAL(WINUSB_FEATURE_REG_PROPERTY_TYPE),  // wDescriptorType 
-    WBVAL(WINUSB_PROP_DATA_TYPE_REG_MULTI_SZ), // wPropertyDataType 
-    WBVAL(42), // wPropertyNameLength 
+    WBVAL(DEVICE_INTERFACE_GUIDS_FEATURE_LEN),// wLength
+    WBVAL(WINUSB_FEATURE_REG_PROPERTY_TYPE),  // wDescriptorType
+    WBVAL(WINUSB_PROP_DATA_TYPE_REG_MULTI_SZ), // wPropertyDataType
+    WBVAL(42), // wPropertyNameLength
     'D',0,'e',0,'v',0,'i',0,'c',0,'e',0,
     'I',0,'n',0,'t',0,'e',0,'r',0,'f',0,'a',0,'c',0,'e',0,
     'G',0,'U',0,'I',0,'D',0,'s',0,0,0,
-    WBVAL(80), // wPropertyDataLength 
+    WBVAL(80), // wPropertyDataLength
     '{',0,
     '9',0,'2',0,'C',0,'E',0,'6',0,'4',0,'6',0,'2',0,'-',0,
     '9',0,'C',0,'7',0,'7',0,'-',0,
@@ -1766,8 +1766,8 @@ U8 USBD_WinUSBDescriptorSetDescriptor[] = {
     '9',0,'3',0,'3',0,'B',0,'-',
     0,'3',0,'1',0,'C',0,'B',0,'9',0,'C',0,'5',0,'A',0,'A',0,'3',0,'B',0,'9',0,
     '}',0,0,0,0,0,
-#endif 
-#if (USBD_BULK_ENABLE)    
+#endif
+#if (USBD_BULK_ENABLE)
     WBVAL(WINUSB_FUNCTION_SUBSET_HEADER_SIZE),/* wLength */
     WBVAL(WINUSB_SUBSET_HEADER_FUNCTION_TYPE),/* wDescriptorType */
     0,                                        /* bFirstInterface USBD_BULK_IF_NUM*/
@@ -1792,7 +1792,7 @@ U8 USBD_WinUSBDescriptorSetDescriptor[] = {
     'A',0,'A',0,'3',0,'6',0,'-',
     0,'1',0,'A',0,'A',0,'E',0,'4',0,'6',0,'4',0,'6',0,'3',0,'7',0,'7',0,'6',0,
     '}',0,0,0,0,0,
-#endif    
+#endif
 };
 
 #else
@@ -1818,7 +1818,7 @@ BOOL USBD_EndPoint0_Setup_WinUSB_ReqToDevice(void)
                                            USBD_WEBUSB_DESC_LEN * USBD_WEBUSB_ENABLE + \
                                            USBD_WINUSB_DESC_LEN * USBD_WINUSB_ENABLE)
 
-__weak \
+__WEAK \
 const U8 USBD_BinaryObjectStoreDescriptor[] = {
 	USB_BOS_DESC_SIZE,                      /* bLength */
 	USB_BINARY_OBJECT_STORE_DESCRIPTOR_TYPE,/* bDescriptorType */
@@ -1854,7 +1854,7 @@ const U8 USBD_BinaryObjectStoreDescriptor[] = {
 };
 
 #else
-__weak \
+__WEAK \
 const U8 USBD_BinaryObjectStoreDescriptor[] = { 0 };
 
 #endif
@@ -2017,7 +2017,7 @@ const U8 USBD_BinaryObjectStoreDescriptor[] = { 0 };
   USB_ENDPOINT_TYPE_BULK,               /* bmAttributes */                                                  \
   WBVAL(USBD_MSC_HS_WMAXPACKETSIZE),    /* wMaxPacketSize */                                                \
   USBD_MSC_HS_BINTERVAL,                /* bInterval */
-  
+
 #define BULK_DESC                                                                                            \
 /* Interface, Alternate Setting 0, MSC Class */                                                             \
   USB_INTERFACE_DESC_SIZE,              /* bLength */                                                       \
@@ -2045,7 +2045,7 @@ const U8 USBD_BinaryObjectStoreDescriptor[] = { 0 };
   USB_ENDPOINT_IN(USBD_BULK_EP_BULKIN),  /* bEndpointAddress */                                              \
   USB_ENDPOINT_TYPE_BULK,               /* bmAttributes */                                                  \
   WBVAL(USBD_BULK_WMAXPACKETSIZE),       /* wMaxPacketSize */                                                \
-  0x00,                                 /* bInterval: ignore for Bulk transfer */                           
+  0x00,                                 /* bInterval: ignore for Bulk transfer */
 
 #define BULK_EP_HS                          /* MSC Endpoints for Low-speed/Full-speed */                        \
 /* Endpoint, EP Bulk OUT */                                                                                  \
@@ -2062,7 +2062,7 @@ const U8 USBD_BinaryObjectStoreDescriptor[] = { 0 };
   USB_ENDPOINT_IN(USBD_BULK_EP_BULKIN),/* bEndpointAddress */                                              \
   USB_ENDPOINT_TYPE_BULK,               /* bmAttributes */                                                  \
   WBVAL(USBD_BULK_HS_WMAXPACKETSIZE),       /* wMaxPacketSize */                                                \
-  0x00,                                 /* bInterval: ignore for Bulk transfer */                           
+  0x00,                                 /* bInterval: ignore for Bulk transfer */
 
 #define ADC_DESC_IAD(first,num_of_ifs)  /* ADC: Interface Association Descriptor */                         \
   USB_INTERFACE_ASSOC_DESC_SIZE,        /* bLength */                                                       \
@@ -2323,16 +2323,16 @@ const U8 USBD_BinaryObjectStoreDescriptor[] = { 0 };
 
 /* USB Device Configuration Descriptor (for Full Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-__weak \
+__WEAK \
 U8 USBD_ConfigDescriptor[200] = { 0 };
 
 #if (USBD_HS_ENABLE == 0)               /* If High-speed not enabled, declare dummy descriptors for High-speed */
-__weak \
+__WEAK \
 U8 USBD_ConfigDescriptor_HS[] = { 0 };
 #else
 /* USB Device Configuration Descriptor (for High Speed) */
 /*   All Descriptors (Configuration, Interface, Endpoint, Class, Vendor) */
-__weak \
+__WEAK \
 U8 USBD_ConfigDescriptor_HS[200] = { 0 };
 
 #endif
@@ -2348,7 +2348,7 @@ U8 USBD_ConfigDescriptor_HS[200] = { 0 };
 #define USBD_STR_VAL(n)                  \
  { sizeof(USBD_##n), USB_STRING_DESCRIPTOR_TYPE, USBD_##n }
 
-__weak \
+__WEAK \
 const struct {
     struct {
         U8  len;
@@ -2445,7 +2445,7 @@ const struct {
     USBD_##n                    \
 }
 
-__weak \
+__WEAK \
 struct {
     WEBUSB_URL_DEF(WEBUSB_LANDING_URL);
     WEBUSB_URL_DEF(WEBUSB_ORIGIN_URL);
@@ -2471,26 +2471,26 @@ extern uint8_t flash_algo_valid(void);
 
 static U16 start_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     U8 * pD = 0;
-    const U8 start_desc[] = { 
+    const U8 start_desc[] = {
         /* Configuration 1 */
-        USB_CONFIGUARTION_DESC_SIZE,                // bLength 
-        USB_CONFIGURATION_DESCRIPTOR_TYPE,          // bDescriptorType 
-        WBVAL(USBD_WTOTALLENGTH_MAX),               // wTotalLength 
-        USBD_IF_NUM_MAX,                            // bNumInterfaces 
-        0x01,                                       // bConfigurationValue: 0x01 is used to select this configuration 
-        0x00,                                       // iConfiguration: no string to describe this configuration 
-        USBD_CFGDESC_BMATTRIBUTES |                 // bmAttributes 
+        USB_CONFIGUARTION_DESC_SIZE,                // bLength
+        USB_CONFIGURATION_DESCRIPTOR_TYPE,          // bDescriptorType
+        WBVAL(USBD_WTOTALLENGTH_MAX),               // wTotalLength
+        USBD_IF_NUM_MAX,                            // bNumInterfaces
+        0x01,                                       // bConfigurationValue: 0x01 is used to select this configuration
+        0x00,                                       // iConfiguration: no string to describe this configuration
+        USBD_CFGDESC_BMATTRIBUTES |                 // bmAttributes
         (USBD_POWER << 6),
-        USBD_CFGDESC_BMAXPOWER                      // bMaxPower, device power consumption 
+        USBD_CFGDESC_BMAXPOWER                      // bMaxPower, device power consumption
     };
     pD = config_desc;
     memcpy(pD, start_desc, sizeof(start_desc));
-    
+
 #if (USBD_HS_ENABLE == 1)
     pD = config_desc_hs;
     memcpy(pD, start_desc, sizeof(start_desc));
 #endif
-    
+
     return sizeof(start_desc);
 }
 
@@ -2509,7 +2509,7 @@ static U16 hid_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     pD = config_desc;
     memcpy(pD, hid_desc, sizeof(hid_desc));
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
-#if (USBD_HS_ENABLE == 1)  
+#if (USBD_HS_ENABLE == 1)
     const U8 hid_desc_hs[] = {
         HID_DESC
     #if ((USBD_HID_EP_INTOUT != 0) && (USBD_HID_EP_INTIN != 0))
@@ -2523,7 +2523,7 @@ static U16 hid_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     pD = config_desc_hs;
     memcpy(pD, hid_desc_hs, sizeof(hid_desc_hs));
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
-#endif    
+#endif
     return sizeof(hid_desc);
 }
 
@@ -2544,8 +2544,8 @@ static U16 acm_cdc_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
 #if (USBD_MULTI_IF)
     ((USB_INTERFACE_ASSOCIATION_DESCRIPTOR *)pD)->bFirstInterface = if_num;
     pD += USB_INTERFACE_ASSOC_DESC_SIZE;
-#endif    
-    
+#endif
+
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
     pD += USB_INTERFACE_DESC_SIZE + CDC_HEADER_SIZE + CDC_CALL_MANAGEMENT_SIZE + CDC_ABSTRACT_CONTROL_MANAGEMENT_SIZE;
     ((UNION_FUNCTIONAL_DESCRIPTOR*)pD)->bMasterInterface = if_num;
@@ -2553,7 +2553,7 @@ static U16 acm_cdc_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     pD += CDC_UNION_SIZE + USB_ENDPOINT_DESC_SIZE;
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num + 1;
 
-#if (USBD_HS_ENABLE == 1)    
+#if (USBD_HS_ENABLE == 1)
     const U8 cdc_desc_hs[] = {
     #if (USBD_MULTI_IF)
         CDC_ACM_DESC_IAD(0, 2)
@@ -2565,35 +2565,35 @@ static U16 acm_cdc_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     };
      pD = config_desc_hs;
     memcpy(pD, cdc_desc_hs, sizeof(cdc_desc_hs));
-    
+
 #if (USBD_MULTI_IF)
     ((USB_INTERFACE_ASSOCIATION_DESCRIPTOR *)pD)->bFirstInterface = if_num;
     pD += USB_INTERFACE_ASSOC_DESC_SIZE;
-#endif    
-    
+#endif
+
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
     pD += USB_INTERFACE_DESC_SIZE + CDC_HEADER_SIZE + CDC_CALL_MANAGEMENT_SIZE + CDC_ABSTRACT_CONTROL_MANAGEMENT_SIZE;
     ((UNION_FUNCTIONAL_DESCRIPTOR*)pD)->bMasterInterface = if_num;
     ((UNION_FUNCTIONAL_DESCRIPTOR*)pD)->bSlaveInterface0 = if_num + 1;
     pD += CDC_UNION_SIZE + USB_ENDPOINT_DESC_SIZE;
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num +1 ;
-#endif  //(USBD_HS_ENABLE == 1)    
+#endif  //(USBD_HS_ENABLE == 1)
     return sizeof(cdc_desc);
 }
 
 static U16 msc_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     U8 * pD = 0;
-    const U8 msc_desc[] = { 
+    const U8 msc_desc[] = {
         MSC_DESC
         MSC_EP
     };
     pD = config_desc;
     memcpy(pD, msc_desc, sizeof(msc_desc));
-    
+
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
 
-#if (USBD_HS_ENABLE == 1)     
-    const U8 msc_desc_hs[] = { 
+#if (USBD_HS_ENABLE == 1)
+    const U8 msc_desc_hs[] = {
         MSC_DESC
         MSC_EP_HS
     };
@@ -2601,7 +2601,7 @@ static U16 msc_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     memcpy(pD, msc_desc_hs, sizeof(msc_desc_hs));
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
 #endif
-    
+
     return sizeof(msc_desc);
 }
 
@@ -2614,36 +2614,36 @@ static U16 webusb_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     pD = config_desc;
     memcpy(pD, webusb_desc, sizeof(webusb_desc));
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
-    
+
 #if (USBD_HS_ENABLE == 1)
     pD = config_desc_hs;
     memcpy(pD, webusb_desc, sizeof(webusb_desc));
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
 #endif
-    
+
 #if (USBD_WINUSB_ENABLE)
     pD = USBD_WinUSBDescriptorSetDescriptor + WINUSB_DESCRIPTOR_SET_HEADER_SIZE;
     ((WINUSB_FUNCTION_SUBSET_HEADER*)pD)->bFirstInterface = if_num;
 #else
 #error "WEBUSB requires WINUSB!"
 #endif
-    
-    return sizeof(webusb_desc); 
+
+    return sizeof(webusb_desc);
 }
 #endif
 
 #if (USBD_BULK_ENABLE)
 static U16 bulk_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
     U8 * pD = 0;
-    const U8 bulk_desc[] = { 
+    const U8 bulk_desc[] = {
         BULK_DESC
         BULK_EP
     };
     pD = config_desc;
     memcpy(pD, bulk_desc, sizeof(bulk_desc));
     ((USB_INTERFACE_DESCRIPTOR *)pD)->bInterfaceNumber = if_num;
-#if (USBD_HS_ENABLE == 1)   
-    const U8 bulk_desc_hs[] = { 
+#if (USBD_HS_ENABLE == 1)
+    const U8 bulk_desc_hs[] = {
         BULK_DESC
         BULK_EP_HS
     };
@@ -2661,25 +2661,25 @@ static U16 bulk_desc_fill(U8 * config_desc, U8 * config_desc_hs, U8 if_num) {
 #else
 #error "BULK interfaces requires WINUSB!"
 #endif
-    
+
     return sizeof(bulk_desc);
 }
 #endif
 
 void usbd_class_init(void)
-{   
+{
     U8  if_num = 0;
     U16 desc_ptr = 0;
-    
-    desc_ptr += start_desc_fill(&USBD_ConfigDescriptor[desc_ptr], &USBD_ConfigDescriptor_HS[desc_ptr], if_num);    
-    
+
+    desc_ptr += start_desc_fill(&USBD_ConfigDescriptor[desc_ptr], &USBD_ConfigDescriptor_HS[desc_ptr], if_num);
+
 #if (USBD_ADC_ENABLE)
     usbd_adc_init();
 #endif
 
 
-#if (USBD_MSC_ENABLE)        
-    
+#if (USBD_MSC_ENABLE)
+
 #if !(defined(DAPLINK_BL)) &&  defined(DRAG_N_DROP_SUPPORT)
     //change descriptors here
     if (config_ram_get_disable_msd() == 1 || flash_algo_valid()==0 ){
@@ -2695,7 +2695,7 @@ void usbd_class_init(void)
         usb_conf_desc->bNumInterfaces = usbd_if_num;
         usb_conf_desc->wTotalLength = usb_wtotal_len;
         USBD_ConfigDescriptor_HS[usb_wtotal_len] = 0;
-#endif         
+#endif
     } else
 #endif
     {
@@ -2704,7 +2704,7 @@ void usbd_class_init(void)
     usbd_msc_init();
 
     }
-#endif //#if (USBD_MSC_ENABLE)  
+#endif //#if (USBD_MSC_ENABLE)
 
 #if (USBD_CDC_ACM_ENABLE)
     usbd_cdc_acm_cif_num = if_num++;
@@ -2713,19 +2713,19 @@ void usbd_class_init(void)
     USBD_CDC_ACM_Initialize();
 #endif
 
-#if (USBD_HID_ENABLE) 
+#if (USBD_HID_ENABLE)
     usbd_hid_if_num = if_num++;
     desc_ptr += hid_desc_fill(&USBD_ConfigDescriptor[desc_ptr], &USBD_ConfigDescriptor_HS[desc_ptr], usbd_hid_if_num);
     usbd_hid_init();
 #endif
 
 #if (USBD_WEBUSB_ENABLE)
-    usbd_webusb_if_num = if_num++;   
+    usbd_webusb_if_num = if_num++;
     desc_ptr += webusb_desc_fill(&USBD_ConfigDescriptor[desc_ptr], &USBD_ConfigDescriptor_HS[desc_ptr], usbd_webusb_if_num);
 #endif
 
 #if (USBD_BULK_ENABLE)
-    usbd_bulk_if_num = if_num++;  
+    usbd_bulk_if_num = if_num++;
     desc_ptr += bulk_desc_fill(&USBD_ConfigDescriptor[desc_ptr], &USBD_ConfigDescriptor_HS[desc_ptr], usbd_bulk_if_num);
     usbd_bulk_init();
 #endif

--- a/source/usb/usb_msc.h
+++ b/source/usb/usb_msc.h
@@ -54,7 +54,7 @@
 
 
 /* Bulk-only Command Block Wrapper */
-typedef __packed struct _MSC_CBW {
+typedef __PACKED_STRUCT _MSC_CBW {
     U32 dSignature;
     U32 dTag;
     U32 dDataLength;
@@ -65,7 +65,7 @@ typedef __packed struct _MSC_CBW {
 } MSC_CBW;
 
 /* Bulk-only Command Status Wrapper */
-typedef __packed struct _MSC_CSW {
+typedef __PACKED_STRUCT _MSC_CSW {
     U32 dSignature;
     U32 dTag;
     U32 dDataResidue;

--- a/source/usb/usb_webusb.h
+++ b/source/usb/usb_webusb.h
@@ -29,7 +29,7 @@
 #define WEBUSB_URL_TYPE                         0x03
 
 /* WebUSB Platform Capability Descriptor */
-typedef __packed struct _WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
+typedef __PACKED_STRUCT _WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDevCapabilityType;
@@ -40,7 +40,7 @@ typedef __packed struct _WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
     U8  iLandingPage;
 } WEBUSB_PLATFORM_CAPABILITY_DESCRIPTOR;
 
-typedef __packed struct _WEBUSB_URL_DESCRIPTOR {
+typedef __PACKED_STRUCT _WEBUSB_URL_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bScheme;

--- a/source/usb/usb_winusb.h
+++ b/source/usb/usb_winusb.h
@@ -37,7 +37,7 @@
 #define WINUSB_PROP_DATA_TYPE_REG_MULTI_SZ          0x07
 
 /* WinUSB Microsoft OS 2.0 descriptor Platform Capability Descriptor */
-typedef __packed struct _WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
+typedef __PACKED_STRUCT _WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
     U8  bLength;
     U8  bDescriptorType;
     U8  bDevCapabilityType;
@@ -50,7 +50,7 @@ typedef __packed struct _WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR {
 } WINUSB_PLATFORM_CAPABILITY_DESCRIPTOR;
 
 /* WinUSB Microsoft OS 2.0 descriptor set header */
-typedef __packed struct _WINUSB_DESCRIPTOR_SET_HEADER {
+typedef __PACKED_STRUCT _WINUSB_DESCRIPTOR_SET_HEADER {
     U16 wLength;
     U16 wDescriptorType;
     U32 dwWindowsVersion;

--- a/source/usb/usbd_core.c
+++ b/source/usb/usbd_core.c
@@ -44,12 +44,6 @@ OS_TID USBD_RTX_CoreTask;           /* USB Core Task ID */
 #endif
 
 
-__asm void $$USBD$$version(void)
-{
-    /* Export a version number symbol for a version control. */
-    EXPORT  __RL_USBD_VER
-__RL_USBD_VER   EQU     0x470
-}
 
 
 /*

--- a/source/usb/usbd_core.c
+++ b/source/usb/usbd_core.c
@@ -202,7 +202,7 @@ static inline BOOL USBD_ReqGetStatus(void)
 
         case REQUEST_TO_INTERFACE:
             if ((USBD_Configuration != 0) && (USBD_SetupPacket.wIndexL < USBD_NumInterfaces)) {
-                *((__packed U16 *)USBD_EP0Buf) = 0;
+                __UNALIGNED_UINT16_WRITE(USBD_EP0Buf, 0);
                 USBD_EP0Data.pData = USBD_EP0Buf;
             } else {
                 return (__FALSE);
@@ -215,7 +215,7 @@ static inline BOOL USBD_ReqGetStatus(void)
             m = (n & 0x80) ? ((1 << 16) << (n & 0x0F)) : (1 << n);
 
             if (((USBD_Configuration != 0) || ((n & 0x0F) == 0)) && (USBD_EndPointMask & m)) {
-                *((__packed U16 *)USBD_EP0Buf) = (USBD_EndPointHalt & m) ? 1 : 0;
+                __UNALIGNED_UINT16_WRITE(USBD_EP0Buf, (USBD_EndPointHalt & m) ? 1 : 0);
                 USBD_EP0Data.pData = USBD_EP0Buf;
             } else {
                 return (__FALSE);

--- a/source/usb/webusb/usbd_core_webusb.c
+++ b/source/usb/webusb/usbd_core_webusb.c
@@ -31,7 +31,7 @@
  *    Return Value:    TRUE - Setup vendor request ok, FALSE - Setup vendor request not supported
  */
 
-__weak BOOL USBD_EndPoint0_Setup_WebUSB_ReqToDevice(void)
+__WEAK BOOL USBD_EndPoint0_Setup_WebUSB_ReqToDevice(void)
 {
     U8  *pD;
     U32 len, n;

--- a/source/usb/winusb/usbd_core_winusb.c
+++ b/source/usb/winusb/usbd_core_winusb.c
@@ -30,7 +30,7 @@
  *    Return Value:    TRUE - Setup vendor request ok, FALSE - Setup vendor request not supported
  */
 
-__weak BOOL USBD_EndPoint0_Setup_WinUSB_ReqToDevice(void)
+__WEAK BOOL USBD_EndPoint0_Setup_WinUSB_ReqToDevice(void)
 {
     U8  *pD;
     U32 len;


### PR DESCRIPTION
This PR contains a lot of little changes that remove armcc version 5 compiler specific code, plus some related general cleanup. Most of the armcc-only keywords, such as `__packed`, were migrated to macros defined in the CMSIS compiler support headers.