### PR TITLE
[HIC]Add support for the NXP LPC845 Breakout board

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -410,6 +410,10 @@ projects:
         - *module_if
         - *module_hic_lpc11u35
         - records/board/lpc824xpresso.yaml
+    lpc11u35_lpc845breakout_if:
+        - *module_if
+        - *module_hic_lpc11u35
+        - records/board/lpc845breakout.yaml
     lpc11u35_mini_iot_lpc54018_if:
         - *module_if
         - *module_hic_lpc11u35

--- a/records/board/lpc845breakout.yaml
+++ b/records/board/lpc845breakout.yaml
@@ -1,0 +1,6 @@
+common:
+    sources:
+        board:
+            - source/board/lpc845breakout.c
+        family:
+            - source/family/nxp/lpc845/target.c

--- a/source/board/lpc845breakout.c
+++ b/source/board/lpc845breakout.c
@@ -1,0 +1,32 @@
+/**
+ * @file    lpc845breakout.c
+ * @brief   board ID for the NXP LPC845 Breakout board
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_family.h"
+#include "target_board.h"
+
+const board_info_t g_board_info = {
+    .info_version = kBoardInfoVersion,
+    .board_id = "D002",
+    .family_id = kStub_HWReset_FamilyID,
+    .target_cfg = &target_device,
+    .board_vendor = "NXP",
+    .board_name = "LPC845BREAKOUT",
+};

--- a/source/family/nxp/lpc845/flash_blob.c
+++ b/source/family/nxp/lpc845/flash_blob.c
@@ -1,0 +1,82 @@
+/* Flash algorithm for LPC84x IAP 64kB Flash
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2026 Arm Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Generated from 'LPC84x_64.FLM' (LPC84x IAP 64kB Flash)
+// Originating from 'Keil.LPC800_DFP.1.10.2.pack'
+// digest = 7456044e6eab538adb83363713d1bf756d11efc6acce4f93e184587a8b8b97bc, file size = 12556
+// algo version = 0x101, algo size = 356 (0x164)
+static const uint32_t LPC84x_64_flash_prog_blob[] = {
+    0xe7fdbe00,
+    0x47700a80, 0x48474948, 0x60084449, 0x22004847, 0x21016102, 0x61426141, 0x61816141, 0x20024943,
+    0x70083940, 0x47704610, 0x47702000, 0x4c40b5f8, 0x444c2032, 0x25004621, 0xc461263f, 0x483c3114,
+    0x44484f3c, 0x91003c0c, 0x696047b8, 0xd10d2800, 0xc4612034, 0x44484834, 0x60206800, 0x3c0c4834,
+    0x99004448, 0x696047b8, 0xd0002800, 0xbdf82001, 0x4d2fb5f8, 0x20320a84, 0xc511444d, 0x310c4629,
+    0x4e2c482b, 0x460f602c, 0x3d084448, 0x696847b0, 0xd10e2800, 0xc5112034, 0x602c4823, 0x68004448,
+    0x48236068, 0x44484639, 0x47b03d08, 0x28006968, 0x2001d000, 0xb5f8bdf8, 0x00064614, 0xcc03d10e,
+    0x18406862, 0x18896821, 0x68a11840, 0x68e11840, 0x69211840, 0x42401840, 0x3c086160, 0x0ab04d14,
+    0x2132444d, 0x60296068, 0x462960a8, 0x4f113114, 0x91004628, 0x696847b8, 0xd1112800, 0x60ac2033,
+    0x20ffc541, 0x60683001, 0x44484807, 0x60a86800, 0x3d084807, 0x99004448, 0x696847b8, 0xd0002800,
+    0xbdf82001, 0x00002ee0, 0x00000004, 0x40048040, 0x00000008, 0x0f001ff1, 0x00000000, 0x00000000,
+    0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000
+};
+
+// Start address of flash
+static const uint32_t flash_start = 0x00000000;
+// Size of flash
+static const uint32_t flash_size = 0x00010000;
+
+/**
+* List of start and size for each size of flash sector - even indexes are start, odd are size
+* The size will apply to all sectors between the listed address and the next address
+* in the list.
+* The last pair in the list will have sectors starting at that address and ending
+* at address flash_start + flash_size.
+*/
+static const sector_info_t sectors_info[] = {
+    {0x00000000, 0x00000400},
+};
+
+static const program_target_t flash = {
+    0x10000009, // Init
+    0x1000002d, // UnInit
+    0x10000031, // EraseChip
+    0x10000075, // EraseSector
+    0x100000bb, // ProgramPage
+    0x00000000, // Verify
+
+    // BKPT : start of blob + 1
+    // RSB  : blob start + header + rw data offset
+    // RSP  : stack pointer
+    {
+        0x10000001,
+        0x1000013c,
+        0x10000a00
+    },
+
+    // mem buffer location
+    0x10000a00,
+    // location to write prog_blob in target RAM
+    0x10000000,
+    // prog_blob size
+    sizeof(LPC84x_64_flash_prog_blob),
+    // address of prog_blob
+    LPC84x_64_flash_prog_blob,
+    // ram_to_flash_bytes_to_be_written
+    0x00000100
+};

--- a/source/family/nxp/lpc845/target.c
+++ b/source/family/nxp/lpc845/target.c
@@ -1,0 +1,40 @@
+/**
+ * @file    target.c
+ * @brief   Target information for the LPC845
+ *
+ * DAPLink Interface Firmware
+ * Copyright (c) 2009-2019, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "target_config.h"
+
+// The file flash_blob.c must only be included in target.c
+#include "flash_blob.c"
+
+// target information
+target_cfg_t target_device = {
+    .version                        = kTargetConfigVersion,
+    .sectors_info                   = sectors_info,
+    .sector_info_length             = (sizeof(sectors_info))/(sizeof(sector_info_t)),
+    .flash_regions[0].start         = 0,
+    .flash_regions[0].end           = KB(64),
+    .flash_regions[0].flags         = kRegionIsDefault,
+    .flash_regions[0].flash_algo    = (program_target_t *) &flash,
+    .ram_regions[0].start           = 0x10000000,
+    .ram_regions[0].end             = 0x10004000,
+    .target_vendor                  = "NXP",
+    .target_part_number             = "LPC845M301JBD48",
+};

--- a/source/hic_hal/nxp/lpc11u35/gcc/lpc11u35.ld
+++ b/source/hic_hal/nxp/lpc11u35/gcc/lpc11u35.ld
@@ -160,8 +160,20 @@ SECTIONS
 
   __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
 
-  /* unlike the other HICs, the LPC11U35 doesn't need to have the firmware image filled
-   * out to the end of memory since it doesn't use the DAPLink bootloader */
+  /* Fill .text out to the end of the app region. The LPC11U35 has no DAPLink bootloader,
+   * so the only way to program it is the on-chip ROM ISP MSC drive (CRP DISABLD), which
+   * maps a fixed-size firmware.bin 1:1 onto the whole app region. A short image would
+   * leave stale bytes from the previous firmware in the tail, corrupting the image. It
+   * also keeps the build-time CRC at the same offset info_crc_compute() checksums. */
+  .fill __DATA_END :
+  {
+    FILL(0xffffffff)
+    . = ALIGN(4);
+    . += DAPLINK_ROM_APP_START + DAPLINK_ROM_APP_SIZE - __DATA_END - 4;
+    /* Need some contents in this section or it won't be copied to bin or hex. The CRC will
+     * be placed here by post_build_script.py. */
+    LONG(0x55555555)
+  } > m_text
 
   text_end = ORIGIN(m_text) + LENGTH(m_text);
   ASSERT(__DATA_END <= text_end, "region m_text overflowed with text and data")

--- a/test/info.py
+++ b/test/info.py
@@ -245,6 +245,7 @@ SUPPORTED_CONFIGURATIONS = [
     (   0x9905,     VENDOR_TO_FAMILY('Nordic', 2),      'nrf52820_microbit_if',                     'nrf52820_bl',      'Microbitv2'                            ),
     (   0x9906,     VENDOR_TO_FAMILY('Nordic', 2),      'nrf52820_microbit_if',                     'nrf52820_bl',      'Microbitv2'                            ),
     (   0xA127,     VENDOR_TO_FAMILY('Ambiq', 1),       'kl26z_artemis_dk_if',                      'kl26z_bl',         'ARTMBED'                               ),
+    (   0xD002,     VENDOR_TO_FAMILY('Stub', 1),        'lpc11u35_lpc845breakout_if',               None,               'LPC845BREAKOUT'                        ),
     (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'kl26z_if',                                 None,               None                                    ),
     (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'k20dx_if',                                 None,               None                                    ),
     (   0x0000,     VENDOR_TO_FAMILY('Stub', 1),        'k26f_if',                                  None,               None                                    ),


### PR DESCRIPTION
Adds DAPLink interface firmware support for the **NXP LPC845 Breakout board** (HIC: LPC11U35, target: LPC845), plus two fixes found while bringing it up.

### Commits

**1. `lpc11u35: Fill the interface image out to the end of the app region.`**

The LPC11U35 has no DAPLink bootloader, so the only way to program the HIC is the on-chip ROM ISP MSC drive (`CRP DISABLD`). That drive maps a fixed-size `firmware.bin` 1:1 onto the whole `0xF000` app region, and deleting `firmware.bin` only clears the directory entry — the flash sectors keep their previous contents. A short image therefore left stale bytes from the old firmware in the tail, producing an image that would not boot, with no USB enumeration and no indication why.

Adds a `.fill` section padding `.text` out to the end of the app region, the same way `kinetis.ld` and `lpc4322.ld` already do.

This also fixes the interface CRC reported in `DETAILS.TXT`. `info_crc_compute()` checksums `DAPLINK_ROM_IF_SIZE - 4` unconditionally, so with a short image the value depended on whatever stale bytes followed the image and never matched the CRC recorded at build time. The build-time CRC now lands at `0xEFFC`, exactly where `info_crc_compute()` expects it.

Affects all 30 `lpc11u35_*_if` projects, so it is kept as a separate commit.

**2. `Add support for the NXP LPC845 Breakout board.`**

Board and target-family layers only; the firmware reuses the existing `lpc11u35` HIC anchor. No custom reset or unlock behaviour is needed, so the generic `kStub_HWReset_FamilyID` stub family is used rather than a new `target_reset.c`.

**3. `lpc845: Regenerate the flash algorithm from the official LPC84x FLM.`**

The flash algorithm was initially copied from the LPC824 family on the assumption that LPC84x shares the LPC82x IAP ROM interface. It does not. Keil's own algorithm source, shipped in `Keil.LPC800_DFP` as `Flash/LPC8xx_IAP/FlashPrg.c`, distinguishes the two:

```c
#if   defined LPC8XX || defined LPC8N04
  #define IAP_Call ((IAP_Entry) 0x1FFF1FF1)
#elif defined LPC84X || defined LPC80X
  #define IAP_Call ((IAP_Entry) 0x0F001FF1)
```

Byte-comparing `LPC8xx_32.FLM` against `LPC84x_64.FLM` shows exactly three functional differences, all of which the copied blob got wrong:

| | LPC82x (was used) | LPC84x (correct) | effect |
|---|---|---|---|
| IAP entry | `0x1FFF1FF1` | `0x0F001FF1` | LPC84x boot ROM is at `0x0F000000`; every IAP call branched to a non-existent address |
| `END_SECTOR` | `31` | `63` | chip erase covered only the lower 32 kB, leaving the upper 32 kB unerased |
| `MAINCLKSEL`/`MAINCLKUEN`/`SYSAHBCLKDIV` | SYSCON `+0x70/74/78` | `+0x50/54/58` | `Init` wrote to the wrong registers |

The `END_SECTOR` bug is on the default drag-n-drop path: `flash_manager` calls `erase_chip()` whenever `kEnablePageErase` is not set, and this board does not set it.

Regenerated from the authoritative algorithm rather than patching bytes:

```
python tools/generate_flash_algo.py LPC84x_64.FLM \
    --blob-start 0x10000000 --pack-path Keil.LPC800_DFP.1.10.2.pack
```

The flash geometry the previous blob declared was already correct and is unchanged (one 1 kB sector descriptor at 0, 64 kB region), matching the FLM. `target.c` needs no change; its flash and RAM regions also match the pack's `IROM1`/`IRAM1` for `LPC845M301JBD48`.

### Testing

- All 30 `lpc11u35_*_if` projects build with GCC 10.3-2021.10; each produces a `0xF000` image and none overflow `m_text`.
- Flashed `lpc11u35_lpc845breakout_if` to an LPC845 Breakout board. It enumerates as a full DAPLink MSD drive, and `DETAILS.TXT` reports an interface CRC matching the build's `_crc.txt`.
- Drag-n-drop to the LPC845 target succeeds. Reading the target flash back over SWD shows a ~34 kB image programmed correctly past `0x8000` — sectors that the previous `END_SECTOR` of 31 would have left unerased.
- CMSIS-DAP/SWD verified via pyOCD against `lpc845m301jbd48`: halt/resume, core register reads, CPUID (`0x410CC601`, Cortex-M0+), 4 kB RAM write/read round trip, and `reset_and_halt`.

`test/run_test.py` endpoint tests were not run: they require a `daplink-validation` image built for the LPC845, which does not exist, and `--testdl` self-skips because this board has no bootloader.

### Notes for reviewers

- A `test/info.py` entry is added for board ID `0xD002` (`LPC845BREAKOUT`).
- `records/board/lpc845breakout.yaml` and `source/board/lpc845breakout.c` follow `docs/PORT_BOARD.md`; no common code is touched, so the no-`#ifdef` rule is preserved.
