### PR TITLE
kl27z_hic: Change GCC GPIO port C+D IRQ handler name to match armcc.

### DIFF
--- a/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
+++ b/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
@@ -72,7 +72,7 @@ __isr_vector:
     .long   LPTMR0_IRQHandler                               /* LPTMR0 interrupt*/
     .long   Reserved45_IRQHandler                           /* Reserved interrupt*/
     .long   PORTA_IRQHandler                                /* PORTA Pin detect*/
-    .long   PORTC_PORTD_IRQHandler                          /* Single interrupt vector for PORTC; PORTD Pin detect*/
+    .long   PORTCD_IRQHandler                               /* Single interrupt vector for PORTC; PORTD Pin detect*/
 
     .size    __isr_vector, . - __isr_vector
 
@@ -379,6 +379,6 @@ I2S0_IRQHandler:
     def_irq_handler    LPTMR0_IRQHandler
     def_irq_handler    Reserved45_IRQHandler
     def_irq_handler    PORTA_IRQHandler
-    def_irq_handler    PORTC_PORTD_IRQHandler
+    def_irq_handler    PORTCD_IRQHandler
 
     .end


### PR DESCRIPTION
Fixes the issue where GCC builds do not call the expected ISR:
https://github.com/ARMmbed/DAPLink/blob/c782a5ba907377658bc28aa8d132a0fa44543687/source/board/microbitv2/kl27z/power.c#L91