### PR TITLE
ci: Update version of GH official actions to fix deprecation error.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Cache Python modules
       id: cache-python
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -30,7 +30,7 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Checkout source files
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
 
     - name: Cache CCache
       id:   ccache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .ccache
         key: ${{ runner.os }}-gcc-${{ matrix.gcc }}-${{ hashFiles('log.txt') }}
@@ -70,7 +70,7 @@ jobs:
         (ls -lR firmware_*; ccache -s; arm-none-eabi-gcc -v) | tee log.txt
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: firmware-dev-${{github.run_number}}
         path: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Cache Python modules
       id: cache-python
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -30,7 +30,7 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Checkout source files
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
 
     - name: Cache CCache
       id:   ccache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .ccache
         key: ${{ runner.os }}-gcc-${{ matrix.gcc }}-${{ hashFiles('log.txt') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
         release: ${{ matrix.gcc }}
 
     - name: Cache Python modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~\AppData\Local\pip\Cache
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -24,7 +24,7 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Checkout source files
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
       shell: cmd
 
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: firmware-dev-${{github.run_number}}
         path: |


### PR DESCRIPTION
`actions/upload-artifact@v3` stopped working on January 30th 2025: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/a80f3abc-6981-4ffb-9fe4-bf59a1b6ce8e" />

Also took the opportunity to update the other GH actions to the latest version.