### PR TITLE
LPC55xx: Fix USART0 to USB CDC ACM

### DIFF
--- a/source/hic_hal/nxp/lpc55xx/LPC55S69/drivers/fsl_usart_cmsis.c
+++ b/source/hic_hal/nxp/lpc55xx/LPC55S69/drivers/fsl_usart_cmsis.c
@@ -683,16 +683,12 @@ static int32_t USART_NonBlockingControl(uint32_t control, uint32_t arg, cmsis_us
     {
         /* Abort Send */
         case ARM_USART_ABORT_SEND:
-            usart->resource->base->FIFOINTENSET &= ~USART_FIFOINTENSET_TXLVL_MASK;
-            usart->handle->txDataSize = 0;
-            usart->handle->txState    = kUSART_TxIdle;
+            USART_TransferAbortSend(usart->resource->base, usart->handle);
             return ARM_DRIVER_OK;
 
         /* Abort receive */
         case ARM_USART_ABORT_RECEIVE:
-            usart->resource->base->FIFOINTENSET &= ~USART_FIFOINTENSET_RXLVL_MASK;
-            usart->handle->rxDataSize = 0U;
-            usart->handle->rxState    = kUSART_RxIdle;
+            USART_TransferAbortReceive(usart->resource->base, usart->handle);
             return ARM_DRIVER_OK;
 
         default:

--- a/source/hic_hal/nxp/lpc55xx/uart.c
+++ b/source/hic_hal/nxp/lpc55xx/uart.c
@@ -61,6 +61,7 @@ int32_t uart_initialize(void)
 {
     clear_buffers();
     Driver_USART0.Initialize(uart_handler);
+    Driver_USART0.PowerControl(ARM_POWER_FULL);
 
     return 1;
 }
@@ -68,6 +69,8 @@ int32_t uart_initialize(void)
 int32_t uart_uninitialize(void)
 {
     USART_INSTANCE.Control(ARM_USART_CONTROL_RX, 0);
+    USART_INSTANCE.Control(ARM_USART_ABORT_RECEIVE, 0U);
+    Driver_USART0.PowerControl(ARM_POWER_OFF);
     Driver_USART0.Uninitialize();
     clear_buffers();
 

--- a/source/hic_hal/nxp/lpc55xx/uart.c
+++ b/source/hic_hal/nxp/lpc55xx/uart.c
@@ -154,6 +154,11 @@ int32_t uart_set_configuration(UART_Configuration *config)
 
     NVIC_DisableIRQ(USART_IRQ);
     clear_buffers();
+
+    // If there was no Receive() call in progress aborting it is harmless.
+    USART_INSTANCE.Control(ARM_USART_CONTROL_RX, 0U);
+    USART_INSTANCE.Control(ARM_USART_ABORT_RECEIVE, 0U);
+
     uint32_t r = USART_INSTANCE.Control(control, config->Baudrate);
     if (r != ARM_DRIVER_OK) {
         return 0;


### PR DESCRIPTION
This series of patches fix various aspects of the LPC55xx USART CMSIS driver as used by the `uart.c` to expose the USB serial terminal. 