### PR TITLE
kinetis: Fix bin file generation regression

### DIFF
--- a/records/hic_hal/kl27z.yaml
+++ b/records/hic_hal/kl27z.yaml
@@ -10,6 +10,7 @@ common:
         - FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT=0
         - FLASH_DRIVER_IS_FLASH_RESIDENT=1
         - DAPLINK_NO_ASSERT_FILENAMES
+        - BOOTLOADER_CONFIG
         - OS_CLOCK=48000000
     includes:
         - source/hic_hal/freescale/kl27z

--- a/source/hic_hal/freescale/kinetis.ld
+++ b/source/hic_hal/freescale/kinetis.ld
@@ -34,8 +34,12 @@ STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : DAPLINK_STACK_SIZE;
 MEMORY
 {
 #if defined(DAPLINK_BL)
+#if defined(BOOTLOADER_CONFIG)
   m_interrupts          (RX)  : ORIGIN = DAPLINK_ROM_APP_START, LENGTH = 0x3C0
   m_bootloader_config   (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x3C0, LENGTH = 0x40
+#else
+  m_interrupts          (RX)  : ORIGIN = DAPLINK_ROM_APP_START, LENGTH = 0x400
+#endif
   m_flash_config        (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x400, LENGTH = 0x10
   m_text                (RX)  : ORIGIN = DAPLINK_ROM_APP_START + 0x410, LENGTH = DAPLINK_ROM_APP_SIZE - 0x410
 #else
@@ -61,12 +65,14 @@ SECTIONS
   } > m_interrupts
 
 #if defined(DAPLINK_BL)
+#if defined(BOOTLOADER_CONFIG)
   .bootloader_config :
   {
     . = ALIGN(4);
     KEEP(*(.BootloaderConfig)) /* Bootloader Configuration Area (BCA) */
     . = ALIGN(4);
   } > m_bootloader_config
+#endif
 
   .flash_config :
   {
@@ -245,4 +251,3 @@ SECTIONS
 
   ASSERT(__StackLimit >= __HeapLimit, "region overflowed with stack and heap")
 }
-


### PR DESCRIPTION
Changes in #959 created an issue for GCC builds of k26f_bl, kl26z_bl, and k20dx_bl in the generation of .bin file:

```
../../../tools/post_build_script_gcc.py
build/k26f_bl_crc
Error - only 1 region allowed in hex file 2 found.
Regions:
 0: 0x00000000 - 0x000003bf
 1: 0x00000400 - 0x0000ffff
```

@microbit-carlos 