### PR TITLE
tools: add exit error codes when a project name is invalid or git throws errors

### DIFF
--- a/tools/mbedcli_compile.py
+++ b/tools/mbedcli_compile.py
@@ -77,7 +77,9 @@ def main():
         print("Error - this script must be run from the tools directory")
         exit(-1)
     version_git_dir = os.path.join(daplink_dir, "source", "daplink")
-    generate_version_file(version_git_dir)
+    error = generate_version_file(version_git_dir)
+    if error:
+        exit(-1)
     if not args.projects == []: 
         for project in args.projects:
             print("Compiling %s" % project)

--- a/tools/progen_compile.py
+++ b/tools/progen_compile.py
@@ -107,7 +107,9 @@ cores = get_core_count() if args.parallel else 1
 projects = args.projects if len(args.projects) > 0 else project_list
 generator = generate.Generator(PROJECTS_YAML)
 for p_name in projects:
+    p_valid = False
     for project in generator.generate(p_name):
+        p_valid = True
         failed = False
         if hasattr(project, 'workspace_name') and (project.workspace_name is not None):
             logger.info("Generating %s for %s in workspace %s", toolchain, project.name, project.workspace_name)
@@ -126,6 +128,8 @@ for p_name in projects:
                 failed = True
         if failed and not args.ignore_failures:
             exit(-1)
+    if not p_valid:
+        exit(-1)
 
 # Generate images with boardid / familyid for supported configurations
 if args.release or args.supported:

--- a/tools/progen_compile.py
+++ b/tools/progen_compile.py
@@ -100,7 +100,9 @@ if args.release:
     if len(args.projects) > 0:
         logger.warning("A release can should only be done on all packages")
     version_git_dir = os.path.join(daplink_dir, "source", "daplink")
-    generate_version_file(version_git_dir)
+    error = generate_version_file(version_git_dir)
+    if error:
+        exit(-1)
 
 # Build the project(s)
 cores = get_core_count() if args.parallel else 1


### PR DESCRIPTION
- Add error exit code when project name provided is invalid.
    -  If project_generator doesn't find the project you get an empty generator, it logs something like this, and progen_compile.py exits 0:
      `2021-12-08 18:01:30,260                 root ERROR      You specified an invalid project name.`
- Check error code from generate_version_file().