### PR TITLE
Fix HID interface of LPC55xx HIC

### DIFF
--- a/source/hic_hal/nxp/lpc55xx/usbd_LPC55xx.c
+++ b/source/hic_hal/nxp/lpc55xx/usbd_LPC55xx.c
@@ -628,7 +628,8 @@ uint32_t USBD_ReadEP(uint32_t EPNum, uint8_t *pData, uint32_t size)
 
         memcpy(pData, dataptr, cnt);
 
-        *ptr = N_BYTES(EPBufInfo[EP_OUT_IDX(EPNum)].buf_len) |
+        *ptr = (*ptr & (EP_TYPE | EP_RF_TV)) |
+               N_BYTES(EPBufInfo[EP_OUT_IDX(EPNum)].buf_len) |
                BUF_ADDR(EPBufInfo[EP_OUT_IDX(EPNum)].buf_ptr) |
                EP_BUF_ACTIVE;
 


### PR DESCRIPTION
Fixes DAPv1 compatibility issue of lpc55s69_if mentioned in https://github.com/ARMmbed/DAPLink/issues/915 .
This also makes it compatible with now old openocd-0.10.0 .