### PR TITLE
add support for even/odd check on hic_hal stm32

### DIFF
--- a/source/hic_hal/stm32/stm32f103xb/uart.c
+++ b/source/hic_hal/stm32/stm32f103xb/uart.c
@@ -170,7 +170,11 @@ int32_t uart_set_configuration(UART_Configuration *config)
 
     //Only 8 bit support
     configuration.DataBits = UART_DATA_BITS_8;
-    uart_handle.Init.WordLength = UART_WORDLENGTH_8B;
+    if (uart_handle.Init.Parity == HAL_UART_PARITY_ODD || uart_handle.Init.Parity == HAL_UART_PARITY_EVEN) {
+        uart_handle.Init.WordLength = UART_WORDLENGTH_9B;
+    } else {
+        uart_handle.Init.WordLength = UART_WORDLENGTH_8B;
+    }
 
     // No flow control
     configuration.FlowControl = UART_FLOW_CONTROL_NONE;


### PR DESCRIPTION
some target platform support ISP with uart (such as STM32)，but the ISP need even/odd check，this patch add even/odd check on hic_hal STM32