### PR TITLE
Support for newer Arm GNU Toolchain versions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        gcc: ['13.2.Rel1']
+        gcc: ['14.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        gcc: ['12.3.Rel1']
+        gcc: ['13.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        gcc: ['10.3-2021.10']
+        gcc: ['12.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        gcc: ['12.2.Rel1']
+        gcc: ['12.3.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        gcc: ['13.2.Rel1']
+        gcc: ['14.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        gcc: ['12.3.Rel1']
+        gcc: ['13.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        gcc: ['10.3-2021.10']
+        gcc: ['12.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        gcc: ['12.2.Rel1']
+        gcc: ['12.3.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        gcc: ['13.2.Rel1']
+        gcc: ['14.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        gcc: ['10.3-2021.10']
+        gcc: ['12.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        gcc: ['12.2.Rel1']
+        gcc: ['12.3.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        gcc: ['12.3.Rel1']
+        gcc: ['13.2.Rel1']
 
     steps:
     - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)

--- a/docs/DEVELOPERS-GUIDE.md
+++ b/docs/DEVELOPERS-GUIDE.md
@@ -9,7 +9,7 @@ Install the necessary tools listed below. Skip any step where a compatible tool 
 * Install [Python 3](https://www.python.org/downloads/) . Add to PATH.
 * Install [Git](https://git-scm.com/downloads) . Add to PATH.
 * Install a compiler:
-    * [GNU Arm Embedded Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads) . This compiler will be identified as `gcc_arm`. It is recommended to use version `10.3-2021.10`. Versions 11.3 and later of GCC (Arm GNU Toolchain / `arm-none-eabi-gcc`) are known to require some changes to build (see [#1043](https://github.com/ARMmbed/DAPLink/pull/1043)).
+    * [Arm GNU Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain) for AArch32 bare-metal target. This compiler will be identified as `gcc_arm`.
     * [Arm Compiler 6](https://developer.arm.com/tools-and-software/embedded/arm-compiler) . This compiler will be identified as `armclang`. Only supported on Linux and Windows.
     * [Keil MDK](https://developer.arm.com/tools-and-software/embedded/keil-mdk) or [Arm Compiler 5](https://developer.arm.com/tools-and-software/embedded/arm-compiler/downloads/legacy-compilers#arm-compiler-5). This compiler will be identified as `armcc`. Only supported on Linux and Windows.
 * Install `make` (tested with [GNU Make](https://www.gnu.org/software/make)). [CMake](https://cmake.org) can alternatively be used in conjunction with different implementations of `make` as well as [ninja](https://ninja-build.org).

--- a/docs/DEVELOPERS-GUIDE.md
+++ b/docs/DEVELOPERS-GUIDE.md
@@ -6,10 +6,10 @@ DAPLink sources are compiled using `progen` (from [project-generator](https://gi
 
 Install the necessary tools listed below. Skip any step where a compatible tool already exists.
 
-* Install [Python 3](https://www.python.org/downloads/) . Add to PATH.
-* Install [Git](https://git-scm.com/downloads) . Add to PATH.
+* Install [Python 3](https://www.python.org/downloads/). Add to PATH.
+* Install [Git](https://git-scm.com/downloads). Add to PATH.
 * Install a compiler:
-    * [Arm GNU Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain) for AArch32 bare-metal target. This compiler will be identified as `gcc_arm`.
+    * [Arm GNU Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain) for AArch32 bare-metal targets. This compiler will be identified as `gcc_arm`. It is recommended to use version `12.2.Rel1` or later. Support for building with versions 11.2 and earlier of GCC (GNU Arm Embedded Toolchain / `arm-none-eabi-gcc`) was some removed in [#1043](https://github.com/ARMmbed/DAPLink/pull/1043) because of incompatibilities.
     * [Arm Compiler 6](https://developer.arm.com/tools-and-software/embedded/arm-compiler) . This compiler will be identified as `armclang`. Only supported on Linux and Windows.
     * [Keil MDK](https://developer.arm.com/tools-and-software/embedded/keil-mdk) or [Arm Compiler 5](https://developer.arm.com/tools-and-software/embedded/arm-compiler/downloads/legacy-compilers#arm-compiler-5). This compiler will be identified as `armcc`. Only supported on Linux and Windows.
 * Install `make` (tested with [GNU Make](https://www.gnu.org/software/make)). [CMake](https://cmake.org) can alternatively be used in conjunction with different implementations of `make` as well as [ninja](https://ninja-build.org).

--- a/records/tools/gcc_arm.yaml
+++ b/records/tools/gcc_arm.yaml
@@ -30,6 +30,7 @@ tool_specific:
                 - -Wl,-fatal-warnings
                 - -Wl,--gc-sections
                 - -Wl,--no-wchar-size-warning
+                - -Wl,--no-warn-rwx-segment
                 - -Wl,--print-memory-usage
             pre_build_script:
                 - tools/pre_build_script.py

--- a/source/daplink/stubs.c
+++ b/source/daplink/stubs.c
@@ -1,9 +1,9 @@
 /**
- * @file    sdk_stub.c
+ * @file    stubs.c
  * @brief
  *
  * DAPLink Interface Firmware
- * Copyright (c) 2017-2017, ARM Limited, All Rights Reserved
+ * Copyright (c) 2017, 2023, ARM Limited, All Rights Reserved
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -25,3 +25,21 @@ __WEAK void sdk_init()
 {
     // Do nothing
 }
+
+/*
+ * Work-around for a link-time issue with Arm GNU Toolchain
+ * in version 11.3 and later.
+ */
+#ifdef __GNUC__
+#if ((__GNUC__ > 11) || \
+     ((__GNUC__ == 11) && (__GNUC_MINOR__ >= 3)))
+__WEAK void _close() {}
+__WEAK void _fstat() {}
+__WEAK void _getpid() {}
+__WEAK void _isatty() {}
+__WEAK void _kill() {}
+__WEAK void _lseek() {}
+__WEAK void _read() {}
+__WEAK void _write() {}
+#endif
+#endif


### PR DESCRIPTION
- Fixes #1040
- Updates CI to use Arm GNU Toolchain version 13.2.Rel1 (builds on #1042)