### PR TITLE
Fix family_id for Renesas targets

### DIFF
--- a/source/board/gr-lychee.c
+++ b/source/board/gr-lychee.c
@@ -25,7 +25,7 @@
 const board_info_t g_board_info = {
     .info_version = kBoardInfoVersion,
     .board_id = "5501",
-    .family_id = kStub_HWReset_FamilyID,
+    .family_id = kRenesas_FamilyID,
     .flags = kEnablePageErase,
     .daplink_drive_name =       "MBED       ",
     .target_cfg = &target_device,

--- a/source/board/gr-peach.c
+++ b/source/board/gr-peach.c
@@ -25,7 +25,7 @@
 const board_info_t g_board_info = {
     .info_version = kBoardInfoVersion,
     .board_id = "5500",
-    .family_id = kStub_HWReset_FamilyID,
+    .family_id = kRenesas_FamilyID,
     .flags = kEnablePageErase,
     .daplink_drive_name =       "MBED       ",
     .target_cfg = &target_device,


### PR DESCRIPTION
The family_id for Renesas target board (GR-PEACH and GR-LYCHEE) was wrongly set as `kStub_HWReset_FamilyID` rather than `kRenesas_FamilyID`.  This was caused unexpected behavior for reset.

This fixes https://github.com/ARMmbed/DAPLink/issues/941 issue.