### PR TITLE
Support VFS file of arbitrary length

### DIFF
--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -339,7 +339,7 @@ uint32_t expand_string_in_region(uint8_t *buf, uint32_t size, uint32_t start, ui
 uint32_t string_field_in_region(uint8_t *buf, uint32_t size, uint32_t start, uint32_t pos, uint8_t *label, const uint8_t *value) {
     uint32_t l = util_write_string_in_region(buf, size, start, pos, label);
     l += util_write_in_region(buf, size, start, pos + l, ": ", 2);
-    l += util_write_string_in_region(buf, size, start, pos, value);
+    l += util_write_string_in_region(buf, size, start, pos + l, value);
     l += util_write_in_region(buf, size, start, pos + l, "\r\n", 2);
     return l;
 }

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -4,7 +4,7 @@
  *
  * DAPLink Interface Firmware
  * Copyright (c) 2009-2020, ARM Limited, All Rights Reserved
- * Copyright 2019, Cypress Semiconductor Corporation 
+ * Copyright 2019, Cypress Semiconductor Corporation
  * or a subsidiary of Cypress Semiconductor Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -497,6 +497,20 @@ static uint32_t update_html_file(uint8_t *data, uint32_t datasize)
     return expand_info(data, datasize);
 }
 
+#if defined(__CC_ARM)
+#define COMPILER_DESCRIPTION "armcc"
+#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+#define COMPILER_DESCRIPTION "armclang"
+#elif defined(__GNUC__)
+#define COMPILER_DESCRIPTION "gcc"
+#endif
+
+#if (GIT_LOCAL_MODS)
+#define LOCAL_MODS ", local mods"
+#else
+#define LOCAL_MODS ""
+#endif
+
 static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
 {
     uint32_t pos=0;
@@ -504,10 +518,13 @@ static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
 
     char *buf = (char *)data;
 
-    //Needed by expand_info strlen
+    // Needed by expand_info strlen
     memset(buf, 0, datasize);
 
     pos += util_write_string(buf + pos, "# DAPLink Firmware - see https://mbed.com/daplink\r\n");
+    // Build ID
+    pos += util_write_string(buf + pos, "Build ID: " GIT_DESCRIPTION \
+        " (" COMPILER_DESCRIPTION LOCAL_MODS ")\r\n");
     // Unique ID
     pos += util_write_string(buf + pos, "Unique ID: @U\r\n");
     // HIC ID
@@ -550,22 +567,6 @@ static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
         pos += util_write_string(buf + pos, "\r\n");
     }
 
-#if defined(__CC_ARM)
-    pos += util_write_string(buf + pos, "Compiler: armcc\r\n");
-#elif (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    pos += util_write_string(buf + pos, "Compiler: armclang\r\n");
-#elif defined(__GNUC__)
-    pos += util_write_string(buf + pos, "Compiler: gcc\r\n");
-#endif
-
-    // GIT sha
-    pos += util_write_string(buf + pos, "Git SHA: ");
-    pos += util_write_string(buf + pos, GIT_COMMIT_SHA);
-    pos += util_write_string(buf + pos, "\r\n");
-    // Local modifications when making the build
-    pos += util_write_string(buf + pos, "Local Mods: ");
-    pos += util_write_uint32(buf + pos, GIT_LOCAL_MODS);
-    pos += util_write_string(buf + pos, "\r\n");
     // Supported USB endpoints
     pos += util_write_string(buf + pos, "USB Interfaces: ");
 #ifdef MSC_ENDPOINT
@@ -599,7 +600,7 @@ static uint32_t update_details_txt_file(uint8_t *data, uint32_t datasize)
     pos += util_write_uint32(buf + pos, remount_count);
     pos += util_write_string(buf + pos, "\r\n");
 
-    //Target URL
+    // Target URL
     pos += util_write_string(buf + pos, "URL: @R\r\n");
 
     return expand_info(data, datasize);

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -527,10 +527,10 @@ static uint32_t update_details_txt_file(uint8_t *buf, uint32_t size, uint32_t st
 {
     uint32_t pos = 0;
 
-    pos += util_write_string_in_region(buf, size, start, pos, "# DAPLink Firmware - see https://mbed.com/daplink\r\n");
-    // Build ID
-    pos += util_write_string_in_region(buf, size, start, pos, "Build ID: " GIT_DESCRIPTION \
-        " (" COMPILER_DESCRIPTION LOCAL_MODS ")\r\n");
+    pos += util_write_string_in_region(buf, size, start, pos,
+        "# DAPLink Firmware - see https://mbed.com/daplink\r\n"
+        // Build ID
+        "Build ID: " GIT_DESCRIPTION " (" COMPILER_DESCRIPTION LOCAL_MODS ")\r\n");
     // Unique ID
     pos += expand_string_in_region(buf, size, start, pos, "Unique ID: @U\r\n");
     // HIC ID
@@ -567,22 +567,30 @@ static uint32_t update_details_txt_file(uint8_t *buf, uint32_t size, uint32_t st
 #endif
 #endif
 
-    // Supported USB endpoints
-    pos += util_write_string_in_region(buf, size, start, pos, "USB Interfaces: "
+    pos += util_write_string_in_region(buf, size, start, pos,
+        // Full commit hash
+        "Git SHA: " GIT_COMMIT_SHA "\r\n"
+        // Local modifications when making the build
+#if GIT_LOCAL_MODS
+        "Local Mods: 1\r\n"
+#else
+        "Local Mods: 0\r\n"
+#endif
+        // Supported USB endpoints
+        "USB Interfaces: "
 #ifdef MSC_ENDPOINT
-      "MSD"
+        "MSD"
 #endif
 #ifdef CDC_ENDPOINT
-      ", CDC"
+        ", CDC"
 #endif
 #ifdef HID_ENDPOINT
-      ", HID"
+        ", HID"
 #endif
 #if (WEBUSB_INTERFACE)
-      ", WebUSB"
+        ", WebUSB"
 #endif
-      "\r\n"
-    );
+        "\r\n");
 
 #if DAPLINK_ROM_BL_SIZE != 0
     // CRC of the bootloader (if there is one)

--- a/source/daplink/util.c
+++ b/source/daplink/util.c
@@ -111,9 +111,7 @@ uint32_t util_write_string(char *str, const char *data)
 }
 
 uint32_t util_write_string_in_region(uint8_t *buf, uint32_t size, uint32_t start, uint32_t pos, const uint8_t *input) {
-    uint32_t length = strlen(input);
-
-    return util_write_in_region(buf, size, start, pos, input, length);
+    return util_write_in_region(buf, size, start, pos, input, strlen(input));
 }
 
 uint32_t util_write_in_region(uint8_t *buf, uint32_t size, uint32_t start, uint32_t pos, const uint8_t *input, uint32_t length) {

--- a/source/daplink/util.c
+++ b/source/daplink/util.c
@@ -110,6 +110,35 @@ uint32_t util_write_string(char *str, const char *data)
     return pos;
 }
 
+uint32_t util_write_string_in_region(uint8_t *buf, uint32_t size, uint32_t start, uint32_t pos, const uint8_t *input) {
+    uint32_t length = strlen(input);
+
+    return util_write_in_region(buf, size, start, pos, input, length);
+}
+
+uint32_t util_write_in_region(uint8_t *buf, uint32_t size, uint32_t start, uint32_t pos, const uint8_t *input, uint32_t length) {
+    if (buf != NULL) {
+        // Check if there is something to copy
+        if (((pos + length) >= start) && (pos <= (start + size))) {
+            uint32_t i_off = 0;
+            uint32_t o_off = 0;
+            uint32_t l = length;
+            if (pos < start) {
+                i_off = start - pos;
+                l -= i_off;
+            } else {
+                o_off = pos - start;
+            }
+            if ((pos + length) > (start + size)) {
+                l -= (pos + length) - (start + size);
+            }
+            memcpy(buf + o_off, input + i_off, l);
+        }
+    }
+
+    return length;
+}
+
 void _util_assert(bool expression, const char *filename, uint16_t line)
 {
     bool assert_set;

--- a/source/daplink/util.h
+++ b/source/daplink/util.h
@@ -66,6 +66,11 @@ uint32_t util_write_uint32(char *str, uint32_t value);
 uint32_t util_write_uint32_zp(char *str, uint32_t value, uint16_t total_size);
 uint32_t util_write_string(char *str, const char *data);
 
+uint32_t util_write_in_region(uint8_t *buf, uint32_t size, uint32_t start,
+    uint32_t pos, const uint8_t *input, uint32_t length);
+uint32_t util_write_string_in_region(uint8_t *buf, uint32_t size, uint32_t start,
+    uint32_t pos, const uint8_t *input);
+
 __STATIC_INLINE uint32_t util_div_round_up(uint32_t dividen, uint32_t divisor)
 {
     return (dividen + divisor - 1) / divisor;

--- a/tools/pre_build_script.py
+++ b/tools/pre_build_script.py
@@ -48,6 +48,7 @@ VERSION_GIT_FILE_TEMPLATE = """
 #ifndef VERSION_GIT_H
 #define VERSION_GIT_H
 
+#define GIT_DESCRIPTION  \"%s\"
 #define GIT_COMMIT_SHA  \"%s\"
 #define GIT_LOCAL_MODS  %d
 
@@ -58,6 +59,15 @@ VERSION_GIT_FILE_TEMPLATE = """
 
 
 def generate_version_file(version_git_dir):
+
+    # Get the git description.
+    print("#> Getting git description")
+    try:
+        git_description = check_output("git describe HEAD", shell=True)
+        git_description = git_description.decode().strip()
+    except:
+        print("#> ERROR: Failed to get git description, do you have git.exe in your PATH environment variable?")
+        return 1
 
     output_file = os.path.join(os.path.normpath(version_git_dir),'version_git.h')
     print("#> Pre-build script start")
@@ -80,9 +90,8 @@ def generate_version_file(version_git_dir):
     else:
         git_has_changes = 0
 
-
     # Create the version file. Only overwrite an existing file if it changes.
-    version_text = VERSION_GIT_FILE_TEMPLATE % (git_sha, git_has_changes)
+    version_text = VERSION_GIT_FILE_TEMPLATE % (git_description, git_sha, git_has_changes)
     try:
         with open(output_file, 'r') as version_file:
             current_version_text = version_file.read()


### PR DESCRIPTION
Builds on #836. It reduces RAM usage by removing `VFS_SECTOR_SIZE`-sized `file_buffer`, but increases a little bit the  code size (~200 bytes on Cortex-M0). It uses a stack-allocated buffer (configurable, default: 128 bytes) for tag expansion.