### PR TITLE
Update hook to skip blinking on WebUSB HID serial traffic

### DIFF
--- a/source/board/artemis_dk.c
+++ b/source/board/artemis_dk.c
@@ -53,7 +53,7 @@ static void prerun_board_config(void)
 }
 
 // USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
+uint8_t DAP_no_activity(const uint8_t *buf)
 {
     if (buf[0] == ID_DAP_Vendor3 && buf[1] == 0)
         return 1;

--- a/source/board/microbit.c
+++ b/source/board/microbit.c
@@ -70,9 +70,9 @@ static void prerun_board_config(void) {
 }
 
 // USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
+uint8_t DAP_no_activity(const uint8_t *buf)
 {
-    if(buf[0] == ID_DAP_Vendor3 &&  buf[1] == 0)
+    if(buf[0] == ID_DAP_Vendor3)
         return 1;
     else
         return 0;

--- a/source/board/microbitv2/microbitv2.c
+++ b/source/board/microbitv2/microbitv2.c
@@ -458,9 +458,9 @@ uint8_t board_detect_incompatible_image(const uint8_t *data, uint32_t size)
 }
 
 // USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
+uint8_t DAP_no_activity(const uint8_t *buf)
 {
-    if(buf[0] == ID_DAP_Vendor3 &&  buf[1] == 0)
+    if (buf[0] == ID_DAP_Vendor3)
         return 1;
     else
         return 0;

--- a/source/usb/bulk/usbd_bulk.c
+++ b/source/usb/bulk/usbd_bulk.c
@@ -78,7 +78,6 @@ void USBD_BULK_EP_BULKOUT_Event(U32 event)
     if ((DataInReceLen >= USBD_Bulk_BulkBufSize) ||
             (bytes_rece    <  usbd_bulk_maxpacketsize[USBD_HighSpeed])) {
         if (DAP_queue_execute_buf(&DAP_Cmd_queue, USBD_Bulk_BulkOutBuf, DataInReceLen, &rbuf)) {
-            main_blink_hid_led(MAIN_LED_FLASH);
             //Trigger the BULKIn for the reply
             if (USB_ResponseIdle) {
                 USBD_BULK_EP_BULKIN_Event(0);


### PR DESCRIPTION
Move usbd_hid_no_activity() hook from usbd_user_hid.c to DAP_queue.c and rename it to DAP_no_activity().

In this new location it can be used to skip HID LED blinking in traffic from USB bulk as well.

-----

This is one option out of two, so between https://github.com/ARMmbed/DAPLink/pull/1017 and this only one PR should be merged.