### PR TITLE
microbitv2_bl: Add non-zero board ID to micro:bit DAPLink bootloader.

### DIFF
--- a/source/board/kl27z_microbit_bl.c
+++ b/source/board/kl27z_microbit_bl.c
@@ -59,7 +59,7 @@ const target_family_descriptor_t *g_target_family = NULL;
 
 const board_info_t g_board_info = {
     .info_version = kBoardInfoVersion,
-    .board_id = "0000",
+    .board_id = "9903",
     .daplink_url_name =       "HELP_FAQHTM",
     .daplink_drive_name =       "MAINTENANCE",
     .daplink_target_url = "https://microbit.org/device/?id=@B&v=@V&bl=1",

--- a/source/board/nrf52820_microbit_bl.c
+++ b/source/board/nrf52820_microbit_bl.c
@@ -68,9 +68,11 @@ target_cfg_t target_device = {
 // bootloader has no family
 const target_family_descriptor_t *g_target_family = NULL;
 
+// Use the 9905 board ID in the bootloader for both nRF52833 and nRF52820
+// Mainly used to identify which interface hex file to download from the micro:bit help page
 const board_info_t g_board_info = {
     .info_version               = kBoardInfoVersion,
-    .board_id                   = "0000",
+    .board_id                   = "9905",
     .daplink_url_name           = "HELP_FAQHTM",
     .daplink_drive_name         = "MAINTENANCE",
     .daplink_target_url         = "https://microbit.org/device/?id=@B&v=@V&bl=1",


### PR DESCRIPTION
In some cases a micro:bit can get stuck in MAINTENANCE mode (the DAPLink interface could have been overwritten/corrupted, the reset button could have been damaged, etc).

The URL redirect from the help html file in the MAINTENANCE drive has a flag to indicate it came from the bootloader, but because the board ID is `0000` the microbit.org help page cannot identify which board version it was.
Having this board ID can help us pre-select the right DAPLink interface hex file for the user to update/fix their board. 

@flit @mathias-arm I think the DAPLink bootloader board ID has been historically always `0000`, which is one of the reasons we've never touched it. I assume having a different value for the microbit-specific bootloaders should be fine?