### PR TITLE
microbit specific: Serial and I2C fixes for Microbit V2

### DIFF
--- a/source/board/microbitv2/i2c_commands.h
+++ b/source/board/microbitv2/i2c_commands.h
@@ -77,7 +77,8 @@ typedef enum errorCode_tag {
     gErrorWrongPropertySize_c   = 0x35,
     gErrorReadDisallowed_c      = 0x36,
     gErrorWriteDisallowed_c     = 0x37,
-    gErrorWriteFail_c           = 0x38
+    gErrorWriteFail_c           = 0x38,
+    gErrorBusy_c                = 0x39
 } errorCode_t;
 
 typedef __PACKED_STRUCT readReqCmd_tag {
@@ -123,6 +124,8 @@ typedef __PACKED_STRUCT flashConfig_tag {
     vfs_filename_t  fileName;
     uint32_t        fileSize;
     bool            fileVisible;
+    uint32_t        fileEncWindowStart;
+    uint32_t        fileEncWindowEnd;
 } flashConfig_t;
 
 /*! Flash interface command type */
@@ -135,6 +138,7 @@ typedef enum flashCmdId_tag {
     gFlashStorageSize_c     = 0x06,
     gFlashSectorSize_c      = 0x07,
     gFlashRemountMSD_c      = 0x08,
+    gFlashCfgEncWindow_c    = 0x09,
     gFlashDataRead_c        = 0x0A,
     gFlashDataWrite_c       = 0x0B,
     gFlashDataErase_c       = 0x0C,

--- a/source/hic_hal/freescale/kl27z/uart.c
+++ b/source/hic_hal/freescale/kl27z/uart.c
@@ -180,7 +180,7 @@ int32_t uart_set_configuration(UART_Configuration *config)
     // Enable UART interrupt
     NVIC_ClearPendingIRQ(UART_RX_TX_IRQn);
     NVIC_EnableIRQ(UART_RX_TX_IRQn);
-    UART->CTRL |= LPUART_CTRL_RIE_MASK;
+    UART->CTRL |= LPUART_CTRL_RIE_MASK | LPUART_CTRL_ORIE_MASK;
     return 1;
 }
 


### PR DESCRIPTION
-Enabled UART HW overrun interrupt
-Optimized time spent in I2C IRQ handler by moving buffer clearing outside
-Add I2C busy singaling mechanism
-Add I2C ASCII encoding window command feature