### PR TITLE
Allow use of MSC/CDC USB endpoints for bulk on sam3u2

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -37,6 +37,22 @@ module:
         - records/daplink/interface.yaml
         - records/daplink/target_family.yaml
         - records/daplink/target_board.yaml
+    # this is exactly the same as if without usb-msc
+    # intended use is HICs that do not have enough USB endpoints to have MSC and BULK at the same time
+    no_msc_if: &module_no_msc_if
+        - *module_tools
+        - records/usb/usb-core.yaml
+        - records/usb/usb-cdc.yaml
+        - records/usb/usb-webusb.yaml
+        - records/usb/usb-winusb.yaml
+        - records/daplink/cmsis-dap.yaml
+        - records/daplink/drag-n-drop.yaml
+        - records/daplink/usb2uart.yaml
+        - records/daplink/settings.yaml
+        - records/daplink/settings_rom.yaml
+        - records/daplink/interface.yaml
+        - records/daplink/target_family.yaml
+        - records/daplink/target_board.yaml
     # HICs
     hic_k20dx: &module_hic_k20dx
         - records/rtos/rtos-cm3.yaml

--- a/projects.yaml
+++ b/projects.yaml
@@ -626,3 +626,9 @@ projects:
         - *module_hic_lpc55s69
         - records/board/lpc55s69_nrf52840dk.yaml
         - records/board/mcu_link.yaml
+
+    sam3u2c_bulk_test_if:
+        - *module_no_msc_if
+        - *module_hic_sam3u2c
+        - records/family/all_family.yaml
+        - records/usb/usb-bulk.yaml

--- a/source/hic_hal/atmel/sam3u2c/usb_config.c
+++ b/source/hic_hal/atmel/sam3u2c/usb_config.c
@@ -395,9 +395,21 @@
 #else
 #define BULK_ENDPOINT 1
 #endif
-#define USBD_BULK_ENABLE             BULK_ENDPOINT //no endpts left
-#define USBD_BULK_EP_BULKIN          7
-#define USBD_BULK_EP_BULKOUT         8
+#define USBD_BULK_ENABLE             BULK_ENDPOINT
+// We don't have enough endpoints for BULK unless MSC or CDC are disabled.
+// MSC is the best choice, since this is only useful in the fixed target IF config and we can still upload firmware via DAP.
+// We'll still want MSC for the BL though, but in that case BULK isn't useful anyway.
+#if USBD_MSC_ENABLE == 0
+#define USBD_BULK_EP_BULKIN          1 // Use the MSC endpoints for BULK
+#define USBD_BULK_EP_BULKOUT         2
+#elif USBD_CDC_ACM_ENABLE == 0
+#define USBD_BULK_EP_BULKIN          5 // Use the CDC endpoints for BULK
+#define USBD_BULK_EP_BULKOUT         6
+#else
+#define USBD_BULK_EP_BULKIN          7 // Use non-existent endpoints to force an error
+#define USBD_BULK_EP_BULKOUT         8 // if BULK is enabled but MSC + CDC are still enabled
+#endif
+
 #define USBD_BULK_WMAXPACKETSIZE     64
 #define USBD_BULK_HS_ENABLE          1
 #define USBD_BULK_HS_WMAXPACKETSIZE  512


### PR DESCRIPTION
The sam3u2 USB peripheral does not have enough endpoints after CDC and MSC are enabled to enable the BULK endpoints. Bulk endpoints are required for CMSIS-DAP v2 support - the existing projects for this HIC use HID+MSC+CDC

This PR makes it possible for the sam3u2 to enable BULK if either CDC or MSC are disabled.
In order to demonstrate this setup, the sam3u2c_bulk_test_if project has been added which uses HID+CDC+BULK, 

I have tested this configuration with a nanoDAP-hs, probe-rs-cli and few computers I had at my disposal:
raspberry pi 4 -  hid: 90KB/s, bulk: 152KB/s
AMD 7700x, ubuntu 22.10 -  hid: 17KB/s, bulk: 280KB/s
intel u5200, windows 10 - hid: 100KB/s, bulk: 160KB/s

Not sure why my AMD box is so slow with HID, but the speed-up is very significant in this case.