### PR TITLE
Update hook to skip blinking on WebUSB HID serial traffic.

### DIFF
--- a/source/board/artemis_dk.c
+++ b/source/board/artemis_dk.c
@@ -52,15 +52,6 @@ static void prerun_board_config(void)
     set_board_id(board_version);
 }
 
-// USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
-{
-    if (buf[0] == ID_DAP_Vendor3 && buf[1] == 0)
-        return 1;
-    else
-        return 0;
-}
-
 const board_info_t g_board_info = {
     .info_version = 0x1,
     .family_id = kAmbiq_ama3b1kk_FamilyID,

--- a/source/board/microbit.c
+++ b/source/board/microbit.c
@@ -69,15 +69,6 @@ static void prerun_board_config(void) {
     set_board_id(board_version);
 }
 
-// USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
-{
-    if(buf[0] == ID_DAP_Vendor3 &&  buf[1] == 0)
-        return 1;
-    else
-        return 0;
-}
-
 extern target_cfg_t target_device_nrf51822_16;
 
 const board_info_t g_board_info = {

--- a/source/board/microbitv2/microbitv2.c
+++ b/source/board/microbitv2/microbitv2.c
@@ -457,15 +457,6 @@ uint8_t board_detect_incompatible_image(const uint8_t *data, uint32_t size)
     return result == 0;
 }
 
-// USB HID override function return 1 if the activity is trivial or response is null
-uint8_t usbd_hid_no_activity(uint8_t *buf)
-{
-    if(buf[0] == ID_DAP_Vendor3 &&  buf[1] == 0)
-        return 1;
-    else
-        return 0;
-}
-
 // This function is called before the rest of target_set_state code, so it will
 // reset the micro:bit specific features state before the target state is executed
 static uint8_t target_set_state_microbit(target_state_t state)

--- a/source/usb/bulk/usbd_bulk.c
+++ b/source/usb/bulk/usbd_bulk.c
@@ -78,7 +78,6 @@ void USBD_BULK_EP_BULKOUT_Event(U32 event)
     if ((DataInReceLen >= USBD_Bulk_BulkBufSize) ||
             (bytes_rece    <  usbd_bulk_maxpacketsize[USBD_HighSpeed])) {
         if (DAP_queue_execute_buf(&DAP_Cmd_queue, USBD_Bulk_BulkOutBuf, DataInReceLen, &rbuf)) {
-            main_blink_hid_led(MAIN_LED_FLASH);
             //Trigger the BULKIn for the reply
             if (USB_ResponseIdle) {
                 USBD_BULK_EP_BULKIN_Event(0);


### PR DESCRIPTION
A continuation from this PR, opened from my account fork so that it can be edited by maintainers:
- https://github.com/ARMmbed/DAPLink/pull/1018

Implemented the suggestion from https://github.com/ARMmbed/DAPLink/pull/1018#issuecomment-1480288695 and the final result is:

Moves `usbd_hid_no_activity()` hook from `usbd_user_hid.c` to `DAP_queue.c` and renames it to `DAP_activity_blink()`.

In this new location it can be used to skip HID LED blinking in traffic from USB bulk as well.

Adds the default behaviour to the weak function to skip HID blink of DAP serial & MSD activity.

Removes customised hooks in the artemis & micro:bit projects as they are no longer needed.

The logic in the hook has been reverted from a "negative check" to a "positive check" (before `usbd_hid_no_activity()` returned true when there was no activity, so then we checked for "not [no activity]") as this way it's easier to reason.