### PR TITLE
Support alternate SWD pins via vendor command

### DIFF
--- a/source/daplink/cmsis-dap/DAP_vendor.c.orig
+++ b/source/daplink/cmsis-dap/DAP_vendor.c.orig
@@ -41,7 +41,6 @@
 #include "util.h"
 #include <string.h>
 #include "daplink_vendor_commands.h"
-#include "daplink_swd_dynamic_pins.h"
 
 #ifdef DRAG_N_DROP_SUPPORT
 #include "file_stream.h"
@@ -234,19 +233,7 @@ uint32_t DAP_ProcessVendorCommand(const uint8_t *request, uint8_t *response) {
     case ID_DAP_Vendor20: break;
     case ID_DAP_Vendor21: break;
     case ID_DAP_Vendor22: break;
-    case ID_DAP_SWDConfigurePins: {
-        // Select SWD output port configuration.
-        const int pin_set_as_int = (int)*request;
-        if (pin_set_as_int > (int)SWD_PIN_SET_MAX_ALLOWED) {
-            // Report invalid selection with 0xFF.
-            *response = 0xFF;
-        } else {
-            *response =
-                (uint8_t)swd_configure_pins((swd_pin_set_t)pin_set_as_int);
-        }
-        num += (1 << 16) | 1;
-        break;
-    }
+    case ID_DAP_Vendor23: break;
     case ID_DAP_Vendor24: break;
     case ID_DAP_Vendor25: break;
     case ID_DAP_Vendor26: break;

--- a/source/daplink/cmsis-dap/daplink_swd_dynamic_pins.c
+++ b/source/daplink/cmsis-dap/daplink_swd_dynamic_pins.c
@@ -1,0 +1,17 @@
+#include "daplink_swd_dynamic_pins.h"
+
+static swd_pin_set_t latched_configured_pins = SWD_PIN_SET_DEFAULT;
+static swd_pin_set_t pending_configured_pins = SWD_PIN_SET_DEFAULT;
+
+swd_pin_set_t swd_configure_pins(swd_pin_set_t pin_set) {
+    pending_configured_pins = pin_set;
+    return latched_configured_pins;
+}
+
+swd_pin_set_t swd_get_configured_pins(void) {
+    return latched_configured_pins;
+}
+
+void swd_configure_latch_pins(void) {
+    latched_configured_pins = pending_configured_pins;
+}

--- a/source/daplink/cmsis-dap/daplink_swd_dynamic_pins.h
+++ b/source/daplink/cmsis-dap/daplink_swd_dynamic_pins.h
@@ -1,0 +1,22 @@
+#ifndef DAPLINK_SWD_DYNAMIC_PINS_H_
+#define DAPLINK_SWD_DYNAMIC_PINS_H_
+
+typedef enum {
+    SWD_PIN_SET_DEFAULT,
+    SWD_PIN_SET_ALT_1,
+
+    SWD_PIN_SET_MAX_ALLOWED = SWD_PIN_SET_ALT_1,
+} swd_pin_set_t;
+
+// Stages the provided `pin_set` for latching on the next target connection.
+//
+// Returns the currently latched `swd_pin_set_t`.
+swd_pin_set_t swd_configure_pins(swd_pin_set_t pin_set);
+
+// Gets the currently latched `swd_pin_set_t`.
+swd_pin_set_t swd_get_configured_pins(void);
+
+// Latches the last configured `swd_pin_set_t` choice.
+void swd_configure_latch_pins(void);
+
+#endif // DAPLINK_SWD_DYNAMIC_PINS_H_

--- a/source/daplink/cmsis-dap/daplink_vendor_commands.h
+++ b/source/daplink/cmsis-dap/daplink_vendor_commands.h
@@ -35,5 +35,6 @@
 #define ID_DAP_MSD_Close                ID_DAP_Vendor11
 #define ID_DAP_MSD_Write                ID_DAP_Vendor12
 #define ID_DAP_SelectEraseMode          ID_DAP_Vendor13
+#define ID_DAP_SWDConfigurePins         ID_DAP_Vendor23
 //@}
 

--- a/source/hic_hal/atmel/sam3u2c/DAP_config.h
+++ b/source/hic_hal/atmel/sam3u2c/DAP_config.h
@@ -23,6 +23,7 @@
 #define __DAP_CONFIG_H__
 
 #include "IO_Config.h"
+#include "daplink_swd_dynamic_pins.h"
 
 //**************************************************************************************************
 /**
@@ -198,23 +199,49 @@ __STATIC_INLINE void PORT_SWD_SETUP(void)
 {
     PMC->PMC_PCER0 = (1 << 10) | (1 << 11) | (1 << 12);  // Enable clock for all PIOs
 
-    PIN_nRESET_PORT->PIO_MDDR = PIN_nRESET; // Disable multi drive
-    PIN_nRESET_PORT->PIO_PUER = PIN_nRESET; // pull-up enable
-    PIN_nRESET_PORT->PIO_SODR = PIN_nRESET; // HIGH
-    PIN_nRESET_PORT->PIO_OER  = PIN_nRESET; // output
-    PIN_nRESET_PORT->PIO_PER  = PIN_nRESET; // GPIO control
+    swd_configure_latch_pins();
 
-    PIN_SWCLK_PORT->PIO_MDDR = PIN_SWCLK; // Disable multi drive
-    PIN_SWCLK_PORT->PIO_PUER = PIN_SWCLK; // pull-up enable
-    PIN_SWCLK_PORT->PIO_SODR = PIN_SWCLK; // HIGH
-    PIN_SWCLK_PORT->PIO_OER  = PIN_SWCLK; // output
-    PIN_SWCLK_PORT->PIO_PER  = PIN_SWCLK; // GPIO control
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_nRESET_PORT_ALT_1->PIO_MDER = PIN_nRESET_ALT_1; // Enable multi drive (open-drain on nRST)
+            PIN_nRESET_PORT_ALT_1->PIO_PUER = PIN_nRESET_ALT_1; // pull-up enable
+            PIN_nRESET_PORT_ALT_1->PIO_SODR = PIN_nRESET_ALT_1; // HIGH
+            PIN_nRESET_PORT_ALT_1->PIO_OER  = PIN_nRESET_ALT_1; // output
+            PIN_nRESET_PORT_ALT_1->PIO_PER  = PIN_nRESET_ALT_1; // GPIO control
 
-    PIN_SWDIO_PORT->PIO_MDDR = PIN_SWDIO; // Disable multi drive
-    PIN_SWDIO_PORT->PIO_PUER = PIN_SWDIO; // pull-up enable
-    PIN_SWDIO_PORT->PIO_SODR = PIN_SWDIO; // HIGH
-    PIN_SWDIO_PORT->PIO_OER  = PIN_SWDIO; // output
-    PIN_SWDIO_PORT->PIO_PER  = PIN_SWDIO; // GPIO control
+            PIN_SWCLK_PORT_ALT_1->PIO_MDDR = PIN_SWCLK_ALT_1; // Disable multi drive
+            PIN_SWCLK_PORT_ALT_1->PIO_PUER = PIN_SWCLK_ALT_1; // pull-up enable
+            PIN_SWCLK_PORT_ALT_1->PIO_SODR = PIN_SWCLK_ALT_1; // HIGH
+            PIN_SWCLK_PORT_ALT_1->PIO_OER  = PIN_SWCLK_ALT_1; // output
+            PIN_SWCLK_PORT_ALT_1->PIO_PER  = PIN_SWCLK_ALT_1; // GPIO control
+
+            PIN_SWDIO_PORT_ALT_1->PIO_MDDR = PIN_SWDIO_ALT_1; // Disable multi drive
+            PIN_SWDIO_PORT_ALT_1->PIO_PUER = PIN_SWDIO_ALT_1; // pull-up enable
+            PIN_SWDIO_PORT_ALT_1->PIO_SODR = PIN_SWDIO_ALT_1; // HIGH
+            PIN_SWDIO_PORT_ALT_1->PIO_OER  = PIN_SWDIO_ALT_1; // output
+            PIN_SWDIO_PORT_ALT_1->PIO_PER  = PIN_SWDIO_ALT_1; // GPIO control
+            break;
+
+        default:
+            PIN_nRESET_PORT_DEFAULT->PIO_MDER = PIN_nRESET_DEFAULT; // Enable multi drive (open-drain on nRST)
+            PIN_nRESET_PORT_DEFAULT->PIO_PUER = PIN_nRESET_DEFAULT; // pull-up enable
+            PIN_nRESET_PORT_DEFAULT->PIO_SODR = PIN_nRESET_DEFAULT; // HIGH
+            PIN_nRESET_PORT_DEFAULT->PIO_OER  = PIN_nRESET_DEFAULT; // output
+            PIN_nRESET_PORT_DEFAULT->PIO_PER  = PIN_nRESET_DEFAULT; // GPIO control
+
+            PIN_SWCLK_PORT_DEFAULT->PIO_MDDR = PIN_SWCLK_DEFAULT; // Disable multi drive
+            PIN_SWCLK_PORT_DEFAULT->PIO_PUER = PIN_SWCLK_DEFAULT; // pull-up enable
+            PIN_SWCLK_PORT_DEFAULT->PIO_SODR = PIN_SWCLK_DEFAULT; // HIGH
+            PIN_SWCLK_PORT_DEFAULT->PIO_OER  = PIN_SWCLK_DEFAULT; // output
+            PIN_SWCLK_PORT_DEFAULT->PIO_PER  = PIN_SWCLK_DEFAULT; // GPIO control
+
+            PIN_SWDIO_PORT_DEFAULT->PIO_MDDR = PIN_SWDIO_DEFAULT; // Disable multi drive
+            PIN_SWDIO_PORT_DEFAULT->PIO_PUER = PIN_SWDIO_DEFAULT; // pull-up enable
+            PIN_SWDIO_PORT_DEFAULT->PIO_SODR = PIN_SWDIO_DEFAULT; // HIGH
+            PIN_SWDIO_PORT_DEFAULT->PIO_OER  = PIN_SWDIO_DEFAULT; // output
+            PIN_SWDIO_PORT_DEFAULT->PIO_PER  = PIN_SWDIO_DEFAULT; // GPIO control
+            break;
+    }
 }
 
 /** Disable JTAG/SWD I/O Pins.
@@ -223,18 +250,34 @@ Disables the DAP Hardware I/O pins which configures:
 */
 __STATIC_INLINE void PORT_OFF(void)
 {
-    PIN_nRESET_PORT->PIO_PUER = PIN_nRESET; // pull-up enable
-    PIN_nRESET_PORT->PIO_ODR  = PIN_nRESET; // input
-    PIN_nRESET_PORT->PIO_PER  = PIN_nRESET; // GPIO control
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_nRESET_PORT_ALT_1->PIO_PUER = PIN_nRESET_ALT_1; // pull-up enable
+            PIN_nRESET_PORT_ALT_1->PIO_ODR  = PIN_nRESET_ALT_1; // input
+            PIN_nRESET_PORT_ALT_1->PIO_PER  = PIN_nRESET_ALT_1; // GPIO control
 
-    PIN_SWCLK_PORT->PIO_PUER = PIN_SWCLK; // pull-up enable
-    PIN_SWCLK_PORT->PIO_ODR  = PIN_SWCLK; // input
-    PIN_SWCLK_PORT->PIO_PER  = PIN_SWCLK; // GPIO control
+            PIN_SWCLK_PORT_ALT_1->PIO_PUER = PIN_SWCLK_ALT_1; // pull-up enable
+            PIN_SWCLK_PORT_ALT_1->PIO_ODR  = PIN_SWCLK_ALT_1; // input
+            PIN_SWCLK_PORT_ALT_1->PIO_PER  = PIN_SWCLK_ALT_1; // GPIO control
 
-    PIN_SWDIO_PORT->PIO_PUER = PIN_SWDIO; // pull-up enable
-    PIN_SWDIO_PORT->PIO_ODR  = PIN_SWDIO; // input
-    PIN_SWDIO_PORT->PIO_PER  = PIN_SWDIO; // GPIO control
+            PIN_SWDIO_PORT_ALT_1->PIO_PUER = PIN_SWDIO_ALT_1; // pull-up enable
+            PIN_SWDIO_PORT_ALT_1->PIO_ODR  = PIN_SWDIO_ALT_1; // input
+            PIN_SWDIO_PORT_ALT_1->PIO_PER  = PIN_SWDIO_ALT_1; // GPIO control
+            break;
+        default:
+            PIN_nRESET_PORT_DEFAULT->PIO_PUER = PIN_nRESET_DEFAULT; // pull-up enable
+            PIN_nRESET_PORT_DEFAULT->PIO_ODR  = PIN_nRESET_DEFAULT; // input
+            PIN_nRESET_PORT_DEFAULT->PIO_PER  = PIN_nRESET_DEFAULT; // GPIO control
 
+            PIN_SWCLK_PORT_DEFAULT->PIO_PUER = PIN_SWCLK_DEFAULT; // pull-up enable
+            PIN_SWCLK_PORT_DEFAULT->PIO_ODR  = PIN_SWCLK_DEFAULT; // input
+            PIN_SWCLK_PORT_DEFAULT->PIO_PER  = PIN_SWCLK_DEFAULT; // GPIO control
+
+            PIN_SWDIO_PORT_DEFAULT->PIO_PUER = PIN_SWDIO_DEFAULT; // pull-up enable
+            PIN_SWDIO_PORT_DEFAULT->PIO_ODR  = PIN_SWDIO_DEFAULT; // input
+            PIN_SWDIO_PORT_DEFAULT->PIO_PER  = PIN_SWDIO_DEFAULT; // GPIO control
+            break;
+    }
 }
 
 // SWCLK/TCK I/O pin -------------------------------------
@@ -244,7 +287,12 @@ __STATIC_INLINE void PORT_OFF(void)
 */
 __STATIC_FORCEINLINE uint32_t PIN_SWCLK_TCK_IN(void)
 {
-    return ((PIN_SWCLK_PORT->PIO_PDSR >> PIN_SWCLK_BIT) & 1);
+    switch(swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            return (PIN_SWCLK_PORT_ALT_1->PIO_PDSR >> PIN_SWCLK_BIT_ALT_1) & 1;
+        default:
+            return (PIN_SWCLK_PORT_DEFAULT->PIO_PDSR >> PIN_SWCLK_BIT_DEFAULT) & 1;
+    }
 }
 
 /** SWCLK/TCK I/O pin: Set Output to High.
@@ -252,7 +300,14 @@ Set the SWCLK/TCK DAP hardware I/O pin to high level.
 */
 __STATIC_FORCEINLINE void     PIN_SWCLK_TCK_SET(void)
 {
-    PIN_SWCLK_PORT->PIO_SODR = PIN_SWCLK;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_SWCLK_PORT_ALT_1->PIO_SODR = PIN_SWCLK_ALT_1;
+            break;
+        default:
+            PIN_SWCLK_PORT_DEFAULT->PIO_SODR = PIN_SWCLK_DEFAULT;
+            break;
+    }
 }
 
 /** SWCLK/TCK I/O pin: Set Output to Low.
@@ -260,7 +315,14 @@ Set the SWCLK/TCK DAP hardware I/O pin to low level.
 */
 __STATIC_FORCEINLINE void     PIN_SWCLK_TCK_CLR(void)
 {
-    PIN_SWCLK_PORT->PIO_CODR = PIN_SWCLK;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_SWCLK_PORT_ALT_1->PIO_CODR = PIN_SWCLK_ALT_1;
+            break;
+        default:
+            PIN_SWCLK_PORT_DEFAULT->PIO_CODR = PIN_SWCLK_DEFAULT;
+            break;
+    }
 }
 
 // SWDIO/TMS Pin I/O --------------------------------------
@@ -270,7 +332,12 @@ __STATIC_FORCEINLINE void     PIN_SWCLK_TCK_CLR(void)
 */
 __STATIC_FORCEINLINE uint32_t PIN_SWDIO_TMS_IN(void)
 {
-    return ((PIN_SWDIO_PORT->PIO_PDSR >> PIN_SWDIO_BIT) & 1);
+    switch(swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            return (PIN_SWDIO_PORT_ALT_1->PIO_PDSR >> PIN_SWDIO_BIT_ALT_1) & 1;
+        default:
+            return (PIN_SWDIO_PORT_DEFAULT->PIO_PDSR >> PIN_SWDIO_BIT_DEFAULT) & 1;
+    }
 }
 
 /** SWDIO/TMS I/O pin: Set Output to High.
@@ -278,7 +345,14 @@ Set the SWDIO/TMS DAP hardware I/O pin to high level.
 */
 __STATIC_FORCEINLINE void     PIN_SWDIO_TMS_SET(void)
 {
-    PIN_SWDIO_PORT->PIO_SODR = PIN_SWDIO;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_SWDIO_PORT_ALT_1->PIO_SODR = PIN_SWDIO_ALT_1;
+            break;
+        default:
+            PIN_SWDIO_PORT_DEFAULT->PIO_SODR = PIN_SWDIO_DEFAULT;
+            break;
+    }
 }
 
 /** SWDIO/TMS I/O pin: Set Output to Low.
@@ -286,7 +360,14 @@ Set the SWDIO/TMS DAP hardware I/O pin to low level.
 */
 __STATIC_FORCEINLINE void     PIN_SWDIO_TMS_CLR(void)
 {
-    PIN_SWDIO_PORT->PIO_CODR = PIN_SWDIO;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_SWDIO_PORT_ALT_1->PIO_CODR = PIN_SWDIO_ALT_1;
+            break;
+        default:
+            PIN_SWDIO_PORT_DEFAULT->PIO_CODR = PIN_SWDIO_DEFAULT;
+            break;
+    }
 }
 
 /** SWDIO I/O pin: Get Input (used in SWD mode only).
@@ -294,7 +375,12 @@ __STATIC_FORCEINLINE void     PIN_SWDIO_TMS_CLR(void)
 */
 __STATIC_FORCEINLINE uint32_t PIN_SWDIO_IN(void)
 {
-    return ((PIN_SWDIO_PORT->PIO_PDSR >> PIN_SWDIO_BIT) & 1);
+    switch(swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            return (PIN_SWDIO_PORT_ALT_1->PIO_PDSR >> PIN_SWDIO_BIT_ALT_1) & 1;
+        default:
+            return (PIN_SWDIO_PORT_DEFAULT->PIO_PDSR >> PIN_SWDIO_BIT_DEFAULT) & 1;
+    }
 }
 
 /** SWDIO I/O pin: Set Output (used in SWD mode only).
@@ -302,11 +388,21 @@ __STATIC_FORCEINLINE uint32_t PIN_SWDIO_IN(void)
 */
 __STATIC_FORCEINLINE void     PIN_SWDIO_OUT(uint32_t bit)
 {
-    if (bit & 1) {
-        PIN_SWDIO_PORT->PIO_SODR = PIN_SWDIO;
-
-    } else {
-        PIN_SWDIO_PORT->PIO_CODR = PIN_SWDIO;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            if (bit & 1) {
+                PIN_SWDIO_PORT_ALT_1->PIO_SODR = PIN_SWDIO_ALT_1;
+            } else {
+                PIN_SWDIO_PORT_ALT_1->PIO_CODR = PIN_SWDIO_ALT_1;
+            }
+            break;
+        default:
+            if (bit & 1) {
+                PIN_SWDIO_PORT_DEFAULT->PIO_SODR = PIN_SWDIO_DEFAULT;
+            } else {
+                PIN_SWDIO_PORT_DEFAULT->PIO_CODR = PIN_SWDIO_DEFAULT;
+            }
+            break;
     }
 }
 
@@ -316,7 +412,14 @@ called prior \ref PIN_SWDIO_OUT function calls.
 */
 __STATIC_FORCEINLINE void     PIN_SWDIO_OUT_ENABLE(void)
 {
-    PIN_SWDIO_PORT->PIO_OER = PIN_SWDIO;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_SWDIO_PORT_ALT_1->PIO_OER = PIN_SWDIO_ALT_1;
+            break;
+        default:
+            PIN_SWDIO_PORT_DEFAULT->PIO_OER = PIN_SWDIO_DEFAULT;
+            break;
+    }
 }
 
 /** SWDIO I/O pin: Switch to Input mode (used in SWD mode only).
@@ -325,7 +428,14 @@ called prior \ref PIN_SWDIO_IN function calls.
 */
 __STATIC_FORCEINLINE void     PIN_SWDIO_OUT_DISABLE(void)
 {
-    PIN_SWDIO_PORT->PIO_ODR = PIN_SWDIO;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            PIN_SWDIO_PORT_ALT_1->PIO_ODR = PIN_SWDIO_ALT_1;
+            break;
+        default:
+            PIN_SWDIO_PORT_DEFAULT->PIO_ODR = PIN_SWDIO_DEFAULT;
+            break;
+    }
 }
 
 
@@ -386,7 +496,12 @@ __STATIC_FORCEINLINE void     PIN_nTRST_OUT(uint32_t bit)
 */
 __STATIC_FORCEINLINE uint32_t PIN_nRESET_IN(void)
 {
-    return ((PIN_nRESET_PORT->PIO_PDSR >> PIN_nRESET_BIT) & 1);
+    switch(swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            return (PIN_nRESET_PORT_ALT_1->PIO_PDSR >> PIN_nRESET_BIT_ALT_1) & 1;
+        default:
+            return (PIN_nRESET_PORT_DEFAULT->PIO_PDSR >> PIN_nRESET_BIT_DEFAULT) & 1;
+    }
 }
 
 /** nRESET I/O pin: Set Output.
@@ -428,15 +543,26 @@ __STATIC_FORCEINLINE void     PIN_nRESET_OUT(uint32_t bit)
         PIN_SWCLK_PORT->PIO_CODR = PIN_SWCLK;
         osDelay(1);
     }
+#error "NLK: Not using nRF51822AA"
 }
 #else
 __STATIC_FORCEINLINE void     PIN_nRESET_OUT(uint32_t bit)
 {
-    if (bit & 1) {
-        PIN_nRESET_PORT->PIO_SODR = PIN_nRESET;
-
-    } else {
-        PIN_nRESET_PORT->PIO_CODR = PIN_nRESET;
+    switch (swd_get_configured_pins()) {
+        case SWD_PIN_SET_ALT_1:
+            if (bit & 1) {
+                PIN_nRESET_PORT_ALT_1->PIO_SODR = PIN_nRESET_ALT_1;
+            } else {
+                PIN_nRESET_PORT_ALT_1->PIO_CODR = PIN_nRESET_ALT_1;
+            }
+            break;
+        default:
+            if (bit & 1) {
+                PIN_nRESET_PORT_DEFAULT->PIO_SODR = PIN_nRESET_DEFAULT;
+            } else {
+                PIN_nRESET_PORT_DEFAULT->PIO_CODR = PIN_nRESET_DEFAULT;
+            }
+            break;
     }
 }
 #endif

--- a/source/hic_hal/atmel/sam3u2c/IO_Config.h
+++ b/source/hic_hal/atmel/sam3u2c/IO_Config.h
@@ -58,20 +58,43 @@ COMPILER_ASSERT(DAPLINK_HIC_ID == DAPLINK_HIC_ID_SAM3U2C);
 #define PIN_RESET_IN_FWRD_BIT   25
 #define PIN_RESET_IN_FWRD       (1UL << PIN_RESET_IN_FWRD_BIT)
 
+//
+// PIN CONFIGURATIONS FOR SWD
+//
+
+// DEFAULT CONFIG
+//
 // nRESET OUT Pin
-#define PIN_nRESET_PORT         PIOA
-#define PIN_nRESET_BIT          4
-#define PIN_nRESET              (1UL << PIN_nRESET_BIT)
+#define PIN_nRESET_PORT_DEFAULT PIOA
+#define PIN_nRESET_BIT_DEFAULT  4
+#define PIN_nRESET_DEFAULT      (1UL << PIN_nRESET_BIT_DEFAULT)
 
 // SWCLK/TCK Pin
-#define PIN_SWCLK_PORT          PIOA
-#define PIN_SWCLK_BIT           17
-#define PIN_SWCLK               (1UL << PIN_SWCLK_BIT)
+#define PIN_SWCLK_PORT_DEFAULT  PIOA
+#define PIN_SWCLK_BIT_DEFAULT   17
+#define PIN_SWCLK_DEFAULT       (1UL << PIN_SWCLK_BIT_DEFAULT)
 
 // SWDIO/TMS In/Out Pin
-#define PIN_SWDIO_PORT          PIOA
-#define PIN_SWDIO_BIT           18
-#define PIN_SWDIO               (1UL << PIN_SWDIO_BIT)
+#define PIN_SWDIO_PORT_DEFAULT  PIOA
+#define PIN_SWDIO_BIT_DEFAULT   18
+#define PIN_SWDIO_DEFAULT       (1UL << PIN_SWDIO_BIT_DEFAULT)
+
+// ALT_1 CONFIG
+//
+// nRESET OUT Pin
+#define PIN_nRESET_PORT_ALT_1 PIOA
+#define PIN_nRESET_BIT_ALT_1  3
+#define PIN_nRESET_ALT_1      (1UL << PIN_nRESET_BIT_ALT_1)
+
+// SWCLK/TCK Pin
+#define PIN_SWCLK_PORT_ALT_1  PIOA
+#define PIN_SWCLK_BIT_ALT_1   22
+#define PIN_SWCLK_ALT_1       (1UL << PIN_SWCLK_BIT_ALT_1)
+
+// SWDIO/TMS In/Out Pin
+#define PIN_SWDIO_PORT_ALT_1  PIOA
+#define PIN_SWDIO_BIT_ALT_1   15
+#define PIN_SWDIO_ALT_1       (1UL << PIN_SWDIO_BIT_ALT_1)
 
 // TDI Pin - Not used
 


### PR DESCRIPTION
Hi there, we have found it useful to use multiple sets of SWD pins with our ATSAM3U2C-based debug probes in our HITL setup, where we have multiple targets wired up to the same HIC to save on system cost. This feature allows using a vendor command to configure which SWD pins are used by the HIC. We can't talk to multiple targets at the same time (SWD pin selection is mutually exclusive) but this at least allows talking to one at a time without requiring an external multiplexer or changing the copper.

This could probably also be ported to other HICs; we implemented support only on ATSAM3U2C.