### PR TITLE
Add GitHub Actions on experimental_compilers branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,14 +58,14 @@ jobs:
     - name: Install dependencies
       run:  |
         sudo apt install ccache ninja-build
-        for i in ${{ runner.temp }}/arm-gcc/bin/* ; ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
+        for i in ${{ runner.temp }}/arm-gcc/bin/* ; do ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
         ccache -M 1Ti
 
     - name: Compile
       run:  |
         export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:$PATH
-        python tools/progen_compile.py
+        python tools/progen_compile.py --release --parallel
 
     - name: Display results
       run:  |
-        - (find projectfiles -name *.elf | xargs ls -l; ccache -s) | tee log.txt
+        - (ls -lR firmware_*; ccache -s) | tee log.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,31 @@ jobs:
         key:  ${{ runner.os }}-${{ env.cache-name }}
         restore-keys: ${{ runner.os }}-${{ env.cache-name }}
 
+    - name: Cache Python modules
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Checkout source files
+      uses: actions/checkout@v2
+
+    - name: Install Python module
+      run:  |
+        pip3 install --user -r requirements.txt
+        pip3 install --user git+https://github.com/mbrossard/project_generator.git@development
+
+    - name: Install dependencies
+      run:  |
+        sudo apt install ccache ninja
+
     - name: Install Embedded Arm Toolchain
       if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
       run:  |
         curl -O -S https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
+        md5sum gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
         mkdir -p ${{ runner.temp }}/arm-gcc
         tar jvxf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Install Python module
       run:  |
         pip3 install --user -r requirements.txt
+        pip3 uninstall --user -y project-generator
         pip3 install --user git+https://github.com/mbrossard/project_generator.git@development
 
     - name: Install Embedded Arm Toolchain
@@ -63,7 +64,7 @@ jobs:
 
     - name: Compile
       run:  |
-        export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:$PATH
+        export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH
         python tools/progen_compile.py --release --parallel
 
     - name: Display results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install Python module
       run:  |
         pip3 install --user -r requirements.txt
-        pip3 uninstall --user -y project-generator
+        pip3 uninstall -y project-generator
         pip3 install --user git+https://github.com/mbrossard/project_generator.git@development
 
     - name: Install Embedded Arm Toolchain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Install dependencies
       run:  |
         sudo apt install ccache ninja-build
-        for i in ${{ runner.temp }}/arm-gcc/bin/* ; do ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
+        for i in ${{ runner.temp }}/arm-gcc/bin/* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
         ccache -M 1Ti
 
     - name: Compile
@@ -69,3 +69,10 @@ jobs:
     - name: Display results
       run:  |
         - (ls -lR firmware_*; ccache -s) | tee log.txt
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: firmware-package
+        path: |
+          firmware*/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,7 @@ jobs:
     - name: Upload test artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: firmware-package
+        name: firmware-dev-{{github.run_number}}
         path: |
-          firmware*/*.zip
+          firmware*/*
+          !firmware*/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,9 @@
 name: Build DAPLink
-
 on:
-  push:
-    branches: [ development ]
-
-  pull_request:
-    branches: [ development ]
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,15 @@ jobs:
       id:   cache-arm-gcc
       uses: actions/cache@v2
       env:
-        cache-name: cache-arm-gcc-9-2020-q2
+        cache-name: arm-gcc-9-2020-q2
       with:
         path: ${{ runner.temp }}/arm-gcc
-        key:  ${{ runner.os }}-build-${{ env.cache-name }}
-        restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
+        key:  ${{ runner.os }}-${{ env.cache-name }}
+        restore-keys: ${{ runner.os }}-${{ env.cache-name }}
 
     - name: Install Embedded Arm Toolchain
-      if:   steps.cache-arm-none-eabi-gcc.outputs.cache-hit != 'true'
-      uses: fiam/arm-none-eabi-gcc@v1.0.2
-      with:
-        release: 9-2020-q2
-        directory: ${{ runner.temp }}/arm-gcc
+      if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
+      run:  |
+        curl -O -S https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
+        mkdir -p ${{ runner.temp }}/arm-gcc
+        tar jvxf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,14 @@ jobs:
         key:  ${{ runner.os }}-${{ env.cache-name }}
         restore-keys: ${{ runner.os }}-${{ env.cache-name }}
 
+    - name: Cache CCache
+      id:   ccache
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: ${{ runner.os }}-ccache-${{ hashFiles('log.txt') }}
+        restore-keys: ${{ runner.os }}-ccache-
+
     - name: Cache Python modules
       uses: actions/cache@v2
       with:
@@ -38,15 +46,11 @@ jobs:
         pip3 install --user -r requirements.txt
         pip3 install --user git+https://github.com/mbrossard/project_generator.git@development
 
-    - name: Install dependencies
-      run:  |
-        sudo apt install ccache ninja
-
     - name: Install Embedded Arm Toolchain
       if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
       run:  |
-        curl -O -S https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
+        curl -O -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
         md5sum gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
+        echo Installing $gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux in {{ runner.temp }}/arm-gcc
         mkdir -p ${{ runner.temp }}/arm-gcc
         tar jvxf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Upload test artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: firmware-dev-{{github.run_number}}
+        name: firmware-dev-${{github.run_number}}
         path: |
           firmware*/*
           !firmware*/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build DAPLink
+
+on:
+  push:
+    branches: [ development ]
+
+  pull_request:
+    branches: [ development ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Cache Embedded Arm Toolchain
+      id:   cache-arm-gcc
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-arm-gcc-9-2020-q2
+      with:
+        path: ${{ runner.temp }}/arm-gcc
+        key:  ${{ runner.os }}-build-${{ env.cache-name }}
+        restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    - name: Install Embedded Arm Toolchain
+      if:   steps.cache-arm-none-eabi-gcc.outputs.cache-hit != 'true'
+      uses: fiam/arm-none-eabi-gcc@v1.0.2
+      with:
+        release: 9-2020-q2
+        directory: ${{ runner.temp }}/arm-gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,13 @@ jobs:
 
     - name: Install dependencies
       run:  |
-        sudo apt install ccache ninja-build
-        for i in ${{ runner.temp }}/arm-gcc/bin/* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
-        ccache -M 1Ti
+        sudo apt install -y ccache ninja-build
         export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH
+        for i in ${{ runner.temp }}/arm-gcc/bin/* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
+        ccache --set-config=cache_dir="$GITHUB_WORKSPACE"
+        ccache --set-config=cache_dir="$GITHUB_WORKSPACE/.ccache"
+        ccache --set-config=max_size=2Ti
+        ccache -z -s
         arm-none-eabi-gcc -v | tee log.txt
         (git status; git log -1 )>> log.txt
 
@@ -61,7 +64,7 @@ jobs:
       id:   ccache
       uses: actions/cache@v2
       with:
-        path: ~/.ccache
+        path: .ccache
         key: ${{ runner.os }}-ccache-${{ hashFiles('log.txt') }}
         restore-keys: ${{ runner.os }}-ccache-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,6 @@ jobs:
         key:  ${{ runner.os }}-${{ env.cache-name }}
         restore-keys: ${{ runner.os }}-${{ env.cache-name }}
 
-    - name: Cache CCache
-      id:   ccache
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{ runner.os }}-ccache-${{ hashFiles('log.txt') }}
-        restore-keys: ${{ runner.os }}-ccache-
-
     - name: Cache Python modules
       uses: actions/cache@v2
       with:
@@ -62,7 +54,16 @@ jobs:
         for i in ${{ runner.temp }}/arm-gcc/bin/* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
         ccache -M 1Ti
         export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH
-        arm-none-eabi-gcc -v
+        arm-none-eabi-gcc -v | tee log.txt
+        (git status; git log -1 )>> log.txt
+
+    - name: Cache CCache
+      id:   ccache
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: ${{ runner.os }}-ccache-${{ hashFiles('log.txt') }}
+        restore-keys: ${{ runner.os }}-ccache-
 
     - name: Compile
       run:  |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,15 +61,14 @@ jobs:
         sudo apt install ccache ninja-build
         for i in ${{ runner.temp }}/arm-gcc/bin/* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
         ccache -M 1Ti
+        export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH
+        arm-none-eabi-gcc -v
 
     - name: Compile
       run:  |
-        export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH
-        python tools/progen_compile.py --release --parallel
-
-    - name: Display results
-      run:  |
-        - (ls -lR firmware_*; ccache -s) | tee log.txt
+        export PATH="/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH"
+        python tools/progen_compile.py --release --parallel -v -v --ignore-failures
+        (ls -lR firmware_*; ccache -s; arm-none-eabi-gcc -v) | tee log.txt
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,18 @@ jobs:
         echo Installing $gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux in {{ runner.temp }}/arm-gcc
         mkdir -p ${{ runner.temp }}/arm-gcc
         tar jvxf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1
+
+    - name: Install dependencies
+      run:  |
+        sudo apt install ccache ninja-build
+        for i in ${{ runner.temp }}/arm-gcc/bin/* ; ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
+        ccache -M 1Ti
+
+    - name: Compile
+      run:  |
+        export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:$PATH
+        python tools/progen_compile.py
+
+    - name: Display results
+      run:  |
+        - (find projectfiles -name *.elf | xargs ls -l; ccache -s) | tee log.txt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: Build DAPLink
+name: Build DAPLink (Linux)
 on:
   workflow_dispatch:
     inputs:
@@ -42,7 +42,7 @@ jobs:
       run:  |
         curl -O -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
         md5sum gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
-        echo Installing $gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux in {{ runner.temp }}/arm-gcc
+        echo Installing gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux in ${{ runner.temp }}/arm-gcc
         mkdir -p ${{ runner.temp }}/arm-gcc
         tar jvxf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,8 +34,6 @@ jobs:
     - name: Install Python module
       run:  |
         pip3 install --user -r requirements.txt
-        pip3 uninstall -y project-generator
-        pip3 install --user git+https://github.com/mbrossard/project_generator.git@development
 
     - name: Install Embedded Arm Toolchain
       if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,6 @@ name: Build DAPLink (Linux)
 on:
   push:
     branches:
-      - development
       - compilers_experimental
   workflow_dispatch:
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,9 +1,10 @@
 name: Build DAPLink (Linux)
 on:
+  push:
+    branches:
+      - development
+      - compilers_experimental
   workflow_dispatch:
-    inputs:
-      version:
-        required: true
 
 jobs:
   build:
@@ -14,7 +15,7 @@ jobs:
       id:   cache-arm-gcc
       uses: actions/cache@v2
       env:
-        cache-name: arm-gcc-9-2020-q2
+        cache-name: arm-gcc-10-2020-q4
       with:
         path: ${{ runner.temp }}/arm-gcc
         key:  ${{ runner.os }}-${{ env.cache-name }}
@@ -38,11 +39,11 @@ jobs:
     - name: Install Embedded Arm Toolchain
       if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
       run:  |
-        curl -O -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
-        md5sum gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
-        echo Installing gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux in ${{ runner.temp }}/arm-gcc
+        curl -O -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+        md5sum gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+        echo Installing  in ${{ runner.temp }}/arm-gcc
         mkdir -p ${{ runner.temp }}/arm-gcc
-        tar jvxf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1
+        tar jvxf gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1
 
     - name: Install dependencies
       run:  |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Compile
       run:  |
-        python tools/progen_compile.py --release --parallel -v --ignore-
+        python tools/progen_compile.py -t cmake_gcc_arm -g mingw-make --release --parallel -v --ignore-failures
       shell: cmd
 
     - name: Upload test artifacts

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,63 @@
+name: Build DAPLink (Windows)
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+
+jobs:
+  build:
+    runs-on: windows-2019
+
+    steps:
+    - name: Cache Embedded Arm Toolchain
+      id:   cache-arm-gcc
+      uses: actions/cache@v2
+      env:
+        cache-name: arm-gcc-9-2020-q2
+      with:
+        path: ${{ runner.temp }}/arm-gcc
+        key:  ${{ runner.os }}-${{ env.cache-name }}
+        restore-keys: ${{ runner.os }}-${{ env.cache-name }}
+
+    - name: Cache Python modules
+      uses: actions/cache@v2
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Checkout source files
+      uses: actions/checkout@v2
+
+    - name: Install Embedded Arm Toolchain
+      if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
+      run:  |
+        (New-Object System.Net.WebClient).DownloadFile("https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-win32.zip","gcc-arm-none-eabi-9-2020-q2-update-win32.zip");
+        echo "Installing gcc-arm-none-eabi-9-2020-q2-update-win32 in ${{ runner.temp }}\arm-gcc"
+        Expand-Archive -Path .\gcc-arm-none-eabi-9-2020-q2-update-win32.zip -DestinationPath ${{ runner.temp }}\arm-gcc -PassThru;
+
+    - name: Check Embedded Arm Toolchain
+      run:  |
+        echo ${{ runner.temp }}\arm-gcc\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        ${{ runner.temp }}\arm-gcc\bin\arm-none-eabi-gcc -v
+
+    - name: Install Python module
+      run:  |
+        pip install -r requirements.txt
+        pip uninstall -y project-generator
+        pip install -U git+https://github.com/mbrossard/project_generator.git@development
+
+    - name: Compile
+      run:  |
+        python tools/progen_compile.py --release --parallel -v --ignore-
+      shell: cmd
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: firmware-dev-${{github.run_number}}
+        path: |
+          firmware*/*
+          !firmware*/*.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,8 +36,9 @@ jobs:
       if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
       run:  |
         (New-Object System.Net.WebClient).DownloadFile("https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-win32.zip","gcc-arm-none-eabi-10-2020-q4-major-win32.zip");
-        echo "Installing gcc-arm-none-eabi-10-2020-q4-major-win32 in ${{ runner.temp }}\arm-gcc"
-        Expand-Archive -Path .\gcc-arm-none-eabi-10-2020-q4-major-win32.zip -DestinationPath ${{ runner.temp }}\arm-gcc -PassThru;
+        echo "Installing gcc-arm-none-eabi-10-2020-q4-major-win32 in ${{ runner.temp }}\arm-gcc";
+        Expand-Archive -Path .\gcc-arm-none-eabi-10-2020-q4-major-win32.zip -DestinationPath ${{ runner.temp }} -PassThru;
+        Rename-Item ${{ runner.temp }}\gcc-arm-none-eabi-10-2020-q4-major ${{ runner.temp }}\arm-gcc;
 
     - name: Check Embedded Arm Toolchain
       run:  |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,8 +46,6 @@ jobs:
     - name: Install Python module
       run:  |
         pip install -r requirements.txt
-        pip uninstall -y project-generator
-        pip install -U git+https://github.com/mbrossard/project_generator.git@development
 
     - name: Compile
       run:  |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,5 @@
 name: Build DAPLink (Windows)
 on:
-  push:
-    branches:
-      - development
-      - compilers_experimental
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,9 +1,10 @@
 name: Build DAPLink (Windows)
 on:
+  push:
+    branches:
+      - development
+      - compilers_experimental
   workflow_dispatch:
-    inputs:
-      version:
-        required: true
 
 jobs:
   build:
@@ -14,7 +15,7 @@ jobs:
       id:   cache-arm-gcc
       uses: actions/cache@v2
       env:
-        cache-name: arm-gcc-9-2020-q2
+        cache-name: arm-gcc-10-2020-q4
       with:
         path: ${{ runner.temp }}/arm-gcc
         key:  ${{ runner.os }}-${{ env.cache-name }}
@@ -34,9 +35,9 @@ jobs:
     - name: Install Embedded Arm Toolchain
       if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
       run:  |
-        (New-Object System.Net.WebClient).DownloadFile("https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-win32.zip","gcc-arm-none-eabi-9-2020-q2-update-win32.zip");
-        echo "Installing gcc-arm-none-eabi-9-2020-q2-update-win32 in ${{ runner.temp }}\arm-gcc"
-        Expand-Archive -Path .\gcc-arm-none-eabi-9-2020-q2-update-win32.zip -DestinationPath ${{ runner.temp }}\arm-gcc -PassThru;
+        (New-Object System.Net.WebClient).DownloadFile("https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-win32.zip","gcc-arm-none-eabi-10-2020-q4-major-win32.zip");
+        echo "Installing gcc-arm-none-eabi-10-2020-q4-major-win32 in ${{ runner.temp }}\arm-gcc"
+        Expand-Archive -Path .\gcc-arm-none-eabi-10-2020-q4-major-win32.zip -DestinationPath ${{ runner.temp }}\arm-gcc -PassThru;
 
     - name: Check Embedded Arm Toolchain
       run:  |


### PR DESCRIPTION
GitHub Actions can be used on the `experimental_compilers` with GCC. Enabling Linux workflow on all pushes to the branch. Windows is on-demand because it's slower (in part because it does not support `ccache`) and most changes are not OS-dependent.