### PR TITLE
Update to Github Actions builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,8 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ env.cache-name }}
 
     - name: Cache Python modules
-      uses: actions/cache@v2
+      id: cache-python
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -65,7 +66,7 @@ jobs:
 
     - name: Cache CCache
       id:   ccache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: .ccache
         key: ${{ runner.os }}-ccache-${{ hashFiles('log.txt') }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -81,7 +81,7 @@ jobs:
         cp projectfiles/make_gcc_arm/*_bl/build/*_crc.{bin,hex} bootloaders
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: firmware-dev-${{github.run_number}}
         path: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Cache Embedded Arm Toolchain

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,17 +13,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        gcc: ['10.3-2021.10']
 
     steps:
-    - name: Cache Embedded Arm Toolchain
-      id:   cache-arm-gcc
-      uses: actions/cache@v2
-      env:
-        cache-name: arm-gcc-10.3-2021-07
+    - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
+      uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
-        path: ${{ runner.temp }}/arm-gcc
-        key:  ${{ runner.os }}-${{ env.cache-name }}
-        restore-keys: ${{ runner.os }}-${{ env.cache-name }}
+        release: ${{ matrix.gcc }}
+        path-env-var: ARM_NONE_EABI_GCC_PATH
 
     - name: Cache Python modules
       id: cache-python
@@ -42,15 +41,6 @@ jobs:
     - name: Install Python module
       run:  |
         pip3 install --user -r requirements.txt
-
-    - name: Install Embedded Arm Toolchain
-      if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
-      run:  |
-        curl -O -L https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2
-        md5sum gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2
-        echo Installing  in ${{ runner.temp }}/arm-gcc
-        mkdir -p ${{ runner.temp }}/arm-gcc
-        tar jvxf gcc-arm-none-eabi-10.3-2021.07-x86_64-linux.tar.bz2 -C ${{ runner.temp }}/arm-gcc --strip-components 1
 
     - name: Install dependencies
       run:  |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,30 +45,33 @@ jobs:
     - name: Install dependencies
       run:  |
         sudo apt install -y ccache ninja-build
-        export PATH=/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH
-        for i in ${{ runner.temp }}/arm-gcc/bin/* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
-        ccache --set-config=cache_dir="$GITHUB_WORKSPACE"
-        ccache --set-config=cache_dir="$GITHUB_WORKSPACE/.ccache"
-        ccache --set-config=max_size=2Gi
-        ccache -z -s
+        export PATH="/usr/lib/ccache:$ARM_NONE_EABI_GCC_PATH:/home/runner/.local/bin:$PATH"
+        for i in "$ARM_NONE_EABI_GCC_PATH/"* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
         arm-none-eabi-gcc -v | tee log.txt
-        (git status; git log -1 )>> log.txt
+        (git status; git log -1)>> log.txt
 
     - name: Cache CCache
       id:   ccache
       uses: actions/cache@v3
       with:
         path: .ccache
-        key: ${{ runner.os }}-ccache-${{ hashFiles('log.txt') }}
-        restore-keys: ${{ runner.os }}-ccache-
+        key: ${{ runner.os }}-gcc-${{ matrix.gcc }}-${{ hashFiles('log.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-gcc-${{ matrix.gcc }}-
+
+    - name: Configure CCache
+      run:  |
+        ccache --set-config=cache_dir="$GITHUB_WORKSPACE/.ccache"
+        ccache --set-config=max_size=2Gi
+        ccache -z -s
 
     - name: Compile
       run:  |
-        export PATH="/usr/lib/ccache:${{ runner.temp }}/arm-gcc/bin/:/home/runner/.local/bin:$PATH"
+        export PATH="/usr/lib/ccache:$ARM_NONE_EABI_GCC_PATH:/home/runner/.local/bin:$PATH"
         python tools/progen_compile.py --release --parallel -v
-        (ls -lR firmware_*; ccache -s; arm-none-eabi-gcc -v) | tee log.txt
         mkdir bootloaders
         cp projectfiles/make_gcc_arm/*_bl/build/*_crc.{bin,hex} bootloaders
+        (ls -lR firmware_*; ccache -s; arm-none-eabi-gcc -v) | tee log.txt
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
-name: Build DAPLink (Linux)
+name: Build DAPLink PR (Linux)
 on:
-  push:
+  pull_request:
     branches:
       - main
       - develop
@@ -41,8 +41,6 @@ jobs:
     - name: Install dependencies
       run:  |
         sudo apt install -y ccache ninja-build
-        export PATH="/usr/lib/ccache:$ARM_NONE_EABI_GCC_PATH:/home/runner/.local/bin:$PATH"
-        for i in "$ARM_NONE_EABI_GCC_PATH/"* ; do sudo ln -s /usr/bin/ccache /usr/lib/ccache/$(basename $i); done
         arm-none-eabi-gcc -v | tee log.txt
         (git status; git log -1)>> log.txt
 
@@ -59,21 +57,12 @@ jobs:
       run:  |
         ccache --set-config=cache_dir="$GITHUB_WORKSPACE/.ccache"
         ccache --set-config=max_size=2Gi
-        ccache -z -s
+        ccache -s -z
 
     - name: Compile
       run:  |
         export PATH="/usr/lib/ccache:$ARM_NONE_EABI_GCC_PATH:/home/runner/.local/bin:$PATH"
-        python tools/progen_compile.py --release --parallel -v
-        mkdir bootloaders
-        cp projectfiles/make_gcc_arm/*_bl/build/*_crc.{bin,hex} bootloaders
-        (ls -lR firmware_*; ccache -s; arm-none-eabi-gcc -v) | tee log.txt
-
-    - name: Upload test artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: firmware-dev-${{github.run_number}}
-        path: |
-          bootloaders/*
-          firmware*/*
-          !firmware*/*.zip
+        progen generate -t cmake_gcc_arm global_workspace
+        cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -GNinja -S projectfiles/cmake_gcc_arm -B projectfiles/cmake_gcc_arm
+        ninja -C projectfiles/cmake_gcc_arm
+        ccache -s

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,20 +5,18 @@ on:
 jobs:
   build:
     runs-on: windows-2019
+    strategy:
+      matrix:
+        gcc: ['10.3-2021.10']
 
     steps:
-    - name: Cache Embedded Arm Toolchain
-      id:   cache-arm-gcc
-      uses: actions/cache@v2
-      env:
-        cache-name: arm-gcc-10.3-2021-07
+    - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
+      uses: carlosperate/arm-none-eabi-gcc-action@v1
       with:
-        path: ${{ runner.temp }}/arm-gcc
-        key:  ${{ runner.os }}-${{ env.cache-name }}
-        restore-keys: ${{ runner.os }}-${{ env.cache-name }}
+        release: ${{ matrix.gcc }}
 
     - name: Cache Python modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -30,30 +28,18 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install Embedded Arm Toolchain
-      if:   steps.cache-arm-gcc.outputs.cache-hit != 'true'
-      run:  |
-        (New-Object System.Net.WebClient).DownloadFile("https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.07/gcc-arm-none-eabi-10.3-2021.07-win32.zip","gcc-arm-none-eabi-10.3-2021.07-win32.zip");
-        echo "Installing gcc-arm-none-eabi-9-2020-q2-update-win32 in ${{ runner.temp }}\arm-gcc";
-        Expand-Archive -Path .\gcc-arm-none-eabi-10.3-2021.07-win32.zip -DestinationPath ${{ runner.temp }} -PassThru;
-        Rename-Item -Path ${{ runner.temp }}\gcc-arm-none-eabi-10.3-2021.07 -NewName ${{ runner.temp }}\arm-gcc
-
-    - name: Check Embedded Arm Toolchain
-      run:  |
-        echo ${{ runner.temp }}\arm-gcc\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        ${{ runner.temp }}\arm-gcc\bin\arm-none-eabi-gcc -v
-
     - name: Install Python module
       run:  |
         pip install -r requirements.txt
 
     - name: Compile
       run:  |
+        arm-none-eabi-gcc -v
         python tools/progen_compile.py -t cmake_gcc_arm -g mingw-make --release --parallel -v
       shell: cmd
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: firmware-dev-${{github.run_number}}
         path: |


### PR DESCRIPTION
- Add new workflow for PR builds which is much faster and complete.
- Switch download of GCC toolchain to `carlosperate/arm-none-eabi-gcc-action@v1` action from @carlosperate / @microbit-carlos.
- Fix issues with `ccache` persistence across builds.
- Update other dependencies