### PR TITLE
Actually pull up nRESET on STM32F103

### DIFF
--- a/source/hic_hal/stm32/stm32f103xb/DAP_config.h
+++ b/source/hic_hal/stm32/stm32f103xb/DAP_config.h
@@ -260,7 +260,7 @@ __STATIC_INLINE void PORT_SWD_SETUP(void)
 
     pin_in_init(SWDIO_IN_PIN_PORT, SWDIO_IN_PIN_Bit, 1);
     // Set RESET HIGH
-    pin_out_od_init(nRESET_PIN_PORT, nRESET_PIN_Bit);//TODO - fix reset logic
+    pin_in_init(nRESET_PIN_PORT, nRESET_PIN_Bit, 1);  // input with pullup
     nRESET_PIN_PORT->BSRR = nRESET_PIN;
 }
 
@@ -436,10 +436,13 @@ __STATIC_FORCEINLINE uint32_t PIN_nRESET_IN(void)
 
 __STATIC_FORCEINLINE void     PIN_nRESET_OUT(uint32_t bit)
 {
-    if (bit & 1)
+    if (bit & 1) {  // set to input pullup mode, since open-drain doesn't support pullup
+        pin_in_init(nRESET_PIN_PORT, nRESET_PIN_Bit, 1);
         nRESET_PIN_PORT->BSRR = nRESET_PIN;
-    else
+    } else {  // set to open-drain mode
+        pin_out_od_init(nRESET_PIN_PORT, nRESET_PIN_Bit);
         nRESET_PIN_PORT->BRR = nRESET_PIN;
+    }
 }
 
 //**************************************************************************************************
@@ -536,7 +539,7 @@ __STATIC_INLINE void DAP_SETUP(void)
 
     pin_in_init(SWDIO_IN_PIN_PORT, SWDIO_IN_PIN_Bit, 1);
 
-    pin_out_od_init(nRESET_PIN_PORT, nRESET_PIN_Bit);
+    pin_in_init(nRESET_PIN_PORT, nRESET_PIN_Bit, 1);  // input with pullup
     nRESET_PIN_PORT->BSRR = nRESET_PIN;
 
     pin_out_init(CONNECTED_LED_PORT, CONNECTED_LED_PIN_Bit);

--- a/source/hic_hal/stm32/stm32f103xb/gpio.c
+++ b/source/hic_hal/stm32/stm32f103xb/gpio.c
@@ -157,10 +157,10 @@ void gpio_init(void)
     GPIO_InitStructure.Mode = GPIO_MODE_OUTPUT_PP;
     HAL_GPIO_Init(PIN_MSC_LED_PORT, &GPIO_InitStructure);
 
-    // reset button configured as gpio open drain output with a pullup
+    // reset button configured as input for pullup, since pullup is not supported with open drain
     HAL_GPIO_WritePin(nRESET_PIN_PORT, nRESET_PIN, GPIO_PIN_SET);
     GPIO_InitStructure.Pin = nRESET_PIN;
-    GPIO_InitStructure.Mode = GPIO_MODE_OUTPUT_OD;
+    GPIO_InitStructure.Mode = GPIO_MODE_INPUT;
     GPIO_InitStructure.Pull = GPIO_PULLUP;
     HAL_GPIO_Init(nRESET_PIN_PORT, &GPIO_InitStructure);
 


### PR DESCRIPTION
Despite the comments in the STM32F103 HIC, the nRESET pin was never pulled up since the STM32F103 can't do simultaneous open drain and pull up. Previously, it relies on an external pullup resistor to not enter bootloader mode, which isn't present on some standalone debug probes.

This changes the code to initialize nRESET in input mode with pull up when nRESET is high, and configures it in open-drain mode when nRESET is asserted low.

Testing notes:
- Previously, running DAPLink on a STM32F103-based standalone programmer without a nRESET pullup would cause it to always enter bootloader mode. Now, that only happens when nRESET is grounded.
- STLink V2 clone note: these devices have a different nRESET pinning, on PB5 (through a resistor) and PB6 (direct on the nRESET pin). With this PR, they will always boot into the interface, but they can't be forced back into bootloader mode by grounding the nRESET pin.
  - Things behave as expected if the pinning is corrected (and the default CONNECTED_LED is moved elsewhere from the reset pin on these boards).

Resolves #824 (wasn't clear why that never made it into a PR).