### PR TITLE
vfs: Force boot interface FW using start_if.act

### DIFF
--- a/source/daplink/bootloader/main_bootloader.c
+++ b/source/daplink/bootloader/main_bootloader.c
@@ -274,7 +274,7 @@ int main(void)
 
     // check for invalid app image or rst button press. Should be checksum or CRC but NVIC validation is better than nothing.
     // If the interface has set the hold in bootloader setting don't jump to app
-    if (!reset_button_pressed()
+    if ((config_ram_get_force_enter_if() || !reset_button_pressed())
             && g_board_info.target_cfg
             && validate_bin_nvic((uint8_t *)g_board_info.target_cfg->flash_regions[0].start)
             && !config_ram_get_initial_hold_in_bl()) {

--- a/source/daplink/drag-n-drop/vfs_user.c
+++ b/source/daplink/drag-n-drop/vfs_user.c
@@ -218,7 +218,8 @@ void vfs_user_file_change_handler(const vfs_filename_t filename, vfs_file_change
                         if (daplink_is_interface()) {
                             config_ram_set_hold_in_bl(true);
                         } else {
-                            // Do nothing - bootloader will go to interface by default
+                            // Force enter the interface mode regardless of the state of the RESET pin
+                            config_ram_set_force_enter_if(true);
                         }
                         break;
                     case kTestAssertActionFile:

--- a/source/daplink/settings/settings.c
+++ b/source/daplink/settings/settings.c
@@ -58,8 +58,13 @@ typedef struct __attribute__((__packed__)) cfg_ram {
     // Disable msd support
     uint8_t disable_msd;
 
-    //Add new entries from here
+    // Enable page erase
     uint8_t page_erase_enable;
+
+    // Force enter interface firmware (no checks for RESETn)
+    uint8_t force_enter_if;
+
+    //Add new entries from here
 } cfg_ram_t;
 
 // Ensure hexdump field is word aligned.
@@ -104,6 +109,7 @@ void config_init()
     memcpy(config_ram.hexdump, config_ram_copy.hexdump, sizeof(config_ram_copy.hexdump[0]) * config_ram_copy.valid_dumps);
     config_ram.disable_msd = config_ram_copy.disable_msd;
     config_ram.page_erase_enable = config_ram_copy.page_erase_enable;
+    config_ram.force_enter_if = config_ram_copy.force_enter_if;
     config_rom_init();
 }
 
@@ -252,4 +258,14 @@ void config_ram_set_page_erase(bool page_erase_enable)
 bool config_ram_get_page_erase(void)
 {
     return config_ram.page_erase_enable;
+}
+
+void config_ram_set_force_enter_if(bool force_enter)
+{
+    config_ram.force_enter_if = force_enter;
+}
+
+bool config_ram_get_force_enter_if(void)
+{
+    return config_ram.force_enter_if;
 }

--- a/source/daplink/settings/settings.h
+++ b/source/daplink/settings/settings.h
@@ -61,6 +61,8 @@ void config_ram_set_disable_msd(bool disable_msd);
 uint8_t config_ram_get_disable_msd(void);
 void config_ram_set_page_erase(bool page_erase_enable);
 bool config_ram_get_page_erase(void);
+void config_ram_set_force_enter_if(bool force_enter);
+bool config_ram_get_force_enter_if(void);
 
 // Private - should only be called from settings.c
 void config_rom_init(void);


### PR DESCRIPTION
The current behavior of the start_if.act is resetting to the bootloader and assuming the bootloader will jump to the interface firmware, without doing anything specific. On certain targets (like Kinetis), the RST signal may be held down by the target due to buggy program being downloaded to the target, causing the probe enters bootloader mode in such condition.

This patch adds another settings entry which will be set by the MSD command, and will temporarily make the bootloader ignoring the state of the RST pin, force starting the interface firmware.