### PR TITLE
kl27z: Increase DAP_PACKET_COUNT to 8.

### DIFF
--- a/source/board/kl27z_bl.c
+++ b/source/board/kl27z_bl.c
@@ -40,7 +40,7 @@ static const sector_info_t sectors_info[] = {
     {DAPLINK_ROM_IF_START, 1024},
  };
 
-// kl26z128 target information
+// kl27z target information
 target_cfg_t target_device = {
     .version                    = kTargetConfigVersion,
     .sectors_info               = sectors_info,

--- a/source/board/kl27z_microbit_bl.c
+++ b/source/board/kl27z_microbit_bl.c
@@ -43,7 +43,7 @@ static const sector_info_t sectors_info[] = {
     {DAPLINK_ROM_IF_START, 1024},
  };
 
-// kl26z128 target information
+// kl27z target information
 target_cfg_t target_device = {
     .version                    = kTargetConfigVersion,
     .sectors_info               = sectors_info,

--- a/source/hic_hal/freescale/kl27z/DAP_config.h
+++ b/source/hic_hal/freescale/kl27z/DAP_config.h
@@ -95,7 +95,7 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. For devices with limited RAM or USB buffer the
 /// setting can be reduced (valid range is 1 .. 255). Change setting to 4 for High-Speed USB.
-#define DAP_PACKET_COUNT        5              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
+#define DAP_PACKET_COUNT        8              ///< Buffers: 64 = Full-Speed, 4 = High-Speed.
 
 /// Indicate that UART Serial Wire Output (SWO) trace is available.
 /// This information is returned by the command \ref DAP_Info as part of <b>Capabilities</b>.


### PR DESCRIPTION
This is to match the same DAP queue length for micro:bit V2.00, to the same length as configured in V2.2x.

This might not be needed in the end, so leaving as a draft PR first. I'm looking into speeding up WebUSB flashing, and having a longer DAP queue seems to help, but maybe not significantly.