### PR TITLE
MultiTech XDot - connect under reset

### DIFF
--- a/source/board/xDot-L151.c
+++ b/source/board/xDot-L151.c
@@ -21,12 +21,62 @@
 
 #include "target_family.h"
 #include "target_board.h"
+#define DBG_Addr     (0xe000edf0)
+#include "swd_host.h"
+#include "cmsis_os2.h"
+#include "debug_cm.h"
+
+static uint8_t xdot_set_state(target_state_t state)
+{
+    uint32_t val;
+    
+    if (state == RESET_PROGRAM) {
+        swd_init();
+        swd_set_target_reset(1);
+        osDelay(2);
+
+        if (!swd_init_debug()) {
+            return 0;
+        }
+
+        // Enable debug
+        if (!swd_write_word(DBG_HCSR, DBGKEY | C_HALT | C_DEBUGEN)) {
+            return 0;
+        }
+
+        // Enable halt on reset
+        if (!swd_write_word(DBG_EMCR, VC_CORERESET)) {
+            return 0;
+        }
+
+        // Deassert reset
+        swd_set_target_reset(0);
+        osDelay(2);
+
+        do {
+            if (!swd_read_word(DBG_HCSR, &val)) {
+                return 0;
+            }
+        } while ((val & S_HALT) == 0);
+
+        // Disable halt on reset
+        if (!swd_write_word(DBG_EMCR, 0)) {
+            return 0;
+        }
+    } else {
+        return swd_set_target_state_hw(state);
+    }
+
+    return 1;
+}
 
 const board_info_t g_board_info = {
     .info_version = kBoardInfoVersion,
     .board_id = "0350",
     .family_id = kStub_HWReset_FamilyID,
-    .daplink_url_name =       "XDOT    HTM",
-    .daplink_drive_name =       "XDOT       ",
+    .flags = kEnableUnderResetConnect,
+    .daplink_url_name = "XDOT    HTM",
+    .daplink_drive_name =  "XDOT       ",
     .target_cfg = &target_device,
+    .target_set_state = xdot_set_state
 };


### PR DESCRIPTION
Fixes issues connecting to a MultiTech xDot by holding the STM32L151CC in reset while initiating the SWD connection.  This is done with a custom `target_set_state` function in the xDot-L151 board definition.  Using the existing connect-under-reset option did not solve the connection issues and it was determined that the target must be held in reset prior to calling `swd_init_debug`.
