### PR TITLE
microbit: Set CDC ACM default baud rate for micro:bit v1 and v2.0.

### DIFF
--- a/records/board/microbit.yaml
+++ b/records/board/microbit.yaml
@@ -4,6 +4,7 @@ common:
         - CDC_LED_DEF=GPIO_LED_ON
         - MSC_LED_DEF=GPIO_LED_ON
         - USB_PROD_STR="BBC micro:bit CMSIS-DAP"
+        - CDC_ACM_DEFAULT_BAUDRATE=115200
     sources:
         board:
             - source/board/microbit.c

--- a/records/board/microbitv2.yaml
+++ b/records/board/microbitv2.yaml
@@ -8,6 +8,7 @@ common:
         - DELAY_FAST_CYCLES=2U          # Fast delay needed to reach 8MHz SWD clock speed
         - DAP_DEFAULT_SWJ_CLOCK=8000000
         - BOARD_USB_BMAXPOWER=0x96
+        - CDC_ACM_DEFAULT_BAUDRATE=115200
     includes:
         - source/board/microbitv2/
         - source/board/microbitv2/kl27z/

--- a/records/board/microbitv2.yaml
+++ b/records/board/microbitv2.yaml
@@ -8,7 +8,6 @@ common:
         - DELAY_FAST_CYCLES=2U          # Fast delay needed to reach 8MHz SWD clock speed
         - DAP_DEFAULT_SWJ_CLOCK=8000000
         - BOARD_USB_BMAXPOWER=0x96
-        - BOARD_EXTRA_BUFFER=100
     includes:
         - source/board/microbitv2/
         - source/board/microbitv2/kl27z/

--- a/records/board/microbitv2_nrf52820.yaml
+++ b/records/board/microbitv2_nrf52820.yaml
@@ -6,7 +6,6 @@ common:
         - USB_PROD_STR="BBC micro:bit CMSIS-DAP"
         # - DELAY_FAST_CYCLES=2U          # Fast delay needed to reach 8MHz SWD clock speed
         # - DAP_DEFAULT_SWJ_CLOCK=8000000
-        - BOARD_EXTRA_BUFFER=100
         - CDC_ACM_DEFAULT_BAUDRATE=115200
     includes:
         - source/board/microbitv2/

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -45,11 +45,6 @@
 //! device.  This is to accomodate for hex file programming.
 #define VFS_DISK_SIZE (MB(64))
 
-// Additional buffer space to display more than 512 bytes in DETAILS.TXT
-#if !defined(BOARD_EXTRA_BUFFER)
-#define BOARD_EXTRA_BUFFER 0
-#endif
-
 //! @brief Constants for magic action or config files.
 //!
 //! The "magic files" are files with a special name that if created on the USB MSC volume, will


### PR DESCRIPTION
And remove BOARD_EXTRA_BUFFER vestiges that were not used.