### PR TITLE
Fix UART regression with armcc on Max32625

### DIFF
--- a/records/hic_hal/k20dx.yaml
+++ b/records/hic_hal/k20dx.yaml
@@ -33,6 +33,11 @@ tool_specific:
             hic_hal:
                 - source/hic_hal/freescale/k20dx/armcc
     armcc:
+        misc:
+            asm_flags:
+                - --no_unaligned_access
+            c_flags:
+                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/freescale/k20dx/armcc
@@ -40,6 +45,10 @@ tool_specific:
         misc:
             common_flags:
                 - -mfpu=none
+            asm_flags:
+                - --no_unaligned_access
+            c_flags:
+                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/freescale/k20dx/armcc

--- a/records/hic_hal/k20dx.yaml
+++ b/records/hic_hal/k20dx.yaml
@@ -45,10 +45,6 @@ tool_specific:
         misc:
             common_flags:
                 - -mfpu=none
-            asm_flags:
-                - --no_unaligned_access
-            c_flags:
-                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/freescale/k20dx/armcc

--- a/records/hic_hal/k26f.yaml
+++ b/records/hic_hal/k26f.yaml
@@ -49,11 +49,6 @@ tool_specific:
             hic_hal:
                 - source/hic_hal/freescale/k26f/armcc
     armclang:
-        misc:
-            asm_flags:
-                - --no_unaligned_access
-            c_flags:
-                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/freescale/k26f/armcc

--- a/records/hic_hal/k26f.yaml
+++ b/records/hic_hal/k26f.yaml
@@ -40,12 +40,20 @@ tool_specific:
                 - source/hic_hal/freescale/k26f/armcc
     armcc:
         misc:
+            asm_flags:
+                - --no_unaligned_access
             c_flags:
+                - --no_unaligned_access
                 - --diag_suppress=66 # disable warning about enums not fitting in signed 32-bit
         sources:
             hic_hal:
                 - source/hic_hal/freescale/k26f/armcc
     armclang:
+        misc:
+            asm_flags:
+                - --no_unaligned_access
+            c_flags:
+                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/freescale/k26f/armcc

--- a/records/hic_hal/m48ssidae.yaml
+++ b/records/hic_hal/m48ssidae.yaml
@@ -37,11 +37,6 @@ tool_specific:
             hic_hal:
                 - source/hic_hal/nuvoton/m48ssidae/armcc
     armclang:
-        misc:
-            asm_flags:
-                - --no_unaligned_access
-            c_flags:
-                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/nuvoton/m48ssidae/armcc

--- a/records/hic_hal/m48ssidae.yaml
+++ b/records/hic_hal/m48ssidae.yaml
@@ -28,10 +28,20 @@ tool_specific:
             hic_hal:
                 - source/hic_hal/nuvoton/m48ssidae/armcc
     armcc:
+        misc:
+            asm_flags:
+                - --no_unaligned_access
+            c_flags:
+                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/nuvoton/m48ssidae/armcc
     armclang:
+        misc:
+            asm_flags:
+                - --no_unaligned_access
+            c_flags:
+                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/nuvoton/m48ssidae/armcc

--- a/records/hic_hal/stm32f103xb.yaml
+++ b/records/hic_hal/stm32f103xb.yaml
@@ -40,11 +40,6 @@ tool_specific:
             hic_hal:
                 - source/hic_hal/stm32/stm32f103xb/armcc
     armclang:
-        misc:
-            asm_flags:
-                - --no_unaligned_access
-            c_flags:
-                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/stm32/stm32f103xb/armcc

--- a/records/hic_hal/stm32f103xb.yaml
+++ b/records/hic_hal/stm32f103xb.yaml
@@ -31,10 +31,20 @@ tool_specific:
             hic_hal:
                 - source/hic_hal/stm32/stm32f103xb/armcc
     armcc:
+        misc:
+            asm_flags:
+                - --no_unaligned_access
+            c_flags:
+                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/stm32/stm32f103xb/armcc
     armclang:
+        misc:
+            asm_flags:
+                - --no_unaligned_access
+            c_flags:
+                - --no_unaligned_access
         sources:
             hic_hal:
                 - source/hic_hal/stm32/stm32f103xb/armcc

--- a/records/tools/armcc.yaml
+++ b/records/tools/armcc.yaml
@@ -9,7 +9,6 @@ tool_specific:
         misc:
             asm_flags:
                 - -g
-                - --no_unaligned_access
             c_flags:
                 - -O2
                 - -Ospace
@@ -19,7 +18,6 @@ tool_specific:
                 - --split_sections
                 - --interleave
                 - -g
-                - --no_unaligned_access
             ld_flags:
                 - --bestdebug
                 - --summary_stderr

--- a/source/hic_hal/maxim/max32620/system_max32620.c
+++ b/source/hic_hal/maxim/max32620/system_max32620.c
@@ -291,6 +291,20 @@ __weak void SystemInit(void)
     /* Perform an initial trim of the internal ring oscillator */
     CLKMAN_TrimRO();
 
+#if !defined (__CC_ARM) // Prevent Keil tools from calling these functions until post scatter load
     SystemCoreClockUpdate();
     Board_Init();
+#endif /* ! __CC_ARM */
 }
+
+#if defined ( __CC_ARM )
+extern void $Super$$main(void);
+// This will be executed after the RAM initialization
+void $Sub$$main(void)
+{
+    SystemCoreClockUpdate();
+    Board_Init();
+    // Call to main function
+    $Super$$main();
+}
+#endif

--- a/source/hic_hal/maxim/max32620/uart.c
+++ b/source/hic_hal/maxim/max32620/uart.c
@@ -135,7 +135,7 @@ int32_t uart_reset(void)
 /******************************************************************************/
 int32_t uart_set_configuration(UART_Configuration *config)
 {
-    uint32_t ctrl;
+    uint32_t ctrl = 0;
 
     // Get current configuration; clearing parameters that may be configured here
     ctrl = CdcAcmUart->ctrl & ~(MXC_F_UART_CTRL_PARITY |
@@ -183,7 +183,7 @@ int32_t uart_set_configuration(UART_Configuration *config)
 /******************************************************************************/
 int32_t uart_get_configuration(UART_Configuration *config)
 {
-    uint32_t ctrl;
+    uint32_t ctrl = 0;
 
     // Capture current configuration
     ctrl = CdcAcmUart->ctrl;

--- a/source/hic_hal/maxim/max32625/system_max32625.c
+++ b/source/hic_hal/maxim/max32625/system_max32625.c
@@ -284,6 +284,20 @@ __weak void SystemInit(void)
     /* Perform an initial trim of the internal ring oscillator */
     CLKMAN_TrimRO();
 
+#if !defined (__CC_ARM) // Prevent Keil tools from calling these functions until post scatter load
     SystemCoreClockUpdate();
     Board_Init();
+#endif /* ! __CC_ARM */
 }
+
+#if defined ( __CC_ARM )
+extern void $Super$$main(void);
+// This will be executed after the RAM initialization
+void $Sub$$main(void)
+{
+    SystemCoreClockUpdate();
+    Board_Init();
+    // Call to main function
+    $Super$$main();
+}
+#endif

--- a/source/hic_hal/maxim/max32625/uart.c
+++ b/source/hic_hal/maxim/max32625/uart.c
@@ -237,7 +237,7 @@ int32_t uart_reset(void)
 /******************************************************************************/
 int32_t uart_set_configuration(UART_Configuration *config)
 {
-    uint32_t ctrl;
+    uint32_t ctrl = 0;
 
     // Disable UART, clear FIFOs and configuration
     CdcAcmUart->ctrl = 0;
@@ -286,7 +286,7 @@ int32_t uart_set_configuration(UART_Configuration *config)
 /******************************************************************************/
 int32_t uart_get_configuration(UART_Configuration *config)
 {
-    uint32_t ctrl;
+    uint32_t ctrl = 0;
 
     // Capture current configuration
     ctrl = CdcAcmUart->ctrl;


### PR DESCRIPTION
We had moved the `--no_unaligned_access` flag to `record/tools/armcc.yaml`. It causes some issues with max32625 HIC.
