### PR TITLE
Rework UART  implementation for MAX32625 HIC

### DIFF
--- a/source/hic_hal/maxim/max32625/uart.c
+++ b/source/hic_hal/maxim/max32625/uart.c
@@ -25,12 +25,7 @@
 #include "uart.h"
 
 // Size must be 2^n
-#define  BUFFER_SIZE (4096)
-
-#define UART_ERRORS (MXC_F_UART_INTFL_RX_FRAMING_ERR | \
-                     MXC_F_UART_INTFL_RX_PARITY_ERR | \
-                     MXC_F_UART_INTFL_RX_FIFO_OVERFLOW)
-
+#define BUFFER_SIZE (4096)
 
 // Track bit rate to avoid calculation from bus clock, clock scaler and baud divisor values
 static uint32_t baudrate;
@@ -39,6 +34,7 @@ static mxc_uart_regs_t *CdcAcmUart = NULL;
 static mxc_uart_fifo_regs_t *CdcAcmUartFifo = NULL;
 static IRQn_Type CdcAcmUartIrqNumber = MXC_IRQ_EXT_COUNT;
 
+// Ring buffer
 static struct {
     uint8_t  data[BUFFER_SIZE];
     volatile uint16_t idx_in;
@@ -48,15 +44,85 @@ static struct {
 } write_buffer, read_buffer;
 
 /******************************************************************************/
-static void set_bitrate(uint32_t bps)
+static void set_bitrate(uint32_t target_baud)
 {
-    uint32_t baud_divisor;
+    uint32_t clk_scale;
+    uint32_t min_baud;
+    uint32_t uart_clk;
+    uint16_t baud_shift;
+    uint16_t baud_div;
+    uint32_t baud, diff_baud;
+    uint32_t baud_1, diff_baud_1;
 
-    baud_divisor = SystemCoreClock / (1 << (MXC_CLKMAN->sys_clk_ctrl_8_uart - 1));
-    baud_divisor /= (bps * 16);
-    CdcAcmUart->baud = baud_divisor;
+    // Setup system clock divider for given bit rate
+    clk_scale = 0;
+    do {
+        min_baud = (SystemCoreClock >> clk_scale++) / (16 * (MXC_F_UART_BAUD_BAUD_DIVISOR >> MXC_F_UART_BAUD_BAUD_DIVISOR_POS));
+    } while ((target_baud < min_baud) && (clk_scale < MXC_V_CLKMAN_CLK_SCALE_DIV_256));
 
-    baudrate = bps;
+    // Check if the bit rate can be reached
+    if (target_baud < min_baud) {
+        // Fail silently
+        return;
+    }
+
+    if (MXC_CLKMAN->sys_clk_ctrl_8_uart != clk_scale) {
+        MXC_CLKMAN->sys_clk_ctrl_8_uart = clk_scale;
+    }
+
+    uart_clk = SystemCoreClock >> (clk_scale - 1);
+
+    baud_shift = 2;
+    baud_div = uart_clk / (target_baud * 4);
+
+    // Bitrate too high
+    if (baud_div == 0) {
+        // Fail silently
+        return;
+    }
+
+    // Decrease the divisor if baud_div is overflowing
+    while (baud_div > 0x00FF) {
+        if (baud_shift == 0) {
+            // Fail silently
+            return;
+        }
+        baud_shift--;
+        baud_div = uart_clk / (target_baud * (16 >> baud_shift));
+    }
+
+    // Adjust baud_div to avoid overflow in the calculations below
+    if (baud_div == 0x00FF) {
+        baud_div = 0x00FE;
+    }
+
+    if (baud_div == 0x0000) {
+        baud_div = 0x0001;
+    }
+
+    // Determine if truncation increases the error
+    baud = uart_clk / (baud_div * (16 >> baud_shift));
+    baud_1 = uart_clk / ((baud_div + 1) * (16 >> baud_shift));
+
+    if (target_baud > baud) {
+        diff_baud = target_baud - baud;
+    } else {
+        diff_baud = baud - target_baud;
+    }
+
+    if (target_baud > baud_1) {
+        diff_baud_1 = target_baud - baud_1;
+    } else {
+        diff_baud_1 = baud_1 - target_baud;
+    }
+
+    if (diff_baud < diff_baud_1) {
+        CdcAcmUart->baud = (baud_div & MXC_F_UART_BAUD_BAUD_DIVISOR) | (baud_shift << MXC_F_UART_BAUD_BAUD_MODE_POS);
+    } else {
+        CdcAcmUart->baud = ((baud_div + 1) & MXC_F_UART_BAUD_BAUD_DIVISOR) | (baud_shift << MXC_F_UART_BAUD_BAUD_MODE_POS);
+    }
+
+    baudrate = target_baud;
 }
 
 /******************************************************************************/
@@ -81,11 +147,11 @@ int32_t uart_initialize(void)
 {
     int idx;
 
+    /* Do not enable UART Common Clock here, must happen inside uart_set_configuration()
+       to ensure correct clock scale for a given baud rate */
+
     if (CdcAcmUart == MXC_UART0) {
         MXC_CLKMAN->clk_gate_ctrl1 |= MXC_F_CLKMAN_CLK_GATE_CTRL1_UART0_CLK_GATER;
-        if (MXC_CLKMAN->sys_clk_ctrl_8_uart != MXC_S_CLKMAN_CLK_SCALE_DIV_4) {
-            MXC_CLKMAN->sys_clk_ctrl_8_uart = MXC_S_CLKMAN_CLK_SCALE_DIV_4;
-        }
 
         // Configure GPIO for UART
         MXC_IOMAN->uart0_req = ((MXC_V_IOMAN_MAP_A << MXC_F_IOMAN_UART0_REQ_IO_MAP_POS) | MXC_F_IOMAN_UART0_REQ_IO_REQ);
@@ -93,9 +159,6 @@ int32_t uart_initialize(void)
 
     } else if (CdcAcmUart == MXC_UART2) {
         MXC_CLKMAN->clk_gate_ctrl1 |= MXC_F_CLKMAN_CLK_GATE_CTRL1_UART2_CLK_GATER;
-        if (MXC_CLKMAN->sys_clk_ctrl_8_uart != MXC_S_CLKMAN_CLK_SCALE_DIV_4) {
-            MXC_CLKMAN->sys_clk_ctrl_8_uart = MXC_S_CLKMAN_CLK_SCALE_DIV_4;
-        }
 
         // Configure GPIO for UART
         MXC_IOMAN->uart2_req = ((MXC_V_IOMAN_MAP_A << MXC_F_IOMAN_UART2_REQ_IO_MAP_POS) | MXC_F_IOMAN_UART2_REQ_IO_REQ);
@@ -132,7 +195,7 @@ int32_t uart_initialize(void)
     CdcAcmUart->tx_fifo_ctrl |= (MXC_UART_FIFO_DEPTH - (MXC_UART_FIFO_DEPTH >> 2)) << MXC_F_UART_TX_FIFO_CTRL_FIFO_AE_LVL_POS;
 
     // Enable RX and TX interrupts
-    CdcAcmUart->inten = (MXC_F_UART_INTEN_RX_FIFO_NOT_EMPTY | MXC_F_UART_INTFL_RX_FIFO_OVERFLOW | MXC_F_UART_INTEN_TX_FIFO_AE);
+    CdcAcmUart->inten = (MXC_F_UART_INTEN_RX_FIFO_NOT_EMPTY | MXC_F_UART_INTEN_RX_FIFO_OVERFLOW | MXC_F_UART_INTEN_TX_FIFO_AE);
 
     // Enable UART
     CdcAcmUart->ctrl |= MXC_F_UART_CTRL_UART_EN;
@@ -177,14 +240,11 @@ int32_t uart_set_configuration(UART_Configuration *config)
 {
     uint32_t ctrl;
 
-    // Get current configuration; clearing parameters that may be configured here
-    ctrl = CdcAcmUart->ctrl & ~(MXC_F_UART_CTRL_PARITY |
-                                MXC_F_UART_CTRL_DATA_SIZE |
-                                MXC_F_UART_CTRL_EXTRA_STOP |
-                                MXC_F_UART_CTRL_CTS_EN |
-                                MXC_F_UART_CTRL_RTS_EN);
+    // Disable UART, clear FIFOs and configuration
+    CdcAcmUart->ctrl = 0;
 
     switch (config->Parity) {
+        default:
         case UART_PARITY_NONE: break;
         case UART_PARITY_ODD: ctrl |= MXC_S_UART_CTRL_PARITY_ODD;
         case UART_PARITY_EVEN: ctrl |= MXC_S_UART_CTRL_PARITY_EVEN;
@@ -196,17 +256,20 @@ int32_t uart_set_configuration(UART_Configuration *config)
         case UART_DATA_BITS_5:  ctrl |= MXC_S_UART_CTRL_DATA_SIZE_5_BITS; break;
         case UART_DATA_BITS_6:  ctrl |= MXC_S_UART_CTRL_DATA_SIZE_6_BITS; break;
         case UART_DATA_BITS_7:  ctrl |= MXC_S_UART_CTRL_DATA_SIZE_7_BITS; break;
+        default:
         case UART_DATA_BITS_8:  ctrl |= MXC_S_UART_CTRL_DATA_SIZE_8_BITS; break;
         case UART_DATA_BITS_16: return 0;
     }
 
     switch (config->StopBits) {
+        default:
         case UART_STOP_BITS_1:    break;
         case UART_STOP_BITS_1_5:
         case UART_STOP_BITS_2:    ctrl |= MXC_F_UART_CTRL_EXTRA_STOP; break;
     }
 
     switch (config->FlowControl) {
+        default:
         case UART_FLOW_CONTROL_NONE:      break;
         case UART_FLOW_CONTROL_RTS_CTS:   return 0;
         case UART_FLOW_CONTROL_XON_XOFF:  return 0;
@@ -214,8 +277,9 @@ int32_t uart_set_configuration(UART_Configuration *config)
 
     set_bitrate(config->Baudrate);
 
-    // Set the new configuration
+    // Set the new configuration, enable FIFOs and UART
     CdcAcmUart->ctrl = ctrl;
+    CdcAcmUart->ctrl |= MXC_F_UART_CTRL_RX_FIFO_EN | MXC_F_UART_CTRL_TX_FIFO_EN | MXC_F_UART_CTRL_UART_EN;
 
     return 1;
 }
@@ -273,6 +337,7 @@ int32_t uart_write_data(uint8_t *data, uint16_t size)
 {
     uint16_t xfer_count = size;
 
+    // Prioritize writes to TX FIFO, then to write_buffer
     if (write_buffer.cnt_in == write_buffer.cnt_out) {
         while ((((CdcAcmUart->tx_fifo_ctrl & MXC_F_UART_TX_FIFO_CTRL_FIFO_ENTRY) >> MXC_F_UART_TX_FIFO_CTRL_FIFO_ENTRY_POS) < MXC_UART_FIFO_DEPTH) &&
                 (xfer_count > 0)) {
@@ -326,12 +391,12 @@ void UART_IRQHandler(void)
     CdcAcmUart->intfl = intfl;
 
     if (intfl & MXC_F_UART_INTFL_RX_FIFO_OVERFLOW) {
-        read_buffer.data[read_buffer.idx_in++] = '*';
-        read_buffer.idx_in &= (BUFFER_SIZE - 1);
-        read_buffer.cnt_in++;
+        // Flush RX FIFO, prepare for new characters
+        CdcAcmUart->ctrl &= ~MXC_F_UART_CTRL_RX_FIFO_EN;
+        CdcAcmUart->ctrl |= MXC_F_UART_CTRL_RX_FIFO_EN;
     }
 
-    if (intfl & (MXC_F_UART_INTFL_RX_FIFO_NOT_EMPTY | UART_ERRORS)) {
+    if (intfl & MXC_F_UART_INTFL_RX_FIFO_NOT_EMPTY) {
         while ((CdcAcmUart->rx_fifo_ctrl & MXC_F_UART_RX_FIFO_CTRL_FIFO_ENTRY) &&
                 ((read_buffer.cnt_in - read_buffer.cnt_out) < BUFFER_SIZE)) {
             read_buffer.data[read_buffer.idx_in++] = CdcAcmUartFifo->rx;
@@ -339,6 +404,8 @@ void UART_IRQHandler(void)
             read_buffer.idx_in &= (BUFFER_SIZE - 1);
             read_buffer.cnt_in++;
         }
+
+        // Ring buffer overflow
         if (((read_buffer.cnt_in - read_buffer.cnt_out) >= BUFFER_SIZE)) {
             read_buffer.data[read_buffer.idx_in++] = '%';
             read_buffer.idx_in &= (BUFFER_SIZE - 1);


### PR DESCRIPTION
Added support for wide range of baud rates beyond 115200 for MAX32625 HIC along with other minor changes.

Tested on Windows 10 with MAX32630FTHR and MAX32620FTHR targets.