### PR TITLE
DAP: add DAP_GetInterfaceCapabilities vendor command

### DIFF
--- a/docs/dap_vendor_commands.md
+++ b/docs/dap_vendor_commands.md
@@ -1,0 +1,31 @@
+DAPLink CMSIS-DAP vendor commands
+=================================
+
+## DAP_GetInterfaceCapabilities
+
+This command returns a vector of capability bits that indicate the presence or absence of features in DAPLink's interface firmware.
+
+**Command ID**: 0x85 (`ID_DAP_Vendor5`)
+
+**Request**
+
+```
+  BYTE |
+> 0x85 |
+ ******|
+ ```
+
+ **Response**
+
+ ```
+  BYTE | BYTE | WORD |
+< 0x85 | Len  | Caps |
+ ******|******|++++++|
+```
+
+After the command ID, the response contains () a single `Len` byte with the number of capability words. Following is an array of `Len` 32-bit words encoded as little endian.
+
+**Capability bit definitions**
+
+- [0] `kCapability_FileFormatBinary`: Programming of binary firmware files is supported.
+- [1] `kCapability_FileFormatIntelHex`: Programming of Intel hex files is supported.

--- a/source/daplink/cmsis-dap/DAP_vendor.c
+++ b/source/daplink/cmsis-dap/DAP_vendor.c
@@ -121,7 +121,20 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
         num += ((write_len + 1) << 16) | 1;
         break;
     }
-    case ID_DAP_Vendor5:  break;
+    case ID_DAP_GetInterfaceCapabilities: {
+        // Response consists of a 1-byte count of capability words, followed by
+        // that number of 32-bit words encoded as little endian. Currently the
+        // capability word count will only ever be 1.
+        uint32_t caps = get_interface_capabilities();
+        *response++ = 1; // response word count
+        *response++ = (caps >> 0) & 0xff;
+        *response++ = (caps >> 8) & 0xff;
+        *response++ = (caps >> 16) & 0xff;
+        *response++ = (caps >> 24) & 0xff;
+        num += (0 << 16)                    // request bytes consumed
+                | (1 + sizeof(uint32_t));   // response bytes sent
+        break;
+    }
     case ID_DAP_Vendor6:  break;
     case ID_DAP_Vendor7:  break;
     case ID_DAP_SetUSBTestMode: {
@@ -209,6 +222,14 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
   }
 
   return (num);
+}
+
+/*!
+ * @brief Return the DAPLink-specific capabilities of this firmware.
+ */
+__WEAK uint32_t get_interface_capabilities(void) {
+    return kCapability_FileFormatBinary
+            | kCapability_FileFormatIntelHex;
 }
 
 ///@}

--- a/source/daplink/cmsis-dap/daplink_vendor_commands.h
+++ b/source/daplink/cmsis-dap/daplink_vendor_commands.h
@@ -29,6 +29,7 @@
 #define ID_DAP_UART_SetConfiguration    ID_DAP_Vendor2
 #define ID_DAP_UART_Read                ID_DAP_Vendor3
 #define ID_DAP_UART_Write               ID_DAP_Vendor4
+#define ID_DAP_GetInterfaceCapabilities ID_DAP_Vendor5
 #define ID_DAP_SetUSBTestMode           ID_DAP_Vendor8
 #define ID_DAP_ResetTargetIfNoAutoReset ID_DAP_Vendor9
 #define ID_DAP_MSD_Open                 ID_DAP_Vendor10
@@ -37,3 +38,21 @@
 #define ID_DAP_SelectEraseMode          ID_DAP_Vendor13
 //@}
 
+//! @brief DAP_GetInterfaceCapabilities capability definitions.
+enum _interface_capabilities_definitions {
+    //! Supports binary file programming.
+    kCapability_FileFormatBinary = (1 << 0),
+    //! Supports Intel hex file programming.
+    kCapability_FileFormatIntelHex = (1 << 1),
+};
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Return the interface firmware's capabilities vector.
+uint32_t get_interface_capabilities(void);
+
+#if defined(__cplusplus)
+}
+#endif


### PR DESCRIPTION
The default implementation of the `get_interface_capabilities()` function is weak so it can be overridden by HICs.

Only two capabilities are defined so far, primarily for discussion purposes:

- [0] `kCapability_FileFormatBinary`: Programming of binary firmware files is supported.
- [1] `kCapability_FileFormatIntelHex`: Programming of Intel hex files is supported.

Includes documentation of the new command in a new `docs/dap_vendor_commands.md` documentation file. (Existing vendor commands need to be documented here.)