### PR TITLE
Changes to DETAILS.TXT (fix for #719)

### DIFF
--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -4,7 +4,7 @@
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2020, ARM Limited, All Rights Reserved
- * Copyright 2019, Cypress Semiconductor Corporation 
+ * Copyright 2019, Cypress Semiconductor Corporation
  * or a subsidiary of Cypress Semiconductor Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -497,6 +497,20 @@ static uint32_t update_html_file(uint8_t *data, uint32_t datasize)
     return expand_info(data, datasize);
 }
 
+#if defined(__CC_ARM)
+#define COMPILER_DESCRIPTION "armcc"
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+#define COMPILER_DESCRIPTION "armclang"
+#elif defined(__GNUC__)
+#define COMPILER_DESCRIPTION "gcc"
+#endif
+
+#if (GIT_LOCAL_MODS)
+#define LOCAL_MODS ", local mods"
+#else
+#define LOCAL_MODS ""
+#endif
+
 static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
 {
     uint32_t pos=0;
@@ -504,10 +518,13 @@ static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
 
     char *buf = (char *)data;
 
-    //Needed by expand_info strlen
+    // Needed by expand_info strlen
     memset(buf, 0, datasize);
 
     pos += util_write_string(buf + pos, "# DAPLink Firmware - see https://mbed.com/daplink\r\n");
+    // Build ID
+    pos += util_write_string(buf + pos, "Build ID: " GIT_DESCRIPTION \
+        " (" COMPILER_DESCRIPTION LOCAL_MODS ")\r\n");
     // Unique ID
     pos += util_write_string(buf + pos, "Unique ID: @U\r\n");
     // HIC ID
@@ -550,22 +567,6 @@ static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
         pos += util_write_string(buf + pos, "\r\n");
     }
 
-#if defined(__CC_ARM)
-    pos += util_write_string(buf + pos, "Compiler: armcc\r\n");
-#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    pos += util_write_string(buf + pos, "Compiler: armclang\r\n");
-#elif defined(__GNUC__)
-    pos += util_write_string(buf + pos, "Compiler: gcc\r\n");
-#endif
-
-    // GIT sha
-    pos += util_write_string(buf + pos, "Git SHA: ");
-    pos += util_write_string(buf + pos, GIT_COMMIT_SHA);
-    pos += util_write_string(buf + pos, "\r\n");
-    // Local modifications when making the build
-    pos += util_write_string(buf + pos, "Local Mods: ");
-    pos += util_write_uint32(buf + pos, GIT_LOCAL_MODS);
-    pos += util_write_string(buf + pos, "\r\n");
     // Supported USB endpoints
     pos += util_write_string(buf + pos, "USB Interfaces: ");
 #ifdef MSC_ENDPOINT
@@ -599,7 +600,7 @@ static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
     pos += util_write_uint32(buf + pos, remount_count);
     pos += util_write_string(buf + pos, "\r\n");
 
-    //Target URL
+    // Target URL
     pos += util_write_string(buf + pos, "URL: @R\r\n");
 
     return expand_info(data, datasize);

--- a/tools/pre_build_script.py
+++ b/tools/pre_build_script.py
@@ -48,6 +48,7 @@ VERSION_GIT_FILE_TEMPLATE = """
 #ifndef VERSION_GIT_H
 #define VERSION_GIT_H
 
+#define GIT_DESCRIPTION  \"%s\"
 #define GIT_COMMIT_SHA  \"%s\"
 #define GIT_LOCAL_MODS  %d
 
@@ -58,6 +59,15 @@ VERSION_GIT_FILE_TEMPLATE = """
 
 
 def generate_version_file(version_git_dir):
+
+    # Get the git description.
+    print("#> Getting git description")
+    try:
+        git_description = check_output("git describe HEAD", shell=True)
+        git_description = git_description.decode().strip()
+    except:
+        print("#> ERROR: Failed to get git description, do you have git.exe in your PATH environment variable?")
+        return 1
 
     output_file = os.path.join(os.path.normpath(version_git_dir),'version_git.h')
     print("#> Pre-build script start")
@@ -80,9 +90,8 @@ def generate_version_file(version_git_dir):
     else:
         git_has_changes = 0
 
-
     # Create the version file. Only overwrite an existing file if it changes.
-    version_text = VERSION_GIT_FILE_TEMPLATE % (git_sha, git_has_changes)
+    version_text = VERSION_GIT_FILE_TEMPLATE % (git_description, git_sha, git_has_changes)
     try:
         with open(output_file, 'r') as version_file:
             current_version_text = version_file.read()


### PR DESCRIPTION
As discussed in #719 some changes to `DETAILS.TXT` to keep it under 512 bytes. Using the output of `git describe HEAD` instead of simply short commit ID.

For `kl27z_microbit_if` this results in 483 bytes file:
```
# DAPLink Firmware - see https://mbed.com/daplink
Build ID: alpha5-14-gba49a0b8 (gcc)
Unique ID: 9903360258994e45001290120000005c000000009796990b
HIC ID: 9796990b
Auto Reset: 1
Automation allowed: 1
Overflow detection: 0
Page erasing: 0
Daplink Mode: Interface
Interface Version: 0256
Bootloader Version: 0255
USB Interfaces: MSD, CDC, HID, WebUSB
Bootloader CRC: 0x828c6069
Interface CRC: 0xd11fb543
Remount count: 0
URL: https://microbit.org/device/?id=9903&v=0256
```