### PR TITLE
Update hook to skip blinking on WebUSB HID serial traffic (option 1).

### DIFF
--- a/source/board/artemis_dk.c
+++ b/source/board/artemis_dk.c
@@ -23,6 +23,7 @@
 #include "DAP.h"
 #include "target_family.h"
 #include "target_board.h"
+#include DAPLINK_MAIN_HEADER
 
 const char *const board_id_artemis_dk_v10 = "A127";
 
@@ -53,7 +54,7 @@ static void prerun_board_config(void)
 }
 
 // USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
+uint8_t main_dap_no_activity(const uint8_t *buf)
 {
     if (buf[0] == ID_DAP_Vendor3 && buf[1] == 0)
         return 1;

--- a/source/board/microbit.c
+++ b/source/board/microbit.c
@@ -23,6 +23,7 @@
 #include "DAP.h"
 #include "target_family.h"
 #include "target_board.h"
+#include "main_interface.h"
 
 const char * const board_id_mb_1_3 = "9900";
 const char * const board_id_mb_1_5 = "9901";
@@ -70,9 +71,9 @@ static void prerun_board_config(void) {
 }
 
 // USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
+uint8_t main_dap_no_activity(const uint8_t *buf)
 {
-    if(buf[0] == ID_DAP_Vendor3 &&  buf[1] == 0)
+    if(buf[0] == ID_DAP_Vendor3)
         return 1;
     else
         return 0;

--- a/source/board/microbitv2/microbitv2.c
+++ b/source/board/microbitv2/microbitv2.c
@@ -458,9 +458,9 @@ uint8_t board_detect_incompatible_image(const uint8_t *data, uint32_t size)
 }
 
 // USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
+uint8_t main_dap_no_activity(const uint8_t *buf)
 {
-    if(buf[0] == ID_DAP_Vendor3 &&  buf[1] == 0)
+    if(buf[0] == ID_DAP_Vendor3)
         return 1;
     else
         return 0;

--- a/source/daplink/interface/main_interface.c
+++ b/source/daplink/interface/main_interface.c
@@ -181,6 +181,13 @@ __WEAK void board_custom_event()
 
 }
 
+// Override function to check for DAP activity and return 1 if the activity is
+// trivial, null, and/or should be ignored when blinking the HID LED.
+__WEAK uint8_t main_dap_no_activity(const uint8_t *buf)
+{
+    return 0;
+}
+
 // Timer task, set flags every 30mS and 90mS
 void timer_task_30mS(void * arg)
 {

--- a/source/daplink/interface/main_interface.h
+++ b/source/daplink/interface/main_interface.h
@@ -57,6 +57,7 @@ void main_force_msc_disconnect_event(void);
 void main_blink_hid_led(main_led_state_t state);
 void main_blink_msc_led(main_led_state_t state);
 void main_blink_cdc_led(main_led_state_t state);
+uint8_t main_dap_no_activity(const uint8_t *buf);
 
 #ifdef __cplusplus
 }

--- a/source/usb/bulk/usbd_bulk.c
+++ b/source/usb/bulk/usbd_bulk.c
@@ -78,7 +78,9 @@ void USBD_BULK_EP_BULKOUT_Event(U32 event)
     if ((DataInReceLen >= USBD_Bulk_BulkBufSize) ||
             (bytes_rece    <  usbd_bulk_maxpacketsize[USBD_HighSpeed])) {
         if (DAP_queue_execute_buf(&DAP_Cmd_queue, USBD_Bulk_BulkOutBuf, DataInReceLen, &rbuf)) {
-            main_blink_hid_led(MAIN_LED_FLASH);
+            if (!main_dap_no_activity(rbuf)) {
+                main_blink_hid_led(MAIN_LED_FLASH);
+            }
             //Trigger the BULKIn for the reply
             if (USB_ResponseIdle) {
                 USBD_BULK_EP_BULKIN_Event(0);

--- a/source/usb/hid/usbd_user_hid.c
+++ b/source/usb/hid/usbd_user_hid.c
@@ -97,13 +97,6 @@ int usbd_hid_get_report(U8 rtype, U8 rid, U8 *buf, U8 req)
     return (0);
 }
 
-// USB HID override function return 1 if the activity is trivial or response is null
-__attribute__((weak))
-uint8_t usbd_hid_no_activity(U8 *buf)
-{
-    return 0;
-}
-
 // USB HID Callback: when data is received from the host
 void usbd_hid_set_report(U8 rtype, U8 rid, U8 *buf, int len, U8 req)
 {
@@ -122,7 +115,7 @@ void usbd_hid_set_report(U8 rtype, U8 rid, U8 *buf, int len, U8 req)
 
             // execute and store to DAP_queue
             if (DAP_queue_execute_buf(&DAP_Cmd_queue, buf, len, &rbuf)) {
-                if(usbd_hid_no_activity(rbuf) == 1){
+                if(main_dap_no_activity(rbuf) == 1){
                     //revert HID LED to default if the response is null
                     led_next_state = MAIN_LED_DEF;
                 }


### PR DESCRIPTION
Rename the usbd_hid_no_activity hook to main_dap_no_activity as it has been moved to the main_interface.h header file.

Add check to usbd_bulk.c to also skip blinks with bulk traffic, if applicable to the project.

-----

This is one option out of two, so between https://github.com/ARMmbed/DAPLink/pull/1018 and this only one PR should be merged. 