### PR TITLE
Penjun71 patch daplink for mdk

### DIFF
--- a/source/daplink/cmsis-dap/dap_strings.h
+++ b/source/daplink/cmsis-dap/dap_strings.h
@@ -24,7 +24,7 @@
 #include "target_board.h"
 
 #if !defined(CMSIS_DAP_PRODUCT_NAME)
-#define CMSIS_DAP_PRODUCT_NAME "CMSIS-DAP"
+#define CMSIS_DAP_PRODUCT_NAME "DAPLink CMSIS-DAP"
 #endif
 
 //! Maximum output buffer length of all these functions.

--- a/source/daplink/cmsis-dap/dap_strings.h
+++ b/source/daplink/cmsis-dap/dap_strings.h
@@ -24,7 +24,7 @@
 #include "target_board.h"
 
 #if !defined(CMSIS_DAP_PRODUCT_NAME)
-#define CMSIS_DAP_PRODUCT_NAME "DAPLink"
+#define CMSIS_DAP_PRODUCT_NAME "CMSIS-DAP"
 #endif
 
 //! Maximum output buffer length of all these functions.


### PR DESCRIPTION
fix lpc11u35 not found in mdk ,fw >0254

Fixes #977. Some tools (including some versions of MDK) require "CMSIS-DAP" to be present in product name. This has been an issue since DAPLink added support for bulk interface (DAPv2) in v0254.