### PR TITLE
intelhex: Increase optimisation level to O3.

### DIFF
--- a/source/daplink/drag-n-drop/intelhex.c
+++ b/source/daplink/drag-n-drop/intelhex.c
@@ -24,6 +24,15 @@
 #include "intelhex.h"
 #include "cmsis_compiler.h"
 
+#if defined(__CC_ARM)
+#pragma push
+#pragma O3
+#pragma Otime
+#elif defined(__GNUC__) && !defined(__ARMCC_VERSION)
+#pragma GCC push_options
+#pragma GCC optimize("O3")
+#endif
+
 typedef enum hex_record_t hex_record_t;
 enum hex_record_t {
     DATA_RECORD = 0,
@@ -261,3 +270,9 @@ hex_parser_exit:
     *hex_parse_cnt = (uint32_t)(hex_blob_size - (end - hex_blob));
     return status;
 }
+
+#if defined(__CC_ARM)
+#pragma pop
+#elif defined(__GNUC__) && !defined(__ARMCC_VERSION)
+#pragma GCC pop_options
+#endif


### PR DESCRIPTION
Optimisation only applied to the `intelhex.c` file.

In my tests with micro:bit V2, when build with GCC v10.3, this can improve flashing time (rsync a .hex file with 512Kbs of flash data) by around 0.7-0.8 seconds.

For additional info, building the entire project with `-O3` shaved another second-ish of flashing time, but that might be too much of a change/risk (it's likely it can also increase binary size, but I didn't really checked those numbers). I couldn't easily find another single file in the USB or vfs layer that significantly improved times on their own, just a tiny bit here and there, but the `intelhex.c` file is significant enough where this might be worth doing.

The specific compiler incantations have been copy/pasted from the `SW_DP.c` file:

https://github.com/ARMmbed/DAPLink/blob/9e324545bdc37548efc8eac7a41078d7d3f7718a/source/daplink/cmsis-dap/SW_DP.c#L31-L38