### PR TITLE
Fix linking when building without WebUSB support

### DIFF
--- a/source/usb/hid/usbd_core_hid.c
+++ b/source/usb/hid/usbd_core_hid.c
@@ -35,8 +35,11 @@ __WEAK BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
 {
     switch (USBD_SetupPacket.wValueH) {
         case HID_HID_DESCRIPTOR_TYPE:
-            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num &&
-                USBD_SetupPacket.wIndexL != usbd_webusb_if_num) {
+            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num
+#if    (USBD_WEBUSB_ENABLE)
+                && USBD_SetupPacket.wIndexL != usbd_webusb_if_num
+#endif
+            ) {
                 return (__FALSE);
             }
 
@@ -55,8 +58,11 @@ __WEAK BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
             break;
 
         case HID_REPORT_DESCRIPTOR_TYPE:
-            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num &&
-                USBD_SetupPacket.wIndexL != usbd_webusb_if_num) {
+            if (USBD_SetupPacket.wIndexL != usbd_hid_if_num
+#if    (USBD_WEBUSB_ENABLE)
+                && USBD_SetupPacket.wIndexL != usbd_webusb_if_num
+#endif
+             ) {
                 return (__FALSE);
             }
 
@@ -83,8 +89,11 @@ __WEAK BOOL USBD_ReqGetDescriptor_HID(U8 **pD, U32 *len)
 
 __WEAK BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
 {
-    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num ||
-        USBD_SetupPacket.wIndexL == usbd_webusb_if_num) {
+    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num
+#if    (USBD_WEBUSB_ENABLE)
+        || USBD_SetupPacket.wIndexL == usbd_webusb_if_num
+#endif
+       ) {
         switch (USBD_SetupPacket.bRequest) {
             case HID_REQUEST_GET_REPORT:
                 if (USBD_HID_GetReport()) {
@@ -157,8 +166,11 @@ __WEAK BOOL USBD_EndPoint0_Setup_HID_ReqToIF(void)
 
 __WEAK BOOL USBD_EndPoint0_Out_HID_ReqToIF(void)
 {
-    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num ||
-        USBD_SetupPacket.wIndexL == usbd_webusb_if_num) {
+    if (USBD_SetupPacket.wIndexL == usbd_hid_if_num
+#if    (USBD_WEBUSB_ENABLE)
+        || USBD_SetupPacket.wIndexL == usbd_webusb_if_num
+#endif
+        ) {
         switch (USBD_SetupPacket.bRequest) {
             case HID_REQUEST_SET_REPORT:
                 if (USBD_HID_SetReport()) {

--- a/source/usb/usb_lib.c
+++ b/source/usb/usb_lib.c
@@ -136,8 +136,6 @@ U8 USBD_CDC_ACM_NotifyBuf[10];
 #if    (USBD_WEBUSB_ENABLE)
 U8 usbd_webusb_if_num; //assigned during runtime init
 const U8 usbd_webusb_vendor_code = USBD_WEBUSB_VENDOR_CODE;
-#else
-const U8 usbd_webusb_vendor_code;
 #endif
 
 #if    (USBD_WINUSB_ENABLE)


### PR DESCRIPTION
If `records/usb/usb-webusb.yaml` is removed from `projects.yaml` then builds will fail with linking errors like:

```
/usr/lib/gcc/arm-none-eabi/14.2.1/../../../arm-none-eabi/bin/ld: build/usbd_core_hid.o: in function `USBD_ReqGetDescriptor_HID':
/tmp/DAPLink/projectfiles/make_gcc_arm/stm32f103xb_stm32h743zi_if/../../../source/usb/hid/usbd_core_hid.c:64:(.text.USBD_ReqGetDescriptor_HID+0x78): undefined reference to `usbd_webusb_if_num'
/usr/lib/gcc/arm-none-eabi/14.2.1/../../../arm-none-eabi/bin/ld: build/usbd_core_hid.o: in function `USBD_EndPoint0_Setup_HID_ReqToIF':
/tmp/DAPLink/projectfiles/make_gcc_arm/stm32f103xb_stm32h743zi_if/../../../source/usb/hid/usbd_core_hid.c:148:(.text.USBD_EndPoint0_Setup_HID_ReqToIF+0x9c): undefined reference to `usbd_webusb_if_num'
/usr/lib/gcc/arm-none-eabi/14.2.1/../../../arm-none-eabi/bin/ld: build/usbd_core_hid.o: in function `USBD_EndPoint0_Out_HID_ReqToIF':
/tmp/DAPLink/projectfiles/make_gcc_arm/stm32f103xb_stm32h743zi_if/../../../source/usb/hid/usbd_core_hid.c:166:(.text.USBD_EndPoint0_Out_HID_ReqToIF+0x38): undefined reference to `usbd_webusb_if_num'
```

The reason for this is because `usbd_core_hid.c` still checks for `usbd_webusb_if_num` even when `USBD_WEBUSB_ENABLE` is not defined.  This PR addresses this issue, as well as eliminating an unnecessary definition of `usbd_webusb_vendor_code` when `USBD_WEBUSB_ENABLE` is not defined.