### PR TITLE
lpc55xx_hic: Fix circular buffer and re-apply TX performance improvements

### DIFF
--- a/source/daplink/circ_buf.c
+++ b/source/daplink/circ_buf.c
@@ -166,10 +166,10 @@ void circ_buf_pop_n(circ_buf_t *circ_buf, uint32_t n)
     state = cortex_int_get_and_disable();
 
     if (circ_buf->tail >= circ_buf->head) {
-        util_assert(circ_buf->tail - circ_buf->head <= n);
+        util_assert(circ_buf->tail - circ_buf->head >= n);
         circ_buf->head += n;
     } else {
-        util_assert(circ_buf->tail + circ_buf->size - circ_buf->head <= n);
+        util_assert(circ_buf->tail + circ_buf->size - circ_buf->head >= n);
         circ_buf->head += n;
         if (circ_buf->head >= circ_buf->size) {
             circ_buf->head -= circ_buf->size;

--- a/source/hic_hal/nxp/lpc55xx/uart.c
+++ b/source/hic_hal/nxp/lpc55xx/uart.c
@@ -87,6 +87,10 @@ int32_t uart_reset(void)
     // disable interrupt
     NVIC_DisableIRQ(USART_IRQ);
     clear_buffers();
+    if (cb_buf.tx_size != 0) {
+        USART_INSTANCE.Control(ARM_USART_ABORT_SEND, 0U);
+        cb_buf.tx_size = 0;
+    }
     // enable interrupt
     NVIC_EnableIRQ(USART_IRQ);
 
@@ -159,6 +163,10 @@ int32_t uart_set_configuration(UART_Configuration *config)
 
     NVIC_DisableIRQ(USART_IRQ);
     clear_buffers();
+    if (cb_buf.tx_size != 0) {
+        USART_INSTANCE.Control(ARM_USART_ABORT_SEND, 0U);
+        cb_buf.tx_size = 0;
+    }
 
     // If there was no Receive() call in progress aborting it is harmless.
     USART_INSTANCE.Control(ARM_USART_CONTROL_RX, 0U);

--- a/source/hic_hal/nxp/lpc55xx/uart.c
+++ b/source/hic_hal/nxp/lpc55xx/uart.c
@@ -50,7 +50,6 @@ struct {
     volatile uint32_t tx_size;
 
     uint8_t rx;
-    uint8_t tx;
 } cb_buf;
 
 void uart_handler(uint32_t event);
@@ -193,23 +192,41 @@ int32_t uart_write_free(void)
     return circ_buf_count_free(&write_buffer);
 }
 
+// Start a new TX transfer if there are bytes pending to be transferred on the
+// write_buffer buffer. The transferred bytes are not removed from the circular
+// by this function, only the event handler will remove them once the transfer
+// is done.
+static void uart_start_tx_transfer() {
+    uint32_t tx_size = 0;
+    const uint8_t* buf = circ_buf_peek(&write_buffer, &tx_size);
+    if (tx_size > BUFFER_SIZE / 4) {
+        // The bytes being transferred remain on the circular buffer memory
+        // until the transfer is done. Limiting the UART transfer size
+        // allows the uart_handler to clear those bytes earlier.
+        tx_size = BUFFER_SIZE / 4;
+    }
+    cb_buf.tx_size = tx_size;
+    if (tx_size) {
+        USART_INSTANCE.Send(buf, tx_size);
+    }
+}
+
 int32_t uart_write_data(uint8_t *data, uint16_t size)
 {
     if (size == 0) {
         return 0;
     }
 
-    // Disable interrupts to prevent the uart_handler from modifying the
-    // circular buffer at the same time.
-    NVIC_DisableIRQ(USART_IRQ);
     uint32_t cnt = circ_buf_write(&write_buffer, data, size);
-    if (cb_buf.tx_size == 0 && circ_buf_count_used(&write_buffer) > 0) {
-        // There's no pending transfer, so we need to start the process.
-        cb_buf.tx = circ_buf_pop(&write_buffer);
-        USART_INSTANCE.Send(&(cb_buf.tx), 1);
-        cb_buf.tx_size = 1;
+    if (cb_buf.tx_size == 0) {
+        // There's no pending transfer and the value of cb_buf.tx_size will not
+        // change to non-zero by the event handler once it is zero. Note that it
+        // is entirely possible that we transferred all the bytes we added to
+        // the circular buffer in this function by the time we are in this
+        // branch, in that case uart_start_tx_transfer() would not schedule any
+        // transfer.
+        uart_start_tx_transfer();
     }
-    NVIC_EnableIRQ(USART_IRQ);
 
     return cnt;
 }
@@ -233,13 +250,7 @@ void uart_handler(uint32_t event) {
     }
 
     if (event & ARM_USART_EVENT_SEND_COMPLETE) {
-        if (circ_buf_count_used(&write_buffer) > 0) {
-            cb_buf.tx = circ_buf_pop(&write_buffer);
-            USART_INSTANCE.Send(&(cb_buf.tx), 1);
-        } else {
-            // Signals that next call to uart_write_data() should start a
-            // transfer.
-            cb_buf.tx_size = 0;
-        }
+        circ_buf_pop_n(&write_buffer, cb_buf.tx_size);
+        uart_start_tx_transfer();
     }
 }


### PR DESCRIPTION
PR #927 reverted the lpc55xx_hic changes that where sending larger chunks of data since they were hitting an assert during the Validation Tests. The assert was actually backwards, should be checking that the current number of bytes is >= the bytes being removed. In addition to that, the Validation Tests perform baudrate changes during the test with short delays between them and sending/receiving data. Whenever the baudrate or configuration is changed the circular buffers were cleared, but if there was an ongoing TX transfer it would attempt to remove those bytes from the queue once it is done.

This PR re-applies the revert from PR #927, fixes the circular buffer asserts and cancels ongoing TX transfers when clearing the circular buffers.