### PR TITLE
CMSIS-DAPv2: blink LED on bulk interface activity

### DIFF
--- a/source/usb/bulk/usbd_bulk.c
+++ b/source/usb/bulk/usbd_bulk.c
@@ -25,6 +25,8 @@
 #include "usb_for_lib.h"
 #include "util.h"
 #include "DAP_queue.h"
+#include "daplink.h"
+#include DAPLINK_MAIN_HEADER
 
 static U8 *ptrDataIn;
 static U16 DataInReceLen;
@@ -76,6 +78,7 @@ void USBD_BULK_EP_BULKOUT_Event(U32 event)
     if ((DataInReceLen >= USBD_Bulk_BulkBufSize) ||
             (bytes_rece    <  usbd_bulk_maxpacketsize[USBD_HighSpeed])) {
         if (DAP_queue_execute_buf(&DAP_Cmd_queue, USBD_Bulk_BulkOutBuf, DataInReceLen, &rbuf)) {
+            main_blink_hid_led(MAIN_LED_FLASH);
             //Trigger the BULKIn for the reply
             if (USB_ResponseIdle) {
                 USBD_BULK_EP_BULKIN_Event(0);


### PR DESCRIPTION
Fix for #714