### PR TITLE
lpc11u35: fix invalid TDI and TDO pin ports

### DIFF
--- a/source/board/override_96b_nitrogen/IO_Config_Override.h
+++ b/source/board/override_96b_nitrogen/IO_Config_Override.h
@@ -92,14 +92,14 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
 #define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
 
 // TDI Pin                              PIO0_17
-#define PIN_TDI_PORT                    17
+#define PIN_TDI_PORT                    0
 #define PIN_TDI_BIT                     17
 #define PIN_TDI                         (1 << PIN_TDI_BIT)
 #define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17
 #define PIN_TDI_IOCON_INIT              (FUNC_0 | PULL_UP_ENABLED)
 
 // SWO/TDO Pin                          PIO0_9
-#define PIN_TDO_PORT                    9
+#define PIN_TDO_PORT                    0
 #define PIN_TDO_BIT                     9
 #define PIN_TDO                         (1 << PIN_TDO_BIT)
 #define PIN_TDO_IOCON                   LPC_IOCON->PIO0_9

--- a/source/board/override_lpc11u35_6LoWPAN_BorderRouter/IO_Config_Override.h
+++ b/source/board/override_lpc11u35_6LoWPAN_BorderRouter/IO_Config_Override.h
@@ -92,7 +92,7 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
 #define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
 
 // TDI Pin                              PIO0_17
-#define PIN_TDI_PORT                    17
+#define PIN_TDI_PORT                    0
 #define PIN_TDI_BIT                     17
 #define PIN_TDI                         (1 << PIN_TDI_BIT)
 #define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17

--- a/source/board/override_lpc11u35_reset/IO_Config_Override.h
+++ b/source/board/override_lpc11u35_reset/IO_Config_Override.h
@@ -92,14 +92,14 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
 #define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
 
 // TDI Pin                              PIO0_17
-#define PIN_TDI_PORT                    17
+#define PIN_TDI_PORT                    0
 #define PIN_TDI_BIT                     17
 #define PIN_TDI                         (1 << PIN_TDI_BIT)
 #define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17
 #define PIN_TDI_IOCON_INIT              (FUNC_0 | PULL_UP_ENABLED)
 
 // SWO/TDO Pin                          PIO0_9
-#define PIN_TDO_PORT                    9
+#define PIN_TDO_PORT                    0
 #define PIN_TDO_BIT                     9
 #define PIN_TDO                         (1 << PIN_TDO_BIT)
 #define PIN_TDO_IOCON                   LPC_IOCON->PIO0_9

--- a/source/board/override_mtb/IO_Config_Override.h
+++ b/source/board/override_mtb/IO_Config_Override.h
@@ -92,7 +92,7 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
 #define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
 
 // TDI Pin                              PIO0_17
-#define PIN_TDI_PORT                    17
+#define PIN_TDI_PORT                    0
 #define PIN_TDI_BIT                     17
 #define PIN_TDI                         (1 << PIN_TDI_BIT)
 #define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17

--- a/source/board/override_tiny/IO_Config_Override.h
+++ b/source/board/override_tiny/IO_Config_Override.h
@@ -92,14 +92,14 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
 #define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
 
 // TDI Pin                              PIO0_17
-#define PIN_TDI_PORT                    17
+#define PIN_TDI_PORT                    0
 #define PIN_TDI_BIT                     17
 #define PIN_TDI                         (1 << PIN_TDI_BIT)
 #define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17
 #define PIN_TDI_IOCON_INIT              (FUNC_0 | PULL_UP_ENABLED)
 
 // SWO/TDO Pin                          PIO0_9
-#define PIN_TDO_PORT                    9
+#define PIN_TDO_PORT                    0
 #define PIN_TDO_BIT                     9
 #define PIN_TDO                         (1 << PIN_TDO_BIT)
 #define PIN_TDO_IOCON                   LPC_IOCON->PIO0_9

--- a/source/board/override_vbluno51/IO_Config_Override.h
+++ b/source/board/override_vbluno51/IO_Config_Override.h
@@ -97,14 +97,14 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
 #define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
 
 // TDI Pin                              PIO0_17
-#define PIN_TDI_PORT                    17
+#define PIN_TDI_PORT                    0
 #define PIN_TDI_BIT                     17
 #define PIN_TDI                         (1 << PIN_TDI_BIT)
 #define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17
 #define PIN_TDI_IOCON_INIT              (FUNC_0 | PULL_UP_ENABLED)
 
 // SWO/TDO Pin                          PIO0_9
-#define PIN_TDO_PORT                    9
+#define PIN_TDO_PORT                    0
 #define PIN_TDO_BIT                     9
 #define PIN_TDO                         (1 << PIN_TDO_BIT)
 #define PIN_TDO_IOCON                   LPC_IOCON->PIO0_9

--- a/source/hic_hal/nxp/lpc11u35/IO_Config.h
+++ b/source/hic_hal/nxp/lpc11u35/IO_Config.h
@@ -102,14 +102,14 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_LPC11U35);
 #define PIN_SWDIO_TMS_IOCON_INIT        (FUNC_0 | PULL_UP_ENABLED)
 
 // TDI Pin                              PIO0_17
-#define PIN_TDI_PORT                    17
+#define PIN_TDI_PORT                    0
 #define PIN_TDI_BIT                     17
 #define PIN_TDI                         (1 << PIN_TDI_BIT)
 #define PIN_TDI_IOCON                   LPC_IOCON->PIO0_17
 #define PIN_TDI_IOCON_INIT              (FUNC_0 | PULL_UP_ENABLED)
 
 // SWO/TDO Pin                          PIO0_9
-#define PIN_TDO_PORT                    9
+#define PIN_TDO_PORT                    0
 #define PIN_TDO_BIT                     9
 #define PIN_TDO                         (1 << PIN_TDO_BIT)
 #define PIN_TDO_IOCON                   LPC_IOCON->PIO0_9


### PR DESCRIPTION
This issue was raised in #502

It seems the `blueninja` had this fix. `mtb_*` and `6LoWPAN_BorderRouter*` only had the fix for the TDO pin.