### PR TITLE
hic: DAP_PACKET_SIZE must be 64 for FS USB HICs (fixes #1105)

### DIFF
--- a/source/hic_hal/freescale/kl26z/DAP_config.h
+++ b/source/hic_hal/freescale/kl26z/DAP_config.h
@@ -84,11 +84,7 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
-#ifndef HID_ENDPOINT            //HID end points currently set limits to 64
-#define DAP_PACKET_SIZE         512              ///< Specifies Packet Size in bytes.
-#else
 #define DAP_PACKET_SIZE         64              ///< Specifies Packet Size in bytes.
-#endif
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the

--- a/source/hic_hal/freescale/kl27z/DAP_config.h
+++ b/source/hic_hal/freescale/kl27z/DAP_config.h
@@ -85,11 +85,7 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
-#ifndef HID_ENDPOINT            //HID end points currently set limits to 64
-#define DAP_PACKET_SIZE         512              ///< Specifies Packet Size in bytes.
-#else
 #define DAP_PACKET_SIZE         64              ///< Specifies Packet Size in bytes.
-#endif
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the

--- a/source/hic_hal/maxim/max32620/DAP_config.h
+++ b/source/hic_hal/maxim/max32620/DAP_config.h
@@ -80,11 +80,7 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
-#ifndef HID_ENDPOINT            //HID end points currently set limits to 64
-#define DAP_PACKET_SIZE         512              ///< Specifies Packet Size in bytes.
-#else
 #define DAP_PACKET_SIZE         64              ///< Specifies Packet Size in bytes.
-#endif
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the

--- a/source/hic_hal/maxim/max32625/DAP_config.h
+++ b/source/hic_hal/maxim/max32625/DAP_config.h
@@ -80,11 +80,7 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
-#ifndef HID_ENDPOINT            //HID end points currently set limits to 64
-#define DAP_PACKET_SIZE         512              ///< Specifies Packet Size in bytes.
-#else
 #define DAP_PACKET_SIZE         64              ///< Specifies Packet Size in bytes.
-#endif
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the

--- a/source/hic_hal/stm32/stm32f103xb/DAP_config.h
+++ b/source/hic_hal/stm32/stm32f103xb/DAP_config.h
@@ -76,11 +76,7 @@ This information includes:
 /// This configuration settings is used to optimize the communication performance with the
 /// debugger and depends on the USB peripheral. Typical vales are 64 for Full-speed USB HID or WinUSB,
 /// 1024 for High-speed USB HID and 512 for High-speed USB WinUSB.
-#ifndef HID_ENDPOINT            //HID end points currently set limits to 64
-#define DAP_PACKET_SIZE         512              ///< Specifies Packet Size in bytes.
-#else
 #define DAP_PACKET_SIZE         64              ///< Specifies Packet Size in bytes.
-#endif
 
 /// Maximum Package Buffers for Command and Response data.
 /// This configuration settings is used to optimize the communication performance with the


### PR DESCRIPTION
All HICs that only support FS USB should only have 64 bytes as DAP_PACKET_SIZE value.