### PR TITLE
Fix issue flashing hex files with 32 bytes data records.

### DIFF
--- a/source/daplink/drag-n-drop/intelhex.c
+++ b/source/daplink/drag-n-drop/intelhex.c
@@ -37,9 +37,9 @@ enum hex_record_t {
 };
 
 typedef union hex_line_t hex_line_t;
-union __attribute__((packed)) hex_line_t {
+__PACKED_UNION hex_line_t {
     uint8_t buf[0x25];
-    struct __attribute__((packed)) {
+    __PACKED_STRUCT {
         uint8_t  byte_count;
         uint16_t address;
         uint8_t  record_type;
@@ -176,6 +176,9 @@ hexfile_parse_status_t parse_hex_blob(const uint8_t *hex_blob, const uint32_t he
                                             if (((next_address_to_write & 0xffff0000) | line.address) != next_address_to_write) {
                                                 load_unaligned_record = 1;
                                                 status = HEX_PARSE_UNALIGNED;
+                                                // Function will be executed again and will start by finishing to process this record by
+                                                // adding the this line into bin_buf, so the 1st loop iteration should be the next blob byte
+                                                hex_blob++;
                                                 goto hex_parser_exit;
                                             } else {
                                                 // This should be superfluous but it is necessary for GCC


### PR DESCRIPTION
Fix issue flashing hex files with 32 bytes data records

We encountered this issue for the first time with micro:bit when the MakeCode beta editor started creating Universal Hex files with 32 bytes data records.
With the V2.20 DAPLink factory image, and if automation is enabled, it would cause a `ERROR_WRITE_VERIFY` error.

An example hex file can be downloaded here: [20 chrome flash.zip](https://github.com/ARMmbed/DAPLink/files/7975175/20.chrome.flash.zip)


The issue itself is not directly related to the Universal Hex parsing, as this problem can be replicated with Intel Hex files as well.
This error was caused because there was an out-of-bounds write to the `line.buf` array here, which was changing the value of `load_unaligned_record`, and the change to that flag cascaded into DAPLink trying to verify flash writes against empty buffers:
https://github.com/ARMmbed/DAPLink/blob/5dd23001a7a3199d74870790049d6686e183316c/source/daplink/drag-n-drop/intelhex.c#L155

And from the map file we can confirm that for this build `load_unaligned_record` was placed right after `line` in memory:
```
 .bss.idx       0x0000000020002b12        0x1 build/intelhex.o
 .bss.line      0x0000000020002b13       0x25 build/intelhex.o
 .bss.load_unaligned_record
                0x0000000020002b38        0x1 build/intelhex.o
```

This issue happens when a 32 bytes data (or custom data) record is processed and the `HEX_PARSE_UNALIGNED` status is triggered, which happens when `next_address_to_write` is not the same as the address contained in the record being processed.

For example, with a hex file like this:
```
:020000040000FA
:20002000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA80
:00000001FF
```

- The first record, an extended linear address, sets `next_address_to_write` to `0x0000_0000`.
- The second line, a data record, is for address `0x0000_0020`, so this condition would be triggered:
  https://github.com/ARMmbed/DAPLink/blob/7839c6cef09eb1b3ae66e180450753e237559bd7/source/daplink/drag-n-drop/intelhex.c#L166-L172

So at this point it:
- Exists the `parse_hex_blob()` function
- `file_stream.c` `write_hex()` writes to flash the binary buffer, which does not contain the last record line, that record data stays in `line.buffer`
    - In this example it has no data to write anyway
- Then re-enters `parse_hex_blob()`:
   - Right at the start it finishes processing the last line, because the `load_unaligned_record ` flag was set
   - And then to continues with the next block of hex data.

The important part here, is that when `parse_hex_blob()` is executed again:
- The `hex_blob` pointer is still pointing to the last byte from the data record (`0`)
    - This is because this function only increases `hex_blob` if the switch case doesn't exit early, like it does when `HEX_PARSE_UNALIGNED` is set
      https://github.com/ARMmbed/DAPLink/blob/7839c6cef09eb1b3ae66e180450753e237559bd7/source/daplink/drag-n-drop/intelhex.c#L234
- And the `idx` variable has value `37`, which is one byte out of range for `line.buf[idx]`:
  https://github.com/ARMmbed/DAPLink/blob/7839c6cef09eb1b3ae66e180450753e237559bd7/source/daplink/drag-n-drop/intelhex.c#L144-L146

This wasn't an issue for data records with 16 bytes because:
- With 16 data bytes `idx` ends up with value `21`, so `line.buf[idx] |= ...` ends up clobbering a byte in `line.buf` which is never used
- The record is already processed (`record_processed==1`) and at this point it just jumps into the next loop iteration and starts processing the next `hex_blob` byte.
https://github.com/ARMmbed/DAPLink/blob/7839c6cef09eb1b3ae66e180450753e237559bd7/source/daplink/drag-n-drop/intelhex.c#L151
- Because this issue happens at the end of a data record, the next iteration of `hex_blob` is for a new line character, which is ignored, and then the start of the next record (`:`), and that resets the `idx` back to `0`.

@mathias-arm this is my suggestion to fix the issue, it seems to work, but I'm not 100% it is the best approach, so very open to other suggestions. Let me know if there is anything I should explain better about the issue itself.