### PR TITLE
Modified GPIO code to prevent low pulse when switching to Hi-Z mode.

### DIFF
--- a/source/hic_hal/maxim/max32625/DAP_config.h
+++ b/source/hic_hal/maxim/max32625/DAP_config.h
@@ -236,15 +236,10 @@ Disables the DAP Hardware I/O pins which configures:
 */
 __STATIC_INLINE void PORT_OFF (void)
 {
-    // Disable weak pullup in high-z output mode
-    MXC_GPIO_CLRBIT(swclk_port, swclk_pin);
-    MXC_GPIO_CLRBIT(swdio_port, swdio_pin);
-    MXC_GPIO_CLRBIT(nreset_port, nreset_pin);
-
     // High-z output mode
-    MXC_GPIO_SETMODE(swclk_port, swclk_pin, MXC_V_GPIO_OUT_MODE_HIGH_Z_WEAK_PULLUP);
-    MXC_GPIO_SETMODE(swdio_port, swdio_pin, MXC_V_GPIO_OUT_MODE_HIGH_Z_WEAK_PULLUP);
-    MXC_GPIO_SETMODE(nreset_port, nreset_pin, MXC_V_GPIO_OUT_MODE_HIGH_Z_WEAK_PULLUP);
+    MXC_GPIO_SETMODE(swclk_port, swclk_pin, MXC_V_GPIO_OUT_MODE_NORMAL_HIGH_Z);
+    MXC_GPIO_SETMODE(swdio_port, swdio_pin, MXC_V_GPIO_OUT_MODE_NORMAL_HIGH_Z);
+    MXC_GPIO_SETMODE(nreset_port, nreset_pin, MXC_V_GPIO_OUT_MODE_NORMAL_HIGH_Z);
 }
 
 // SWCLK/TCK I/O pin -------------------------------------


### PR DESCRIPTION
When code attempted to release the ports by placing them into Hi-Z mode, it would first clear the out register (so that weak pull-up would be disabled) then made the switch to Hi-Z.  Since the signals were initially in output mode, clearing the out register caused a low pulse on the pins.  One of the pins is the RESETN line which caused an unwanted device reset.

This PR changes the code to use the "NORMAL_HI_Z" mode that the MAX32625 supports.  This mode places the pins in Hi-Z (no pull-up) regardless of the state of the out register.

See section 5.4.3 of the [MAX32625 user guide](https://www.analog.com/media/en/technical-documentation/user-guides/max32625-users-guide.pdf) for the I/O modes supported.