### PR TITLE
LPC55xx: Improve UART TX performance.

### DIFF
--- a/source/daplink/circ_buf.c
+++ b/source/daplink/circ_buf.c
@@ -134,3 +134,47 @@ uint32_t circ_buf_write(circ_buf_t *circ_buf, const uint8_t *data, uint32_t size
 
     return cnt;
 }
+
+const uint8_t* circ_buf_peek(circ_buf_t *circ_buf, uint32_t* size)
+{
+    uint32_t cnt;
+    uint8_t* ret;
+    cortex_int_state_t state;
+
+    state = cortex_int_get_and_disable();
+
+    if (circ_buf->tail >= circ_buf->head) {
+        cnt = circ_buf->tail - circ_buf->head;
+    } else {
+        // We can't peek all the bytes in the circular buffer in this case.
+        cnt = circ_buf->size - circ_buf->head;
+    }
+    ret = circ_buf->buf + circ_buf->head;
+
+    cortex_int_restore(state);
+
+    if (size) {
+        *size = cnt;
+    }
+    return ret;
+}
+
+void circ_buf_pop_n(circ_buf_t *circ_buf, uint32_t n)
+{
+    cortex_int_state_t state;
+
+    state = cortex_int_get_and_disable();
+
+    if (circ_buf->tail >= circ_buf->head) {
+        util_assert(circ_buf->tail - circ_buf->head <= n);
+        circ_buf->head += n;
+    } else {
+        util_assert(circ_buf->tail + circ_buf->size - circ_buf->head <= n);
+        circ_buf->head += n;
+        if (circ_buf->head >= circ_buf->size) {
+            circ_buf->head -= circ_buf->size;
+        }
+    }
+
+    cortex_int_restore(state);
+}

--- a/source/daplink/circ_buf.h
+++ b/source/daplink/circ_buf.h
@@ -57,6 +57,15 @@ uint32_t circ_buf_read(circ_buf_t *circ_buf, uint8_t *data, uint32_t size);
 // Attempt to write size bytes to the buffer. Return the number of bytes written
 uint32_t circ_buf_write(circ_buf_t *circ_buf, const uint8_t *data, uint32_t size);
 
+// Returns a pointer to the next byte on the circular buffer and stores in the
+// value pointed by "size" the number of bytes available in that region, which
+// may be less than the total number of bytes in the circular buffer.
+const uint8_t* circ_buf_peek(circ_buf_t *circ_buf, uint32_t* size);
+
+// Remove n bytes from the front of the circular buffer. The values are
+// discarded.
+void circ_buf_pop_n(circ_buf_t *circ_buf, uint32_t n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/source/hic_hal/nxp/lpc55xx/uart.c
+++ b/source/hic_hal/nxp/lpc55xx/uart.c
@@ -50,7 +50,6 @@ struct {
     volatile uint32_t tx_size;
 
     uint8_t rx;
-    uint8_t tx;
 } cb_buf;
 
 void uart_handler(uint32_t event);
@@ -189,23 +188,41 @@ int32_t uart_write_free(void)
     return circ_buf_count_free(&write_buffer);
 }
 
+// Start a new TX transfer if there are bytes pending to be transferred on the
+// write_buffer buffer. The transferred bytes are not removed from the circular
+// by this function, only the event handler will remove them once the transfer
+// is done.
+static void uart_start_tx_transfer() {
+    uint32_t tx_size = 0;
+    const uint8_t* buf = circ_buf_peek(&write_buffer, &tx_size);
+    if (tx_size > BUFFER_SIZE / 4) {
+        // The bytes being transferred remain on the circular buffer memory
+        // until the transfer is done. Limiting the UART transfer size
+        // allows the uart_handler to clear those bytes earlier.
+        tx_size = BUFFER_SIZE / 4;
+    }
+    cb_buf.tx_size = tx_size;
+    if (tx_size) {
+        USART_INSTANCE.Send(buf, tx_size);
+    }
+}
+
 int32_t uart_write_data(uint8_t *data, uint16_t size)
 {
     if (size == 0) {
         return 0;
     }
 
-    // Disable interrupts to prevent the uart_handler from modifying the
-    // circular buffer at the same time.
-    NVIC_DisableIRQ(USART_IRQ);
     uint32_t cnt = circ_buf_write(&write_buffer, data, size);
-    if (cb_buf.tx_size == 0 && circ_buf_count_used(&write_buffer) > 0) {
-        // There's no pending transfer, so we need to start the process.
-        cb_buf.tx = circ_buf_pop(&write_buffer);
-        USART_INSTANCE.Send(&(cb_buf.tx), 1);
-        cb_buf.tx_size = 1;
+    if (cb_buf.tx_size == 0) {
+        // There's no pending transfer and the value of cb_buf.tx_size will not
+        // change to non-zero by the event handler once it is zero. Note that it
+        // is entirely possible that we transferred all the bytes we added to
+        // the circular buffer in this function by the time we are in this
+        // branch, in that case uart_start_tx_transfer() would not schedule any
+        // transfer.
+        uart_start_tx_transfer();
     }
-    NVIC_EnableIRQ(USART_IRQ);
 
     return cnt;
 }
@@ -229,14 +246,8 @@ void uart_handler(uint32_t event) {
     }
 
     if (event & ARM_USART_EVENT_SEND_COMPLETE) {
-        if (circ_buf_count_used(&write_buffer) > 0) {
-            cb_buf.tx = circ_buf_pop(&write_buffer);
-            USART_INSTANCE.Send(&(cb_buf.tx), 1);
-        } else {
-            // Signals that next call to uart_write_data() should start a
-            // transfer.
-            cb_buf.tx_size = 0;
-        }
+        circ_buf_pop_n(&write_buffer, cb_buf.tx_size);
+        uart_start_tx_transfer();
     }
 }
 


### PR DESCRIPTION
Without this patch, transmitting at 921600 baudrate with 8n1 mode yields
to about 49.8KiB/s instead of the theoretical limit of 90 KiB/s. The
reason for this is because between the rising edge of the last data bit
(start of the STOP bit) and the falling edge before the START bit of the
next transfer we observe about 9.7us gap while the minimum is just the
length of a single STOP bit (about 1.1us). This gap is attributed to the
CPU time running the event handler (uart_handler) and scheduling a new
transfer. The performance was measured using a USB-to-UART probe running
with: `picocom -b 921600 /dev/ttyUSB0 | pv >/dev/null` and also looking
at the TX signal on the oscilloscope.

This commit creates two new functions in the circular buffer module that
let you peek into the internal buffer (avoiding a memcpy) and more
importantly allowing to return larger buffers to be passed to the UART
driver in a single Send() call. The UART module in the chip already has
a small FIFO that would allow the non-blocking transfer to enqueue the
buffer with 0 delay between consecutive bytes of the same transfer.
Given the 512 byte circular buffer size and the maximum 128 byte
transfer size this means that only one every 128 bytes would have a
~9us bigger gap with the previous one than needed. At a baudrate of
921600, 128 bytes take 1389 us to transmit so a 9 us delay is about a
1% performance degradation.

After this patch the effective TX bandwidth goes up 89.4 KiB/s, just shy
of the theoretical maximum of 90 KiB/s and consistent with the expected
performance.