### PR TITLE
A few fixes for LPC55xx HIC

### DIFF
--- a/docs/hic/README.md
+++ b/docs/hic/README.md
@@ -8,7 +8,7 @@
 | [kl27z](kl27z.md)             |  M0+ |  48 Mhz |  32 KB | 128 KB |  FS |
 | [lpc11u35](lpc11u35.md)       |  M0  |  48 Mhz |  12 KB |  64 KB |  FS |
 | [lpc4322](lpc4322.md)         |  M4  | 120 MHz | 256 KB | 256 KB |  HS |
-| [lpc55xx](lpc55xx.md)         |  M33 | 150 MHz | 272 KB | 320 KB |  HS |
+| [lpc55xx](lpc55xx.md)         |  M33 |  96 MHz | 272 KB | 320 KB |  HS |
 | [max32625](max32625.md)       |  M4  |  96 MHz | 160 KB | 512 KB |  FS |
 | [nrf52820](nrf52820.md)       |  M4  |  64 MHz |  32 KB | 256 KB |  FS |
 | [sam3u2c](sam3u2c.md)         |  M3  |  96 MHz |  32 KB | 128 KB |  HS |

--- a/docs/hic/lpc55xx.md
+++ b/docs/hic/lpc55xx.md
@@ -1,7 +1,7 @@
 # lpc55xx HIC
 
 Based on LPC55S69JBD64 chip ([Data Sheet](https://www.nxp.com/docs/en/nxp/data-sheets/LPC55S6x_DS.pdf)):
-- Cortex-M33 150 Mhz (cores)
+- Cortex-M33 96 MHz (2 cores up to 150 Mhz)
 - 640 KB Flash
 - 320 KB RAM
 - High-speed USB 2.0 host/device controller: 8 bi-directional endpoints including EP0 (*)

--- a/projects.yaml
+++ b/projects.yaml
@@ -590,3 +590,11 @@ projects:
         - *module_if
         - *module_hic_stm32f103xb
         - records/board/ublox_evk_odin_w2.yaml
+
+
+    # Test projects
+    lpc55s69_nrf52840dk_test_if:
+        - *module_if
+        - *module_hic_lpc55s69
+        - records/board/lpc55s69_nrf52840dk.yaml
+        - records/board/mcu_link.yaml

--- a/records/board/lpc55s69_nrf52840dk.yaml
+++ b/records/board/lpc55s69_nrf52840dk.yaml
@@ -1,0 +1,9 @@
+common:
+    macros:
+            - SWO_UART=1
+    sources:
+        board:
+            - source/board/lpc55s69_nrf52840dk.c
+        family:
+            - source/family/nordic/nrf52/target.c
+            - source/family/nordic/target_reset_nrf52.c

--- a/records/hic_hal/lpc55s69.yaml
+++ b/records/hic_hal/lpc55s69.yaml
@@ -7,7 +7,7 @@ common:
         - INTERFACE_LPC55XX
         - CPU_LPC55S69JBD64_cm33_core0
         - DAPLINK_HIC_ID=0x4C504355  # DAPLINK_HIC_ID_LPC55XX
-        - OS_CLOCK=150000000
+        - OS_CLOCK=96000000
     includes:
         - source/hic_hal/nxp/lpc55xx
         - source/hic_hal/nxp/lpc55xx/LPC55S69

--- a/source/board/lpc55s69_nrf52840dk.c
+++ b/source/board/lpc55s69_nrf52840dk.c
@@ -1,0 +1,35 @@
+/**
+ * @file    lpc55S69_nrf52840dk.c
+ * @brief   board file for test project MCU-LINK + nRF52840-DK
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_family.h"
+#include "target_board.h"
+
+extern target_cfg_t target_device_nrf52840;
+
+const board_info_t g_board_info = {
+    .info_version = kBoardInfoVersion,
+    .board_id = "1102",
+    .family_id = kNordic_Nrf52_FamilyID,
+    .flags = kEnablePageErase,
+    .target_cfg = &target_device_nrf52840,
+    .board_vendor = "Nordic Semiconductor",
+    .board_name = "nRF52840-DK",
+};

--- a/source/hic_hal/nxp/lpc55xx/hic_init.c
+++ b/source/hic_hal/nxp/lpc55xx/hic_init.c
@@ -172,11 +172,14 @@ void sdk_init(void)
 //! - Configure the USB PHY and USB1 clocks.
 void hic_enable_usb_clocks(void)
 {
-    // For the interface, switch to 150 MHz before enabling USB. The bootloader will stay at 96 MHz
-    // so it can always write internal flash.
-#if defined(DAPLINK_IF)
-    BOARD_BootClockPLL150M();
-#endif
+    // Switching to 150 MHz for interface is disabled because it prevents
+    // interface from writing configuration and updating bootloader.
+    // #if defined(DAPLINK_IF)
+    //     // For the interface, switch to 150 MHz before enabling USB.
+    //     // The bootloader will stay at 96 MHz so it can always write
+    //     // internal flash.
+    //     BOARD_BootClockPLL150M();
+    // #endif
 
     NVIC_ClearPendingIRQ(USB1_IRQn);
     NVIC_ClearPendingIRQ(USB1_NEEDCLK_IRQn);

--- a/test/info.py
+++ b/test/info.py
@@ -235,6 +235,9 @@ SUPPORTED_CONFIGURATIONS = [
     (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'nrf52820_if',                              None,               None                                    ),
     (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'sam3u2c_if',                               None,               None                                    ),
     (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'stm32f103xb_if',                           None,               None                                    ),
+
+    # Test projects
+    (   0x1102,     VENDOR_TO_FAMILY('Nordic', 2),      'lpc55s69_nrf52840dk_test_if',              'lpc55s69_bl',      'Nordic-nRF52840-DK'                    ),
 ]
 
 # Add new HICs here

--- a/tools/progen_compile.py
+++ b/tools/progen_compile.py
@@ -94,6 +94,8 @@ if 'armc' in toolchain:
 # musca projects are too large to fit when compiled with gcc. LTO should fix that but it does not work (yet)
 if 'gcc' in toolchain and args.release:
     project_list = list(filter(lambda p: "musca" not in p, project_list))
+# remove all test projects from list
+project_list = list(filter(lambda p: not p.endswith("test_if"), project_list))
 
 logging_level = logging.DEBUG if args.verbosity >= 2 else (logging.INFO if args.verbosity >= 1 else logging.WARNING)
 logging.basicConfig(format="%(asctime)s %(name)020s %(levelname)s\t%(message)s", level=logging_level)


### PR DESCRIPTION
- Adding a test project combining MCU-LINK and nRF52840-DK
- Partial revert of #842 because it impacted negatively validation tests (leading to some assertion failures).
- Reducing CPU clock to 96 MHz (from 150 MHz), internal flash cannot be written at higher speed. Writing to internal flash is needed for configuration and updating bootloader.