### PR TITLE
kl27z_hic: Update GCC flash & ROM bootloader config and tweak non-microbit value

### DIFF
--- a/source/hic_hal/freescale/kinetis.ld
+++ b/source/hic_hal/freescale/kinetis.ld
@@ -33,11 +33,13 @@ STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : DAPLINK_STACK_SIZE;
 /* Specify the memory areas */
 MEMORY
 {
-  m_interrupts          (RX)  : ORIGIN = DAPLINK_ROM_APP_START, LENGTH = 0x400
 #if defined(DAPLINK_BL)
+  m_interrupts          (RX)  : ORIGIN = DAPLINK_ROM_APP_START, LENGTH = 0x3C0
+  m_bootloader_config   (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x3C0, LENGTH = 0x40
   m_flash_config        (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x400, LENGTH = 0x10
   m_text                (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x410, LENGTH = DAPLINK_ROM_APP_SIZE - 0x410
 #else
+  m_interrupts          (RX)  : ORIGIN = DAPLINK_ROM_APP_START, LENGTH = 0x400
   m_text                (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x400, LENGTH = DAPLINK_ROM_APP_SIZE - 0x400
 #endif
   m_cfgrom              (RW)  : ORIGIN = DAPLINK_ROM_CONFIG_USER_START, LENGTH = DAPLINK_ROM_CONFIG_USER_SIZE
@@ -59,6 +61,13 @@ SECTIONS
   } > m_interrupts
 
 #if defined(DAPLINK_BL)
+  .bootloader_config :
+  {
+    . = ALIGN(4);
+    KEEP(*(.BootloaderConfig)) /* Bootloader Configuration Area (BCA) */
+    . = ALIGN(4);
+  } > m_bootloader_config
+
   .flash_config :
   {
     . = ALIGN(4);

--- a/source/hic_hal/freescale/kinetis.ld
+++ b/source/hic_hal/freescale/kinetis.ld
@@ -34,8 +34,12 @@ STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : DAPLINK_STACK_SIZE;
 MEMORY
 {
   m_interrupts          (RX)  : ORIGIN = DAPLINK_ROM_APP_START, LENGTH = 0x400
+#if defined(DAPLINK_BL)
   m_flash_config        (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x400, LENGTH = 0x10
   m_text                (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x410, LENGTH = DAPLINK_ROM_APP_SIZE - 0x410
+#else
+  m_text                (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x400, LENGTH = DAPLINK_ROM_APP_SIZE - 0x400
+#endif
   m_cfgrom              (RW)  : ORIGIN = DAPLINK_ROM_CONFIG_USER_START, LENGTH = DAPLINK_ROM_CONFIG_USER_SIZE
   m_data                (RW)  : ORIGIN = DAPLINK_RAM_APP_START, LENGTH = DAPLINK_RAM_APP_SIZE
   m_cfgram              (RW)  : ORIGIN = DAPLINK_RAM_SHARED_START, LENGTH = DAPLINK_RAM_SHARED_SIZE
@@ -54,12 +58,14 @@ SECTIONS
     . += LENGTH(m_interrupts) - (. - ORIGIN(m_interrupts)); /* pad out to end of m_interrupts */
   } > m_interrupts
 
+#if defined(DAPLINK_BL)
   .flash_config :
   {
     . = ALIGN(4);
     KEEP(*(.FlashConfig))    /* Flash Configuration Field (FCF) */
     . = ALIGN(4);
   } > m_flash_config
+#endif
 
   /* The program code and other data goes into internal flash */
   .text :

--- a/source/hic_hal/freescale/kl27z/armcc/startup_MKL27Z4.s
+++ b/source/hic_hal/freescale/kl27z/armcc/startup_MKL27Z4.s
@@ -276,7 +276,11 @@ FPROT0          EQU     nFPROT0:EOR:0xFF
 ;       <2=> Boot from ROM
 ;       <3=> Boot from ROM
 ;         <i> Boot source selection
+#if defined(MICROBIT_LOCK_BOOTLOADER)
 FOPT          EQU     0x39
+#else
+FOPT          EQU     0x3B
+#endif
 ;   </h>
 ;   <h> Flash security byte (FSEC)
 ;     <i> WARNING: If SEC field is configured as "MCU security status is secure" and MEEN field is configured as "Mass erase is disabled",

--- a/source/hic_hal/freescale/kl27z/armcc/startup_MKL27Z4.s
+++ b/source/hic_hal/freescale/kl27z/armcc/startup_MKL27Z4.s
@@ -308,16 +308,14 @@ FSEC          EQU     0xFE
 ;   </h>
 ; </h>
 
-            #if defined(DAPLINK_IF)
-                AREA    |.ARM.__at_0x8400|, CODE, READONLY
-            #else
+            #if defined(DAPLINK_BL)
                 AREA    |.ARM.__at_0x400 |, CODE, READONLY
-            #endif
 
                 DCB     BackDoorK0, BackDoorK1, BackDoorK2, BackDoorK3
                 DCB     BackDoorK4, BackDoorK5, BackDoorK6, BackDoorK7
                 DCB     FPROT3    , FPROT2    , FPROT1    , FPROT0
                 DCB     FSEC      , FOPT      , 0xFF      , 0xFF
+            #endif
 
                 AREA    |.text|, CODE, READONLY
 

--- a/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
+++ b/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
@@ -83,15 +83,53 @@ __isr_vector:
 /* Flash Configuration */
     .section .FlashConfig, "a"
 #if defined(MICROBIT_LOCK_BOOTLOADER)
+    /* Backdoor Comparison Key: "MICROBIT" */
     .long 0x5243494D
     .long 0x5449424F
+    /* Program flash protection bytes (FPROT): Protect the first 32 kB of flash */
     .long 0xFFFFFFF0
-    .long 0xFFFF39FE
+    /* Flash security byte (FSEC)
+     * KEYEN  [6:7] -> 0b10 Backdoor key access enabled
+     * MEEN   [4:5] -> 0b11 Mass erase is enabled
+     * FSLACC [2:3] -> 0b11 NXP factory access granted
+     * SEC    [0:1] -> 0b10 MCU security status is unsecure
+     */
+    .byte 0xBE
+    /* Flash nonvolatile option byte (FOPT):
+     * BOOTSRC_SEL [7:6] -> 0b00 Boot from flash
+     * FAST_INIT     [5] -> 0b1 Fast Initialization
+     * RESET_PIN_CFG [3] -> 0b1 RESET_b pin is dedicated
+     * NMI_DIS       [2] -> 0b0 NMI interrupts are always blocked
+     * BOOTPIN_OPT   [1] -> 0b0 Force Boot from ROM if BOOTCFG0 asserted
+     * LPBOOT      [4:0] -> 0b11 Core and system clock divider (OUTDIV1) is 0x0 (divide by 1)
+     */
+    .byte 0x39
+    /* 2 reserved bytes */
+    .byte 0xFF, 0xFF
 #else
+    /* Backdoor Comparison Key: Unset */
     .long 0xFFFFFFFF
     .long 0xFFFFFFFF
+    /* Program flash protection bytes (FPROT): None */
     .long 0xFFFFFFFF
-    .long 0xFFFF3FFE
+    /* Flash security byte (FSEC)
+     * KEYEN  [6:7] -> 0b11 Backdoor key access disabled
+     * MEEN   [4:5] -> 0b11 Mass erase is enabled
+     * FSLACC [2:3] -> 0b11 NXP factory access granted
+     * SEC    [0:1] -> 0b10 MCU security status is unsecure
+     */
+    .byte 0xFE
+    /* Flash nonvolatile option byte (FOPT):
+     * BOOTSRC_SEL [7:6] -> 0b00 Boot from flash
+     * FAST_INIT     [5] -> 0b1 Fast Initialization
+     * RESET_PIN_CFG [3] -> 0b1 RESET_b pin is dedicated
+     * NMI_DIS       [2] -> 0b0 NMI interrupts are always blocked
+     * BOOTPIN_OPT   [1] -> 0b1 Boot source configured by FOPT[7:6] (BOOTSRC_SEL) bits
+     * LPBOOT      [4:0] -> 0b11 Core and system clock divider (OUTDIV1) is 0x0 (divide by 1)
+     */
+    .byte 0x3B
+    /* 2 reserved bytes */
+    .byte 0xFF, 0xFF
 #endif
 
     .text

--- a/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
+++ b/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
@@ -77,7 +77,30 @@ __isr_vector:
     .size    __isr_vector, . - __isr_vector
 
 #if defined(DAPLINK_BL)
-    /* TODO: Bootloader Configuration Area (BCA) used by Kinetis ROM Bootloader */
+    /* Bootloader Configuration Area (BCA) used by Kinetis ROM Bootloader */
+    .section .BootloaderConfig, "a"
+    .long 0x6766636B    /* 0x00 Magic number to verify bootloader configuration is valid. Must be set to 'kcfg'. */
+    .long 0xFFFFFFFF    /* 0x04 Reserved */
+    .long 0xFFFFFFFF    /* 0x08 Reserved */
+    .long 0xFFFFFFFF    /* 0x0C Reserved */
+    .byte 0x10          /* 0x10 Bitfield of peripherals to enable. bit 0 LPUART, bit 1 I2C, bit 2 SPI, bit 4 USB. 0x10 = USB only */
+    .byte 0xFF          /* 0x11 i2cSlaveAddress */
+    .byte 0xFF, 0xFF    /* 0x12 peripheralDetectionTimeout */
+    .byte 0xFF, 0xFF    /* 0x14 usbVid */
+    .byte 0xFF, 0xFF    /* 0x16 usbPid */
+    .long 0xFFFFFFFF    /* 0x18 usbStringsPointer */
+    .byte 0xFF          /* 0x1C clockFlags */
+    .byte 0xFF          /* 0x1D clockDivider */
+    .byte 0xFF          /* 0x1E bootFlags */
+    .byte 0xFF          /* 0x1F pad byte */
+    .long 0xFFFFFFFF    /* 0x20 Reserved */
+    .long 0xFFFFFFFF    /* 0x24 Reserved */
+    .long 0xFFFFFFFF    /* 0x28 Reserved */
+    .long 0xFFFFFFFF    /* 0x2C Reserved */
+    .long 0xFFFFFFFF    /* 0x30 Reserved */
+    .long 0xFFFFFFFF    /* 0x34 Reserved */
+    .long 0xFFFFFFFF    /* 0x38 Reserved */
+    .long 0xFFFFFFFF    /* 0x3C Reserved */
 
     /* Flash Configuration */
     .section .FlashConfig, "a"

--- a/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
+++ b/source/hic_hal/freescale/kl27z/gcc/startup_MKL27Z4.S
@@ -78,9 +78,8 @@ __isr_vector:
 
 #if defined(DAPLINK_BL)
     /* TODO: Bootloader Configuration Area (BCA) used by Kinetis ROM Bootloader */
-#endif
 
-/* Flash Configuration */
+    /* Flash Configuration */
     .section .FlashConfig, "a"
 #if defined(MICROBIT_LOCK_BOOTLOADER)
     /* Backdoor Comparison Key: "MICROBIT" */
@@ -130,7 +129,8 @@ __isr_vector:
     .byte 0x3B
     /* 2 reserved bytes */
     .byte 0xFF, 0xFF
-#endif
+#endif  /* MICROBIT_LOCK_BOOTLOADER */
+#endif  /* DAPLINK_BL */
 
     .text
     .thumb


### PR DESCRIPTION
- Sets the ROM bootloader settings in the GCC builds to mirror armcc
- For both GCC and armcc it changes the default (non-microbit) flash config for `FOPT` from `0x39` to `0x3B`
  - The main difference is that `BOOTPIN_OPT` is set to `1`, so it doesn't trigger the ROM bootloader if the `BOOTCFG0` pin is grounded (which in micro:bit is connected to TP1, to trigger the ROM bootloader)
  - The original GCC code had set this value to `0x3F` which wasn't quite right either
- It also updates the GCC and armcc DAPLink Interface builds to not include the flash config data, which right now is being unnecessarily added to flash at address 0x8400
    - The flash config goes into address 0x400, so it only needs to be set in the DAPLink bootloader builds