### PR TITLE
always put the main.o code and the startup data in RAM1

### DIFF
--- a/source/daplink/daplink.sct
+++ b/source/daplink/daplink.sct
@@ -33,6 +33,8 @@ LR_IROM1 DAPLINK_ROM_APP_START DAPLINK_ROM_APP_SIZE {
   RW_IRAM1 DAPLINK_RAM_APP_START DAPLINK_RAM_APP_SIZE {  ; RW data
    .ANY (ram_func)
    .ANY (+RW +ZI)
+   main.o (+RW +ZI)
+   startup_*.o (+RW +ZI)
    .ANY (RAM1)
   }
 


### PR DESCRIPTION
When DAPLINK_RAM_APP2_START is defined, the startup code and data
may be placed in RAM2, which is not guaranteed to work.

Explicitly place main.o and startup_*.o in RAM1.

Signed-off-by: Adrian Negreanu <adrian.negreanu@nxp.com>