### PR TITLE
dap_vendor: Buffer MSD_Write packets into 512-byte blocks.

### DIFF
--- a/source/daplink/drag-n-drop/vfs_manager.c
+++ b/source/daplink/drag-n-drop/vfs_manager.c
@@ -126,7 +126,7 @@ U32 USBD_MSC_BlockCount;
 U8 *USBD_MSC_BlockBuf;
 #endif
 
-static uint32_t usb_buffer[VFS_SECTOR_SIZE / sizeof(uint32_t)];
+uint32_t usb_buffer[VFS_SECTOR_SIZE / sizeof(uint32_t)];
 static error_t fail_reason = ERROR_SUCCESS;
 static file_transfer_state_t file_transfer_state;
 


### PR DESCRIPTION
Currently flashing a Universal Hex in "segments" or "blocks" format via WebUSB does not work.

This PR sends to the file streamer blocks of the same size as the VFS sector size, which is what `vfs_manager` does and some stream formats expect, like Universal Hex and in the future UF2.

This could have been implemented inside `file_stream` instead, but this way it mirrors what the MSC side is doing, buffering the 64 byte packets into 512-byte sectors before passing it to `vfs_manager`, which then sends it to `file_stream`.

One constrain is that DAPLink doesn't know when the last DAP.js `ID_DAP_MSD_Write` packet is sent, so we need to flush whatever is left in the buffer on `ID_DAP_MSD_Close`. So the "close" response could contain an error writing the last buffer.

There is also a memory hit, as the buffer takes 512 bytes of RAM. We could reuse the `usb_buffer` from `vfs_manager.c` (which is passed to `usbd_msc.c`, so that's where the 64-byte MSC packets are buffer into VFS sectors), not if you prefer to keep them separated. To be fair, using WebUSB flashing + MSD drag&drop at the same time will fail anyway, so probably wouldn't need to worry much about having two different components accessing the same buffer.