### PR TITLE
micro:bit features: I2C busy flag

### DIFF
--- a/source/board/microbitv2/i2c.h
+++ b/source/board/microbitv2/i2c.h
@@ -45,7 +45,7 @@ void i2c_initialize(void);
 void i2c_deinitialize(void);
 i2c_status_t i2c_registerWriteCallback(i2cCallback_t writeCallback, uint8_t slaveAddress);
 i2c_status_t i2c_registerReadCallback(i2cCallback_t readCallback, uint8_t slaveAddress);
-void i2c_clearBuffers(void);
+void i2c_clearState(void);
 void i2c_fillBuffer(uint8_t* data, uint32_t position, uint32_t size);
 /* A more efficient way to fill the first byte for simple transactions. */
 void i2c_fillBufferHead(uint8_t data);

--- a/source/board/microbitv2/i2c_commands.c
+++ b/source/board/microbitv2/i2c_commands.c
@@ -123,6 +123,7 @@ static void i2c_write_comms_callback(uint8_t* pData, uint8_t size) {
                     if (pI2cCommand->cmdData.writeReqCmd.dataSize == 1) {
                         if (pI2cCommand->cmdData.writeReqCmd.data[0] == MB_POWER_DOWN) {
                             interface_power_mode = MB_POWER_DOWN;
+                            main_shutdown_state = MAIN_SHUTDOWN_REQUESTED;
                             i2cResponse.cmdId = gWriteResponse_c;
                             i2cResponse.cmdData.writeRspCmd.propertyId = pI2cCommand->cmdData.writeReqCmd.propertyId;
                         } else {
@@ -191,18 +192,6 @@ static void i2c_write_comms_callback(uint8_t* pData, uint8_t size) {
 }
 
 static void i2c_read_comms_callback(uint8_t* pData, uint8_t size) {
-    i2cCommand_t* pI2cCommand = (i2cCommand_t*) pData;
-
-    switch (pI2cCommand->cmdId) {
-        case gWriteResponse_c:
-            switch (pI2cCommand->cmdData.writeRspCmd.propertyId) {
-                case gPowerMode_c:
-                    main_shutdown_state = MAIN_SHUTDOWN_REQUESTED;
-                break;
-            }
-        break;
-    }
-
     // Release COMBINED_SENSOR_INT
     gpio_disable_combined_int();
 }

--- a/source/board/microbitv2/i2c_commands.h
+++ b/source/board/microbitv2/i2c_commands.h
@@ -36,12 +36,7 @@ extern "C" {
 #define I2C_SLAVE_HID               (0x71U)
 #define I2C_SLAVE_FLASH             (0x72U)
 
-// Busy flag not yet implemented in nRF52
-#if defined(INTERFACE_NRF52820)
-#define I2C_PROTOCOL_VERSION        (0x01)
-#else 
 #define I2C_PROTOCOL_VERSION        (0x02)
-#endif
 
 /*! i2c command Id type enumeration */
 typedef enum cmdId_tag {

--- a/source/board/microbitv2/kl27z/i2c.c
+++ b/source/board/microbitv2/kl27z/i2c.c
@@ -35,8 +35,8 @@
 #define I2C_SLAVE_CLK_FREQ CLOCK_GetFreq(I2C1_CLK_SRC)
 
 static uint16_t g_slave_TX_i = 0;
-static uint8_t g_slave_TX_buff[I2C_DATA_LENGTH];
-static uint8_t g_slave_RX_buff[I2C_DATA_LENGTH];
+static uint8_t __ALIGNED(4) g_slave_TX_buff[I2C_DATA_LENGTH];
+static uint8_t __ALIGNED(4) g_slave_RX_buff[I2C_DATA_LENGTH];
 
 i2c_slave_handle_t g_s_handle;
 static volatile bool g_SlaveCompletionFlag = false;

--- a/source/board/microbitv2/microbitv2.c
+++ b/source/board/microbitv2/microbitv2.c
@@ -406,7 +406,7 @@ void board_vfs_stream_closed_hook()
     reset_power_led_state();
 
     // Clear any pending I2C response
-    i2c_clearBuffers();
+    i2c_clearState();
 
     // Release COMBINED_SENSOR_INT
     gpio_disable_combined_int();
@@ -522,7 +522,7 @@ uint8_t usbd_hid_no_activity(uint8_t *buf)
 static uint8_t target_set_state_microbit(target_state_t state)
 {
     if (state == RESET_RUN) {
-        i2c_clearBuffers();
+        i2c_clearState();
         reset_power_led_state();
     }
     return 0;

--- a/source/board/microbitv2/nrf52820/i2c.c
+++ b/source/board/microbitv2/nrf52820/i2c.c
@@ -171,7 +171,7 @@ static void i2c_signalEvent(uint32_t event) {
 
 void i2c_initialize()
 {
-    i2c_clearBuffers();
+    i2c_clearState();
 
     // I2C addresses configured via default values from RTE_Device.h
     I2Cdrv->Initialize(i2c_signalEvent);
@@ -225,13 +225,14 @@ i2c_status_t i2c_registerReadCallback(i2cCallback_t readCallback, uint8_t slaveA
     return status;
 }
 
-void i2c_clearBuffers()
+void i2c_clearState()
 {
     i2c_clearTxBuffer();
     memset(&g_slave_RX_buff, 0, sizeof(g_slave_RX_buff));
     callbackToExecute.pfCallback = NULL;
     callbackToExecute.pData = NULL;
     callbackToExecute.size = 0;
+    i2c_wake_timeout = 0;
     i2c_allow_sleep = true;
 }
 
@@ -250,9 +251,7 @@ void i2c_fillBuffer(uint8_t* data, uint32_t position, uint32_t size)
     if ((position + size) > I2C_DATA_LENGTH) {
         return;
     }
-    for (uint32_t i = 0; i < size; i++) {
-        g_slave_TX_buff[position + i] = data[i];
-    }
+    memcpy(g_slave_TX_buff + position, data, size);
     i2c_allow_sleep = false;
 }
 

--- a/source/board/microbitv2/nrf52820/i2c.c
+++ b/source/board/microbitv2/nrf52820/i2c.c
@@ -33,17 +33,23 @@
 
 #if DEBUG_I2C
 #include "daplink_debug.h"
-#define debug_i2c_printf    debug_msg
-#define debug_i2c_data      debug_data
+#define debug_i2c_printf        debug_msg
+#define debug_i2c_data          debug_data
+#define debug_i2c_array(a, i)   do {   \
+        for (int x = 0; x < i; x++) debug_msg("%02x ", a[x]); \
+        debug_data((uint8_t *)"\n", 1); \
+    } while(0)
 #else
 #define debug_i2c_printf(...)
 #define debug_i2c_data(...)
+#define debug_i2c_array(...)
 #endif
 
 extern ARM_DRIVER_I2C            Driver_I2C0;
 static ARM_DRIVER_I2C *I2Cdrv = &Driver_I2C0;
 
 static uint8_t g_slave_TX_buff[I2C_DATA_LENGTH] = { 0 };
+static uint16_t g_slave_TX_i = 0;
 static uint8_t g_slave_RX_buff[I2C_DATA_LENGTH] = { 0 };
 
 static i2cCallback_t pfWriteCommsCallback = NULL;
@@ -69,37 +75,34 @@ static void i2c_clearTxBuffer(void);
 
 static void i2c_scheduleCallback(i2cCallback_t callback, uint8_t* pData, uint8_t size)
 {
-    callbackToExecute.pfCallback = callback;
-    callbackToExecute.pData = pData;
-    callbackToExecute.size = size;
-
-    // Raise event so that `board_custom_event()` gets called in the main task
-    main_board_event();
+    if ((callback == pfReadCommsCallback) || (callback == pfReadFlashCallback)) {
+        // Run the I2C TX callback in the interrupt context
+        debug_i2c_data((uint8_t *)"[cbTx]\n", 7);
+        callback(pData, size);
+        i2c_clearTxBuffer();
+    } else {
+        // Raise an RTOS event to run the heavier I2C RX callback in main task
+        callbackToExecute.pfCallback = callback;
+        callbackToExecute.pData = pData;
+        callbackToExecute.size = size;
+        i2c_allow_sleep = false;
+        main_board_event();
+    }
 }
 
 // Hook function executed in the main task
 void board_custom_event()
 {
-    i2cCallback_t evtCallback = NULL;
-
     if (callbackToExecute.pfCallback != NULL) {
-        debug_i2c_data((uint8_t *)"[clbk]\n", 7);
+        debug_i2c_data((uint8_t *)"[cbRx]\n", 7);
         callbackToExecute.pfCallback(callbackToExecute.pData, callbackToExecute.size);
 
         // Clear the callback data
-        evtCallback = callbackToExecute.pfCallback; // Save for later
         callbackToExecute.pfCallback = NULL;
         callbackToExecute.pData = NULL;
         callbackToExecute.size = 0;
 
         i2c_allow_sleep = true;
-    }
-
-    // Clear TX buffer after a TX callback
-    if ((pfReadCommsCallback != NULL && evtCallback == pfReadCommsCallback) ||
-        (pfReadFlashCallback != NULL && evtCallback == pfReadFlashCallback)) {
-        debug_i2c_data((uint8_t *)"[clrTx]\n", 8);
-        i2c_clearTxBuffer();
     }
 }
 
@@ -118,13 +121,11 @@ static void i2c_signalEvent(uint32_t event) {
 
     if (event & ARM_I2C_EVENT_TRANSFER_DONE) {
         // debug_i2c_data((uint8_t *)"[d", 2);
-        i2c_allow_sleep = false;
 
         if (prev_event & ARM_I2C_EVENT_SLAVE_RECEIVE) {
             int32_t data_count = I2Cdrv->GetDataCount();
-            debug_i2c_printf("[rx][%d] ", data_count);
-            // for (int i = 0; i < data_count; i++) debug_i2c_printf("%02x ", g_slave_RX_buff[i]);
-            debug_i2c_data((uint8_t *)"\n", 1);
+            debug_i2c_printf("[R0%x]\n", g_slave_RX_buff[0]);
+            // debug_i2c_array(g_slave_RX_buff, data_count);
 
             // Ignore NOP commands and 0 length transmissions
             if ((data_count != 0) && (g_slave_RX_buff[0] != gNopCmd_c)) {
@@ -136,9 +137,8 @@ static void i2c_signalEvent(uint32_t event) {
             }
         } else if (prev_event & ARM_I2C_EVENT_SLAVE_TRANSMIT) {
             int32_t data_count = I2Cdrv->GetDataCount();
-            debug_i2c_printf("[tx][%d] ", data_count);
-            // for (int i = 0; i < 5; i++) debug_i2c_printf("%02x ", g_slave_TX_buff[i]);
-            debug_i2c_data((uint8_t *)"\n", 1);
+            debug_i2c_printf("[T0%x]\n", g_slave_TX_buff[0]);
+            // debug_i2c_array(g_slave_TX_buff, 5);
 
             if (event & EXTENSION_I2C_EVENT_SLAVE_ADDR_0) {
                 i2c_scheduleCallback(pfReadCommsCallback, &g_slave_TX_buff[0], data_count);
@@ -238,10 +238,9 @@ void i2c_clearState()
 
 void i2c_clearTxBuffer()
 {
-    memset(&g_slave_TX_buff, 0, sizeof(g_slave_TX_buff));
+    memset(&g_slave_TX_buff, 0, g_slave_TX_i);
+    g_slave_TX_i = 0;
     // Set the buffer with the "busy flag"
-    // TODO: This can be later removed and updated in CODAL to interpret 0x00
-    //       as the busy flag
     g_slave_TX_buff[0] = gErrorResponse_c;
     g_slave_TX_buff[1] = gErrorBusy_c;
 }
@@ -252,12 +251,18 @@ void i2c_fillBuffer(uint8_t* data, uint32_t position, uint32_t size)
         return;
     }
     memcpy(g_slave_TX_buff + position, data, size);
+    if (position + size > g_slave_TX_i) {
+        g_slave_TX_i = position + size;
+    }
     i2c_allow_sleep = false;
 }
 
 void i2c_fillBufferHead(uint8_t data)
 {
     g_slave_TX_buff[0] = data;
+    if (0 == g_slave_TX_i) {
+        g_slave_TX_i = 1;
+    }
     i2c_allow_sleep = false;
 }
 

--- a/source/board/microbitv2/nrf52820/i2c.c
+++ b/source/board/microbitv2/nrf52820/i2c.c
@@ -48,9 +48,9 @@
 extern ARM_DRIVER_I2C            Driver_I2C0;
 static ARM_DRIVER_I2C *I2Cdrv = &Driver_I2C0;
 
-static uint8_t g_slave_TX_buff[I2C_DATA_LENGTH] = { 0 };
 static uint16_t g_slave_TX_i = 0;
-static uint8_t g_slave_RX_buff[I2C_DATA_LENGTH] = { 0 };
+static uint8_t __ALIGNED(4) g_slave_TX_buff[I2C_DATA_LENGTH] = { 0 };
+static uint8_t __ALIGNED(4) g_slave_RX_buff[I2C_DATA_LENGTH] = { 0 };
 
 static i2cCallback_t pfWriteCommsCallback = NULL;
 static i2cCallback_t pfReadCommsCallback = NULL;

--- a/source/board/microbitv2/storage_common.c
+++ b/source/board/microbitv2/storage_common.c
@@ -40,7 +40,7 @@ typedef __PACKED_STRUCT storage_cfg_tag {
 } storage_cfg_t;
 
 
-static storage_cfg_t s_storage_cfg = {
+static storage_cfg_t __ALIGNED(4) s_storage_cfg = {
     .key = STORAGE_CFG_KEY,
     .fileName = STORAGE_CFG_FILENAME,
     .fileVisible = STORAGE_CFG_FILEVISIBLE,

--- a/source/hic_hal/nordic/nrf52820/I2C_Slave_nRF52820.c
+++ b/source/hic_hal/nordic/nrf52820/I2C_Slave_nRF52820.c
@@ -417,9 +417,10 @@ static int32_t I2C_Control (uint32_t control, uint32_t arg, I2C_RESOURCES *i2c) 
     case ARM_I2C_ABORT_TRANSFER:
       break;
 
-    default: return ARM_DRIVER_ERROR;
+    default:
+      break;
   }
-  return ARM_DRIVER_OK;
+  return ret;
 }
 
 


### PR DESCRIPTION
This PR only touches the micro:bit specific files to add a feature to the I2C communication with the target: https://github.com/microbit-foundation/spec-i2c-protocol/pull/10

The only exception is commit  2f4b219fe14e447b176064c179caf4a6cc1d4950, which fixes an issue in the nRF52820 hic I2C_Control() function not returning error values for unimplemented features.
