### PR TITLE
Fixed bug where not authorized `sys' @ error/constitute.c/ will raised when building in linux

### DIFF
--- a/tools/mbedcli_compile.py
+++ b/tools/mbedcli_compile.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 #
 # DAPLink Interface Firmware
 # Copyright (c) 2009-2018, ARM Limited, All Rights Reserved


### PR DESCRIPTION
In linux, ```not authorized `sys' @ error/constitute.c/```  will be raised when running ```tools/mbedcli_compile.py```. This PR fixed this issue.

Reference: https://stackoverflow.com/questions/55558605/import-im6-q16-not-authorized-error-os-error-constitue-c-writeimage-1037-fo