### PR TITLE
Fix for micro:bit universal hex support (fixes #847)

### DIFF
--- a/source/daplink/drag-n-drop/intelhex.c
+++ b/source/daplink/drag-n-drop/intelhex.c
@@ -82,7 +82,7 @@ static uint8_t validate_checksum(hex_line_t *record)
     return (result == 0);
 }
 
-static hex_line_t line = {0}, shadow_line = {0};
+static hex_line_t line = {0};
 static uint32_t next_address_to_write = 0;
 static uint8_t low_nibble = 0, idx = 0, record_processed = 0, load_unaligned_record = 0;
 static uint16_t binary_version = 0;
@@ -92,7 +92,6 @@ uint16_t board_id_hex_min __WEAK;
 void reset_hex_parser(void)
 {
     memset(line.buf, 0, sizeof(hex_line_t));
-    memset(shadow_line.buf, 0, sizeof(hex_line_t));
     next_address_to_write = 0;
     low_nibble = 0;
     idx = 0;
@@ -157,11 +156,9 @@ hexfile_parse_status_t parse_hex_blob(const uint8_t *hex_blob, const uint32_t he
                                     case CUSTOM_METADATA_RECORD:
                                         binary_version = (uint16_t) line.data[0] << 8 | line.data[1];
                                         break;
+
                                     case DATA_RECORD:
                                     case CUSTOM_DATA_RECORD:
-                                        // keeping a record of the last hex record
-                                        memcpy(shadow_line.buf, line.buf, sizeof(hex_line_t));
-
                                         if (binary_version == 0 || (binary_version >= board_id_hex_min && binary_version <= board_id_hex)){
                                             // Only save data from the correct binary
                                             // verify this is a continous block of memory or need to exit and dump
@@ -169,6 +166,9 @@ hexfile_parse_status_t parse_hex_blob(const uint8_t *hex_blob, const uint32_t he
                                                 load_unaligned_record = 1;
                                                 status = HEX_PARSE_UNALIGNED;
                                                 goto hex_parser_exit;
+                                            } else {
+                                                // This should be superfluous but it is necessary for GCC
+                                                load_unaligned_record = 0;
                                             }
 
                                             // move from line buffer back to input buffer
@@ -177,10 +177,6 @@ hexfile_parse_status_t parse_hex_blob(const uint8_t *hex_blob, const uint32_t he
                                             *bin_buf_cnt = (uint32_t)(*bin_buf_cnt) + line.byte_count;
                                             // Save next address to write
                                             next_address_to_write = ((next_address_to_write & 0xffff0000) | line.address) + line.byte_count;
-                                        }
-                                        else {
-                                          status = HEX_PARSE_OK;
-                                          goto hex_parser_exit;
                                         }
                                         break;
 


### PR DESCRIPTION
- The extraneous store for load_unaligned_record seems to be a compiler issue.
- The exit with HEX_PARSE_OK in the else clause seems very wrong.
  If the version does not match one should simply continue to the next line and
  not mark the whole buffer as processed.
- The shadow_line content was never used only ever written to.