### PR TITLE
MXRT1050: Issue a hardware reset

### DIFF
--- a/source/family/freescale/target_reset_mimxrt.c
+++ b/source/family/freescale/target_reset_mimxrt.c
@@ -22,14 +22,18 @@
 #include "swd_host.h"
 #include "info.h"
 #include "target_family.h"
+#include "cmsis_os2.h"
 
 static void target_before_init_debug(void)
 {
     // This is for the hardware conflict (the EVK are not consider >2 debugger connection
-    // situation) with another external debugger(such as JLINK). Before drag&pull, to force
-    // RESET pin to high state ensure a successfully access. If external debugger not
-    // connected. It's not necessary for doing that.
+    // situation) with another external debugger(such as JLINK). Before drag&pull, issue a
+    // hardware reset to bring the platform to a known state and also force
+    // RESET pin to high state ensure a successfully access.
+    swd_set_target_reset(1);
+    osDelay(5);
     swd_set_target_reset(0);
+    osDelay(5);
 }
 
 static void prerun_target_config(void)


### PR DESCRIPTION
This is to bring the hardware to a known state before drag-n-drop.

Failures were seen when running automated mbed-os tests as drag-n-drop would fail when the completed test left the platform in a low-power state. 
Issuing a hardware reset before drag-n-drop would put the platform back to default reset state. 

Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>