### PR TITLE
Add source/daplink in assembly include path

### DIFF
--- a/records/hic_hal/max32625.yaml
+++ b/records/hic_hal/max32625.yaml
@@ -18,6 +18,8 @@ tool_specific:
         misc:
             ld_flags:
                 - --predefine="-I..\..\..\source\hic_hal\maxim\max32625"
+            asm_flags:
+                - -I../../../source/daplink
         sources:
             hic_hal:
                 - source/hic_hal/maxim/max32625/armcc


### PR DESCRIPTION
It was worked but after rebasing repository with upstream ones the build break. So that this changes applied.
Build error:
source\hic_hal\maxim\max32625\armcc\startup_max32625.S file requires daplink_defaults.h file

Signed-off-by: Sadik.Ozer <sadik.ozer@analog.com>