### PR TITLE
CMSIS-DAP: support for DAP_ID_PRODUCT_FW_VER

### DIFF
--- a/source/daplink/cmsis-dap/DAP.c
+++ b/source/daplink/cmsis-dap/DAP.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
- * Copyright 2019, Cypress Semiconductor Corporation 
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ * Copyright 2019, Cypress Semiconductor Corporation
  * or a subsidiary of Cypress Semiconductor Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -64,7 +64,7 @@
 volatile uint8_t    DAP_TransferAbort;  // Transfer Abort Flag
 
 
-// static const char DAP_FW_Ver [] = DAP_FW_VER;
+static const char DAP_FW_Ver [] = DAP_FW_VER;
 
 #if TARGET_DEVICE_FIXED
 static const char TargetDeviceVendor [] = TARGET_DEVICE_VENDOR;
@@ -89,15 +89,10 @@ static uint8_t DAP_Info(uint8_t id, uint8_t *info) {
     case DAP_ID_SER_NUM:
       length = DAP_GetSerNumString((char *)info);
       break;
-    case DAP_ID_FW_VER: {
-// --- begin DAPLink change ---
-      length = DAP_GetFirmwareVersionString((char *)info);
-// Original:
-//       memcpy(info, DAP_FW_Ver, sizeof(DAP_FW_Ver));
-//       length = (uint8_t)sizeof(DAP_FW_Ver);
-// --- end DAPLink change ---
+    case DAP_ID_CMSIS_DAP_VER:
+      length = (uint8_t)sizeof(DAP_FW_Ver);
+      memcpy(info, DAP_FW_Ver, length);
       break;
-    }
     case DAP_ID_DEVICE_VENDOR:
 #if TARGET_DEVICE_FIXED
       length = (uint8_t)sizeof(TargetDeviceVendor);
@@ -109,6 +104,9 @@ static uint8_t DAP_Info(uint8_t id, uint8_t *info) {
       length = (uint8_t)sizeof(TargetDeviceName);
       memcpy(info, TargetDeviceName, length);
 #endif
+      break;
+    case DAP_ID_PRODUCT_FW_VER:
+      length = DAP_ProductFirmwareVerString((char *)info);
       break;
     case DAP_ID_CAPABILITIES:
       info[0] = ((DAP_SWD  != 0)         ? (1U << 0) : 0U) |
@@ -1643,7 +1641,7 @@ uint32_t DAP_ProcessCommand(const uint8_t *request, uint8_t *response) {
 
   if ((*request >= ID_DAP_VendorExFirst) && (*request <= ID_DAP_VendorExLast)) {
     return DAP_ProcessVendorCommandEx(request, response);
-  }  
+  }
 
   *response++ = *request;
 

--- a/source/daplink/cmsis-dap/DAP.h
+++ b/source/daplink/cmsis-dap/DAP.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013-2019 ARM Limited. All rights reserved.
- * Copyright 2019, Cypress Semiconductor Corporation 
+ * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
+ * Copyright 2019, Cypress Semiconductor Corporation
  * or a subsidiary of Cypress Semiconductor Corporation.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -118,9 +118,11 @@
 #define DAP_ID_VENDOR                   1U
 #define DAP_ID_PRODUCT                  2U
 #define DAP_ID_SER_NUM                  3U
-#define DAP_ID_FW_VER                   4U
+#define DAP_ID_CMSIS_DAP_VER            4U
+#define DAP_ID_FW_VER                   4U      // Deprecated alias of DAP_ID_CMSIS_DAP_VER for backwards compatibility.
 #define DAP_ID_DEVICE_VENDOR            5U
 #define DAP_ID_DEVICE_NAME              6U
+#define DAP_ID_PRODUCT_FW_VER           7U
 #define DAP_ID_CAPABILITIES             0xF0U
 #define DAP_ID_TIMESTAMP_CLOCK          0xF1U
 #define DAP_ID_SWO_BUFFER_SIZE          0xFDU

--- a/source/daplink/cmsis-dap/dap_strings.h
+++ b/source/daplink/cmsis-dap/dap_strings.h
@@ -54,7 +54,7 @@ __STATIC_INLINE uint8_t DAP_GetSerNumString (char *str) {
 \param str Pointer to buffer to store the string.
 \return String length.
 */
-__STATIC_INLINE uint8_t DAP_GetFirmwareVersionString (char *str) {
+__STATIC_INLINE uint8_t DAP_ProductFirmwareVerString (char *str) {
     const char * data = info_get_version();
     uint8_t length = (uint8_t)strlen(data) + 1;
     memcpy(str, data, length);


### PR DESCRIPTION
This change is necessary to fix the version reported for DAP_ID_FW_VER (now DAP_ID_CMSIS_DAP_VER).

Reporting the DAPLink version via the new DAP_ID_PRODUCT_FW_VER.